### PR TITLE
Cleanup and bugfixes

### DIFF
--- a/common/power_ctl.c
+++ b/common/power_ctl.c
@@ -156,9 +156,9 @@ bool set_ps()
     } // loop over 'ok' bits
     if (  ! all_good ) {
       // o tells you which one died.
-      Print("set_ps: Power supply check failed: ");
-      Print(pin_names[oks[o].name]);
-      Print(". Turning off all supplies at this level or lower.\n");
+      Print("set_ps: Power supply check failed. ");
+//      Print(pin_names[oks[o].name]);
+      Print(". Turning off all supplies at this level or lower.\r\n");
       // turn off all supplies at current priority level or lower
       // that is probably overkill since they should not all be
       lowest_enabled_ps_prio = oks[o].priority - 1;
@@ -216,7 +216,7 @@ check_ps(void)
   for ( int o = 0; o < N_PS_OKS; ++o ) {
     if ( new_states[o] != states[o]  && states[o] != PWR_UNKNOWN) {
       static char tmp[128];
-      snprintf(tmp, 128, "check_ps: New failed supply %s (level %d)\n", pin_names[oks[o].name],
+      snprintf(tmp, 128, "check_ps: New failed supply %s (level %d)\r\n", pin_names[oks[o].name],
                oks[o].priority);
       Print(tmp);
     }

--- a/projects/project2/AlarmTask.c
+++ b/projects/project2/AlarmTask.c
@@ -34,7 +34,7 @@ uint32_t getAlarmStatus()
   return status;
 }
 
-#define INITIAL_ALARM_TEMP 55.0 // in Celsius duh
+#define INITIAL_ALARM_TEMP 65.0 // in Celsius duh
 static float alarm_temp = INITIAL_ALARM_TEMP;
 
 float getAlarmTemperature()

--- a/projects/project2/CommandLineTask.c
+++ b/projects/project2/CommandLineTask.c
@@ -955,8 +955,14 @@ void vCommandLineTask( void *pvParameters )
         Blocked state until a character is received. */
     xStreamBufferReceive(uartStreamBuffer, &cRxedChar, 1, portMAX_DELAY);
     UARTCharPut(uart_base, cRxedChar); // TODO this should use the Mutex
-
+    // ugh there has to be a better way of handling this
+    if ( cRxedChar == '\177') {
+      UARTCharPut(uart_base, '\b');
+      UARTCharPut(uart_base, ' ');
+      UARTCharPut(uart_base, '\b'); // I hate you screen
+    }
     if( cRxedChar == '\n' || cRxedChar == '\r' ) {
+      UARTCharPut(uart_base, '\n');
       if ( cInputIndex != 0 ) { // empty command -- skip
 
         snprintf(pcOutputString, MAX_OUTPUT_LENGTH, "Calling command >%s<\r\n",
@@ -996,11 +1002,7 @@ void vCommandLineTask( void *pvParameters )
       /* The if() clause performs the processing after a newline character
             is received.  This else clause performs the processing if any other
             character is received. */
-
-      if( cRxedChar == '\r' ) {
-        /* Ignore carriage returns. */
-      }
-      else if( cRxedChar == '\b' ) {
+      if( cRxedChar == '\b' || cRxedChar == '\177' ) {
         /* Backspace was pressed.  Erase the last character in the input
                 buffer - if there are any. */
         if( cInputIndex > 0 ) {

--- a/projects/project2/FireFlyTask.c
+++ b/projects/project2/FireFlyTask.c
@@ -44,20 +44,24 @@ void Print(const char* str);
 # define DPRINT(x)
 #endif // DEBUG_FIF
 
+// i2c addresses
+// ECUO-B04 XCVR: 0x50 7 bit I2C address
+// ECUO-T12 Tx:   0x50 7 bit I2C address
+// ECUO-R12 Rx:   0x54 7 bit I2C address
 
 
 struct dev_i2c_addr_t ff_i2c_addrs[NFIREFLIES] = {
-    {"K01 12 Tx GTH", 0x70, 0, 0x54},
-    {"K01 12 Rx GTH", 0x70, 1, 0x50},
-    {"K02 12 Tx GTH", 0x70, 2, 0x54},
-    {"K02 12 Rx GTH", 0x70, 3, 0x50},
-    {"K03 12 Tx GTH", 0x70, 4, 0x54},
-    {"K03 12 Rx GTH", 0x70, 5, 0x50},
+    {"K01  12 Tx GTH", 0x70, 0, 0x50},
+    {"K01  12 Rx GTH", 0x70, 1, 0x54},
+    {"K02  12 Tx GTH", 0x70, 2, 0x50},
+    {"K02  12 Rx GTH", 0x70, 3, 0x54},
+    {"K03  12 Tx GTH", 0x70, 4, 0x50},
+    {"K03  12 Rx GTH", 0x70, 5, 0x54},
     {"K04 4 XCVR GTY", 0x71, 0, 0x50},
     {"K05 4 XCVR GTY", 0x71, 1, 0x50},
     {"K06 4 XCVR GTY", 0x71, 2, 0x50},
-    {"K07 12 Tx GTY", 0x71, 3, 0x54},
-    {"K07 12 Rx GTY", 0x71, 4, 0x50},
+    {"K07  12 Tx GTY", 0x71, 3, 0x50},
+    {"K07  12 Rx GTY", 0x71, 4, 0x54},
     {"V01 4 XCVR GTY", 0x70, 0, 0x50},
     {"V02 4 XCVR GTY", 0x70, 1, 0x50},
     {"V03 4 XCVR GTY", 0x70, 2, 0x50},
@@ -68,14 +72,15 @@ struct dev_i2c_addr_t ff_i2c_addrs[NFIREFLIES] = {
     {"V08 4 XCVR GTY", 0x71, 1, 0x50},
     {"V09 4 XCVR GTY", 0x71, 2, 0x50},
     {"V10 4 XCVR GTY", 0x71, 3, 0x50},
-    {"V11 12 Tx GTY", 0x70, 6, 0x54},
-    {"V11 12 Rx GTY", 0x70, 7, 0x50},
-    {"V12 12 Tx GTY", 0x71, 4, 0x54},
-    {"V12 12 Rx GTY", 0x71, 5, 0x50},
+    {"V11  12 Tx GTY", 0x70, 6, 0x50},
+    {"V11  12 Rx GTY", 0x70, 7, 0x54},
+    {"V12  12 Tx GTY", 0x71, 4, 0x50},
+    {"V12  12 Rx GTY", 0x71, 5, 0x54},
 };
 
-#define FF_TEMP_COMMAND_REG 0x16 // 8 bit 2's complement int, valid from 0-80 C, LSB is 1 deg C
-
+// 8 bit 2's complement signed int, valid from 0-80 C, LSB is 1 deg C
+// Same address for 4 XCVR and 12 Tx/Rx devices
+#define FF_TEMP_COMMAND_REG 0x16
 // I2C for VU7P optics
 extern tSMBus g_sMaster3;
 extern tSMBusStatus eStatus3 ;
@@ -227,13 +232,33 @@ void FireFlyTask(void *parameters)
            uint8_t us;
            int8_t s;
          } convert_8_t;
-        convert_8_t tmp; tmp.us = data[0]; // change from uint_8 to int8_t, preserving bit pattern
-        ff_temp[ff] = tmp.s;
+        convert_8_t tmp1; tmp1.us = data[0]; // change from uint_8 to int8_t, preserving bit pattern
+        ff_temp[ff] = tmp1.s;
+
 
 
         // wait here for the x msec, where x is 2nd argument below.
         vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 ) );
       } // loop over commands
+
+      // clear the I2C mux
+      data[0] = 0x0;
+      snprintf(tmp, 64, "FIF: Output of mux set to 0x%02x (clear)\r\n", data[0]);
+      DPRINT(tmp);
+      r = SMBusMasterI2CWrite(smbus, ff_i2c_addrs[ff].mux_addr, data, 1);
+      if ( r != SMBUS_OK ) {
+        Print("FIF: I2CBus command failed  (clearing mux)\r\n");
+        continue;
+      }
+      while ( SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
+        vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
+      }
+      if ( *p_status != SMBUS_OK ) {
+        snprintf(tmp, 64, "FIF: Mux clearing error %d, break out of loop (ps=%d) ...\r\n", *p_status, ff);
+        Print(tmp);
+        break;
+      }
+
     } // loop over firefly modules
     update_max(); update_min();
     vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 250 ) );

--- a/projects/project2/FireFlyTask.c
+++ b/projects/project2/FireFlyTask.c
@@ -150,7 +150,7 @@ void FireFlyTask(void *parameters)
       }
       if ( getPSStatus(5) != PWR_ON) {
         if ( good ) {
-          Print("FIF: 3V3 died. Skipping I2C monitoring.\n");
+          Print("FIF: 3V3 died. Skipping I2C monitoring.\r\n");
           good = false;
         }
         vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(500));
@@ -163,18 +163,18 @@ void FireFlyTask(void *parameters)
       char tmp[64];
       // select the appropriate output for the mux
       data[0] = 0x1U << ff_i2c_addrs[ff].mux_bit;
-      snprintf(tmp, 64, "FIF: Output of mux set to 0x%02x\n", data[0]);
+      snprintf(tmp, 64, "FIF: Output of mux set to 0x%02x\r\n", data[0]);
       DPRINT(tmp);
       tSMBusStatus r = SMBusMasterI2CWrite(smbus, ff_i2c_addrs[ff].mux_addr, data, 1);
       if ( r != SMBUS_OK ) {
-        Print("FIF: I2CBus command failed  (setting mux)\n");
+        Print("FIF: I2CBus command failed  (setting mux)\r\n");
         continue;
       }
       while ( SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
         vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
       }
       if ( *p_status != SMBUS_OK ) {
-        snprintf(tmp, 64, "FIF: Mux writing error %d, break out of loop (ps=%d) ...\n", *p_status, ff);
+        snprintf(tmp, 64, "FIF: Mux writing error %d, break out of loop (ps=%d) ...\r\n", *p_status, ff);
         Print(tmp);
         break;
       }
@@ -183,18 +183,18 @@ void FireFlyTask(void *parameters)
       data[0] = 0xAAU;
       r = SMBusMasterI2CRead(smbus, ff_i2c_addrs[index].mux_addr, data, 1);
       if ( r != SMBUS_OK ) {
-        Print("FIF: Read of MUX output failed\n");
+        Print("FIF: Read of MUX output failed\r\n");
       }
       while ( SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
         vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
       }
       if ( *p_status != SMBUS_OK ) {
-        snprintf(tmp, 64, "FIF: Mux read error %d, break out of loop (ps=%d) ...\n", *p_status, index);
+        snprintf(tmp, 64, "FIF: Mux read error %d, break out of loop (ps=%d) ...\r\n", *p_status, index);
         Print(tmp);
         break;
       }
       else {
-        snprintf(tmp, 64, "FIF: read back register on mux to be %02x\n", data[0]);
+        snprintf(tmp, 64, "FIF: read back register on mux to be %02x\r\n", data[0]);
         DPRINT(tmp);
       }
 #endif // DEBUG_FIF      
@@ -207,7 +207,7 @@ void FireFlyTask(void *parameters)
         r = SMBusMasterI2CWriteRead(smbus, ff_i2c_addrs[ff].dev_addr, &reg_addr, 1, data, 1);
 
         if ( r != SMBUS_OK ) {
-          snprintf(tmp, 64, "FIF: %s: SMBUS failed (master/bus busy, ps=%d,c=%d)\n", __func__, ff,c);
+          snprintf(tmp, 64, "FIF: %s: SMBUS failed (master/bus busy, ps=%d,c=%d)\r\n", __func__, ff,c);
           DPRINT(tmp);
           continue; // abort reading this register
         }
@@ -215,12 +215,12 @@ void FireFlyTask(void *parameters)
           vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
         }
         if ( *p_status != SMBUS_OK ) {
-          snprintf(tmp, 64, "FIF: %s: Error %d, break out of loop (ps=%d,c=%d) ...\n", __func__, *p_status, ff,c);
+          snprintf(tmp, 64, "FIF: %s: Error %d, break out of loop (ps=%d,c=%d) ...\r\n", __func__, *p_status, ff,c);
           DPRINT(tmp);
           break;
         }
 #ifdef DEBUG_FIF
