### PR TITLE
switch to zynq uart for boot loader

### DIFF
--- a/boot_loader/bl_config.h
+++ b/boot_loader/bl_config.h
@@ -359,7 +359,7 @@
 // Requires: UARTx_BASE
 //
 //*****************************************************************************
-#define UART_CLOCK_ENABLE         SYSCTL_RCGCUART_R4
+#define UART_CLOCK_ENABLE         SYSCTL_RCGCUART_R1
 
 //*****************************************************************************
 //
@@ -370,7 +370,7 @@
 // Requires: UART_CLOCK_ENABLE
 //
 //*****************************************************************************
-#define UARTx_BASE                UART4_BASE
+#define UARTx_BASE                UART1_BASE
 
 //*****************************************************************************
 //
@@ -381,7 +381,7 @@
 // Requires: UART_RXPIN_BASE, UART_RXPIN_PCTL and UART_RXPIN_POS
 //
 //*****************************************************************************
-#define UART_RXPIN_CLOCK_ENABLE   SYSCTL_RCGCGPIO_R4
+#define UART_RXPIN_CLOCK_ENABLE   SYSCTL_RCGCGPIO_R0
 
 //*****************************************************************************
 //
@@ -414,7 +414,7 @@
 // Requires: UART_RXPIN_CLOCK_ENABLE, UART_RXPIN_BASE and UART_RXPIN_PCTL
 //
 //*****************************************************************************
-#define UART_RXPIN_POS          2
+#define UART_RXPIN_POS          0
 
 //*****************************************************************************
 //
@@ -425,7 +425,7 @@
 // Requires: UART_TXPIN_BASE, UART_TXPIN_PCTL and UART_TXPIN_POS
 //
 //*****************************************************************************
-#define UART_TXPIN_CLOCK_ENABLE SYSCTL_RCGCGPIO_R4
+#define UART_TXPIN_CLOCK_ENABLE SYSCTL_RCGCGPIO_R0
 
 //*****************************************************************************
 //
@@ -458,7 +458,7 @@
 // Requires: UART_TXPIN_CLOCK_ENABLE, UART_TXPIN_BASE and UART_TXPIN_PCTL
 //
 //*****************************************************************************
-#define UART_TXPIN_POS          3
+#define UART_TXPIN_POS          1
 
 //*****************************************************************************
 //


### PR DESCRIPTION
Switch the boot loader from the FP UART to the Zynq UART.