-        snprintf(tmp, 64, "FIF: %d %s is 0x%02x\n", index, ff_i2c_addrs[index].name, data[0]);
+        snprintf(tmp, 64, "FIF: %d %s is 0x%02x\r\n", index, ff_i2c_addrs[index].name, data[0]);
         DPRINT(tmp);
 #endif // DEBUG_FIF
         typedef union {

--- a/projects/project2/MonitorTask.c
+++ b/projects/project2/MonitorTask.c
@@ -48,19 +48,21 @@ void Print(const char* str);
 #define PAGE_COMMAND 0x0
 
 static
-void SuppressedPrint(const char* str, int * current_error_cnt, bool * logging)
+void SuppressedPrint(const char *str, int *current_error_cnt, bool *logging)
 {
-  const int error_max = 100;
-  const int error_restart_threshold = 50;
+  const int error_max = 40;
+  const int error_restart_threshold = 30;
 
   if (*current_error_cnt < error_max ) {
     if ( *logging == true ) {
       Print(str);
       ++(*current_error_cnt);
+      if (*current_error_cnt == error_max)
+        Print("\t--> suppressing further errors for now\r\n");
     }
     else { // not logging
       if ( *current_error_cnt <= error_restart_threshold )
-        *logging = true;
+        *logging = true; // restart logging
     }
   }
   else { // more than error_max errors

--- a/projects/project2/MonitorTask.c
+++ b/projects/project2/MonitorTask.c
@@ -47,8 +47,28 @@ void Print(const char* str);
 // the PAGE command is an SMBUS standard at register 0
 #define PAGE_COMMAND 0x0
 
+static
+void SuppressedPrint(const char* str, int * current_error_cnt, bool * logging)
+{
+  const int error_max = 100;
+  const int error_restart_threshold = 50;
 
+  if (*current_error_cnt < error_max ) {
+    if ( *logging == true ) {
+      Print(str);
+      ++(*current_error_cnt);
+    }
+    else { // not logging
+      if ( *current_error_cnt <= error_restart_threshold )
+        *logging = true;
+    }
+  }
+  else { // more than error_max errors
+    *logging = false;
+  }
 
+  return;
+}
 
 
 void MonitorTask(void *parameters)
@@ -59,18 +79,23 @@ void MonitorTask(void *parameters)
 
   struct MonitorTaskArgs_t *args = parameters;
 
+  configASSERT(args->name != 0);
 
-  //vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 2500 ) );
+  bool log = true;
+  int current_error_cnt = 0;
 
 
   for (;;) {
     // check if the 3.3V is there or not. If it disappears then nothing works
     // since that is the I2C pullups. This will be changed with next
     // rev of the board.
+    char tmp[64];
     static bool good = false;
     if ( getPSStatus(5) != PWR_ON) {
       if ( good ) {
-        Print("MON: 3V3 died. Skipping I2C monitoring.\n");
+        snprintf(tmp, 64, "MON(%s): 3V3 died. Skipping I2C monitoring.\r\n",
+            args->name);
+        SuppressedPrint(tmp, &current_error_cnt, &log);
         good = false;
       }
       vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(500));
@@ -81,42 +106,48 @@ void MonitorTask(void *parameters)
     }
     // loop over devices
     for ( uint8_t ps = 0; ps < args->n_devices; ++ ps ) {
-      char tmp[64];
+      if ( getPSStatus(5) != PWR_ON)
+        break;
+
       // select the appropriate output for the mux
       data[0] = 0x1U<<args->devices[ps].mux_bit;
-      snprintf(tmp, 64, "MON: Output of mux set to 0x%02x\n", data[0]);
+      snprintf(tmp, 64, "MON(%s): Output of mux set to 0x%02x\r\n", args->name,
+               data[0]);
       DPRINT(tmp);
       tSMBusStatus r = SMBusMasterI2CWrite(args->smbus, args->devices[ps].mux_addr, data, 1);
       if ( r != SMBUS_OK ) {
-        Print("MON: I2CBus command failed  (setting mux)\n");
+        snprintf(tmp, 64, "MON(%s): I2CBus command failed  (setting mux)\r\n", args->name);
+        SuppressedPrint(tmp, &current_error_cnt, &log);
         continue;
       }
       while ( SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
         vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
       }
       if ( *args->smbus_status != SMBUS_OK ) {
-        snprintf(tmp, 64, "MON: Mux writing error %d, break out of loop (ps=%d) ...\n",
-            *args->smbus_status, ps);
-        Print(tmp);
+        snprintf(tmp, 64, "MON(%s): Mux writing error %d, break out of loop (ps=%d) ...\r\n",
+            args->name, *args->smbus_status, ps);
+        SuppressedPrint(tmp, &current_error_cnt, &log);
         break;
       }
 #ifdef DEBUG_MON
       data[0] = 0xAAU;
       r = SMBusMasterI2CRead(args->smbus, 0x70U, data, 1);
       if ( r != SMBUS_OK ) {
-        Print("MON: Read of MUX output failed\n");
+        snprintf(tmp, 64, "MON(%s): Read of MUX output failed\r\n", args->name);
+        SuppressedPrint(tmp, &current_error_cnt, &log);
       }
       while ( SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
         vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
       }
       if ( *args->smbus_status != SMBUS_OK ) {
-        snprintf(tmp, 64, "MON: Mux reading error %d, break out of loop (ps=%d) ...\n",
-            *args->smbus_status, ps);
-        Print(tmp);
+        snprintf(tmp, 64, "MON(%s): Mux reading error %d, break out of loop (ps=%d) ...\r\n",
+            args->name, *args->smbus_status, ps);
+        SuppressedPrint(tmp, &current_error_cnt, &log);
         break;
       }
       else {
-        snprintf(tmp, 64, "MON: read back register on mux to be %02x\n", data[0]);
+        snprintf(tmp, 64, "MON(%s): read back register on mux to be %02x\r\n",
+            args->name, data[0]);
         DPRINT(tmp);
       }
 #endif  // DEBUG_MON
@@ -125,17 +156,18 @@ void MonitorTask(void *parameters)
         r = SMBusMasterByteWordWrite(args->smbus, args->devices[ps].dev_addr, PAGE_COMMAND,
             &page, 1);
         if ( r != SMBUS_OK ) {
-          Print("SMBUS command failed  (setting page)\n");
+          Print("SMBUS command failed  (setting page)\r\n");
         }
         while ( SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
           vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
         }
         // this is checking the return from the interrupt
         if (*args->smbus_status != SMBUS_OK ) {
-          snprintf(tmp, 64, "MON: Page SMBUS ERROR: %d\n", *args->smbus_status);
-          Print(tmp);
+          snprintf(tmp, 64, "MON(%s): Page SMBUS ERROR: %d\r\n",
+              args->name, *args->smbus_status);
+          SuppressedPrint(tmp, &current_error_cnt, &log);
         }
-        snprintf(tmp, 64, "\t\tMON: Page %d\n", page);
+        snprintf(tmp, 64, "\t\tMON(%s): Page %d\r\n", args->name, page);
         DPRINT(tmp);
 
         // loop over commands
@@ -145,25 +177,26 @@ void MonitorTask(void *parameters)
           r = SMBusMasterByteWordRead(args->smbus, args->devices[ps].dev_addr,
               args->commands[c].command, data, args->commands[c].size);
           if ( r != SMBUS_OK ) {
-            snprintf(tmp, 64, "MON: SMBUS failed (master/bus busy, (ps=%d,c=%d,p=%d)\n", ps,c,page);
-            Print(tmp);
+            snprintf(tmp, 64, "MON(%s): SMBUS failed (master/bus busy, (ps=%d,c=%d,p=%d)\r\n",
+                args->name, ps,c,page);
+            SuppressedPrint(tmp, &current_error_cnt, &log);
             continue; // abort reading this register
           }
           while ( SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
             vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 10 )); // wait
           }
           if (*args->smbus_status != SMBUS_OK ) {
-            snprintf(tmp, 64, "MON: SMBUS ERROR: %d\n", *args->smbus_status);
+            snprintf(tmp, 64, "MON(%s): SMBUS ERROR: %d\r\n",args->name, *args->smbus_status);
             DPRINT(tmp);
           }
           if ( *args->smbus_status != SMBUS_OK ) {
-            snprintf(tmp, 64, "Error %d, break out of loop (ps=%d,c=%d,p=%d) ...\n",
-                *args->smbus_status, ps,c,page);
-        	  Print(tmp);
+            snprintf(tmp, 64, "MON(%s): Error %d, break out of loop (ps=%d,c=%d,p=%d) ...\r\n",
+                args->name, *args->smbus_status, ps,c,page);
+        	  SuppressedPrint(tmp, &current_error_cnt, &log);
         	  break;
           }
-          snprintf(tmp, 64, "MON: %d %s is 0x%02x %02x\n", ps, args->commands[c].name,
-                   data[1], data[0]);
+          snprintf(tmp, 64, "MON(%s): %d %s is 0x%02x %02x\r\n", args->name, ps,
+                   args->commands[c].name, data[1], data[0]);
           DPRINT(tmp);
           float val;
           if ( args->commands[c].type == PM_LINEAR11 ) {
@@ -171,7 +204,7 @@ void MonitorTask(void *parameters)
             val = linear11_to_float(ii);
             int tens = val;
             int fraction = ABS((val - tens)*100.0);
-            snprintf(tmp, 64, "\t\t%d.%02d (linear11)\n", tens, fraction);
+            snprintf(tmp, 64, "\t\t%d.%02d (linear11)\r\n", tens, fraction);
             DPRINT(tmp);
           }
           else if ( args->commands[c].type == PM_LINEAR16U ) {
@@ -179,7 +212,7 @@ void MonitorTask(void *parameters)
             val = linear16u_to_float(ii);
             int tens = val;
             int fraction = ABS((val - tens)*100.0);
-            snprintf(tmp, 64,  "\t\t%d.%02d (linear16u)\n", tens, fraction);
+            snprintf(tmp, 64,  "\t\t%d.%02d (linear16u)\r\n", tens, fraction);
             DPRINT(tmp);
           }
           else if ( args->commands[c].type == PM_STATUS ) {

--- a/projects/project2/MonitorTask.h
+++ b/projects/project2/MonitorTask.h
@@ -47,7 +47,7 @@ struct MonitorTaskArgs_t {
 };
 // DC-DC converter
 #define NSUPPLIES_PS (5) // 5 devices, 2 pages each
-#define NCOMMANDS_PS 7 // number of entries in above array
+#define NCOMMANDS_PS 6 // number of entries in above array
 #define NPAGES_PS    2 // number of pages on the power supplies.
 
 extern struct MonitorTaskArgs_t dcdc_args;

--- a/projects/project2/PowerSupplyTask.c
+++ b/projects/project2/PowerSupplyTask.c
@@ -93,9 +93,9 @@ void PowerSupplyTask(void *parameters)
 
 
     if ( newstate == PWR_OFF  && oldState != PWR_OFF) {
-      Print("\nPowerSupplyTask: power supplies turned off.\n");
+      Print("\r\nPowerSupplyTask: power supplies turned off.\r\n");
       if ( ! blade_power_enable )
-        Print("\nPowerSupplyTask: PWR_EN removed by SM\n");
+        Print("\r\nPowerSupplyTask: PWR_EN removed by SM\r\n");
       message = PS_BAD;
     }
     else { // either the PS is now good or there was no change.

--- a/projects/project2/Tasks.h
+++ b/projects/project2/Tasks.h
@@ -50,6 +50,9 @@ void FireFlyTask(void *parameters);
 const char* getFFname(const uint8_t i);
 int8_t getFFvalue(const uint8_t i);
 
+// version info
+const char* buildTime();
+const char* gitVersion();
 
 // ---- ALARMS
 
@@ -69,7 +72,6 @@ void AlarmTask(void *parameters);
 float getAlarmTemperature();
 void setAlarmTemperature(const float);
 uint32_t getAlarmStatus();
-
 
 // Monitoring using the ADC inputs
 void ADCMonitorTask(void *parameters);

--- a/projects/project2/project2.c
+++ b/projects/project2/project2.c
@@ -228,12 +228,13 @@ struct TaskNamePair_t {
   TaskHandle_t value;
 } ;
 
-static struct TaskNamePair_t TaskNamePairs[8];
+#define MAX_TASK_COUNT 9
+static struct TaskNamePair_t TaskNamePairs[MAX_TASK_COUNT];
 
 void vGetTaskHandle( char *key, TaskHandle_t *t)
 {
   *t = NULL;
-  for (int i = 0; i < 6; ++i) {
+  for (int i = 0; i < MAX_TASK_COUNT; ++i) {
     if ( strncmp(key, TaskNamePairs[i].key,3) == 0)
       *t = TaskNamePairs[i].value;
   }
@@ -254,7 +255,7 @@ struct pm_command_t pm_command_fpga[] = {
 float pm_fpga[2] = {0.0,0.0};
 
 struct MonitorTaskArgs_t fpga_args = {
-    .name = "FMON",
+    .name = "XIMON",
     .devices = fpga_addrs,
     .n_devices = 2,
     .commands = pm_command_fpga,
@@ -291,18 +292,18 @@ struct pm_command_t pm_command_dcdc[] = {
         //{ 0x4F, 2, "OT_FAULT_LIMIT", "C", PM_LINEAR11},
         { 0x79, 2, "STATUS_WORD", "", PM_STATUS },
         //{ 0xE7, 2, "IOUT_AVG_OC_FAULT_LIMIT", "A", PM_LINEAR11 },
-        { 0x95, 2, "READ_FREQUENCY", "Hz", PM_LINEAR11},
+        //{ 0x95, 2, "READ_FREQUENCY", "Hz", PM_LINEAR11},
       };
 float dcdc_values[NSUPPLIES_PS*NPAGES_PS*NCOMMANDS_PS];
 struct MonitorTaskArgs_t dcdc_args = {
-    .name = "VMON",
+    .name = "PSMON",
     .devices = pm_addrs_dcdc,
-    .n_devices = 5,
+    .n_devices = NSUPPLIES_PS,
     .commands = pm_command_dcdc,
-    .n_commands = 7,
+    .n_commands = NCOMMANDS_PS,
     .pm_values = dcdc_values,
     .n_values = NSUPPLIES_PS*NPAGES_PS*NCOMMANDS_PS,
-    .n_pages = 2,
+    .n_pages = NPAGES_PS,
     .smbus = &g_sMaster1,
     .smbus_status = &eStatus1,
 };

--- a/projects/project2/project2.c
+++ b/projects/project2/project2.c
@@ -308,6 +308,18 @@ struct MonitorTaskArgs_t dcdc_args = {
     .smbus_status = &eStatus1,
 };
 
+const char* buildTime()
+{
+  const char *btime = __TIME__ ", " __DATE__;
+  return btime;
+}
+
+const char* gitVersion()
+{
+  const char *gitVersion = FIRMWARE_VERSION;
+  return gitVersion;
+}
+
 // 
 int main( void )
 {


### PR DESCRIPTION
- fix newlines to send \r\n everywhere, now tested with `screen` and seems to work. there is a weird issue where the CLI double-prints output in the case of long commands (`adc` and `help` at least have this issue)
- fix a bug in the firefly monitoring code where the values and names would get mis-associated. Also clean up the printout to make it easier to parse
- add a `version` command to the CLI
- buffer overwrite in task name handling 