### PR TITLE
Fix bug in soft UART for MCU->ZYNQ data transfer

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -1507,7 +1507,11 @@ struct command_t commands[] = {
     {
         "suart",
         suart_ctl,
+#ifdef SUART_TEST_MODE
         "suart (on|off|status|debug1|debug2|debugraw|normal|sendone|(settest <sensor> <val>))\r\n"
+#else
+        "suart (on|off)\r\n"
+#endif // SUART_TEST_MODE
         " Control soft uart.\r\n",
         -1,
     },

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -1246,10 +1246,16 @@ static BaseType_t suart_ctl(int argc, char **argv)
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
 			 "%s: transmit off\r\n", argv[0]);
     }
+#ifdef SUART_TEST_MODE
     else if (strncmp(argv[1], "debug1", 6) == 0) {
       message = SOFTUART_TEST_SINGLE;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
 			 "%s: debug mode 1 (single)\r\n", argv[0]);
+    }
+    else if (strncmp(argv[1], "debugraw", 8) == 0) {
+      message = SOFTUART_TEST_RAW;
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                         "%s: debug raw (single)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "debug2", 6) == 0) {
       message = SOFTUART_TEST_INCREMENT;
@@ -1261,6 +1267,11 @@ static BaseType_t suart_ctl(int argc, char **argv)
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
 			 "%s: regular mode\r\n", argv[0]);
     }
+    else if (strncmp(argv[1], "sendone", 7) == 0) {
+      message = SOFTUART_TEST_SEND_ONE;
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                         "%s: send one\r\n", argv[0]);
+    }
     else if (strncmp(argv[1], "status", 5) == 0) {
       uint8_t mode = getSUARTTestMode();
       uint8_t sensor = getSUARTTestSensor();
@@ -1269,10 +1280,12 @@ static BaseType_t suart_ctl(int argc, char **argv)
                          "%s: test mode = %s, sensor = 0x%x, data = 0x%x\r\n",
                          argv[0], mode==0?"single":"increment", sensor, data);
     }
+#endif // SUART_TEST_MODE
     else {
       understood = false;
     }
   }
+#ifdef SUART_TEST_MODE
   else if (argc == 4) {
     if (strncmp(argv[1], "settest", 7) == 0) {
       uint8_t sensor = strtol(argv[2], NULL, 16);
@@ -1286,6 +1299,7 @@ static BaseType_t suart_ctl(int argc, char **argv)
       understood = false;
     }
   }
+#endif // SUART_TEST_MODE
   else {
     understood = false;
   }
@@ -1406,8 +1420,18 @@ struct command_t commands[] = {
       "id\r\n Prints board ID information.\r\n",
       0
     },
-    { "i2c_base", i2c_ctl_set_dev, "i2c_base <device>\r\n Set I2C controller number. Value between 0-9.\r\n", 1},
-    { "i2cr", i2c_ctl_r, "i2cr <address> <number of bytes>\r\n Read I2C controller. Addr in hex.\r\n", 2},
+    { 
+      "i2c_base", 
+      i2c_ctl_set_dev, 
+      "i2c_base <device>\r\n Set I2C controller number. Value between 0-9.\r\n",
+       1
+    },
+    { 
+      "i2cr",
+      i2c_ctl_r,
+      "i2cr <address> <number of bytes>\r\n Read I2C controller. Addr in hex.\r\n",
+      2
+    },
     {
         "i2crr",
         i2c_ctl_reg_r,
@@ -1483,8 +1507,8 @@ struct command_t commands[] = {
     {
         "suart",
         suart_ctl,
-        "suart (on|off|status|debug1|debug2|(settest <sensor> <val>))\r\n"
-	" Control soft uart.\r\n",
+        "suart (on|off|status|debug1|debug2|debugraw|normal|sendone|(settest <sensor> <val>))\r\n"
+        " Control soft uart.\r\n",
         -1,
     },
     {

--- a/projects/cm_mcu/InterruptHandlers.c
+++ b/projects/cm_mcu/InterruptHandlers.c
@@ -282,7 +282,6 @@ void I2CSlave0Interrupt()
 
   // clear the interrupt register
   ROM_I2CSlaveIntClear(I2C0_BASE);
-  //ROM_SysCtlDelay(100u);
   /* At this point xTaskToNotify should not be NULL as a transmission was
       in progress. */
   configASSERT( TaskNotifyI2CSlave != NULL );
@@ -305,7 +304,9 @@ void I2CSlave0Interrupt()
 // Soft UART related
 extern tSoftUART g_sUART;
 //
-// The transmit timer tick function.
+// The transmit timer tick function. This does not call
+// any FreeRTOS functions such that it can operate at a high enough
+// priority to allow the soft UART to operate reliably.
 //
 void
 Timer0AIntHandler(void)

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -134,5 +134,9 @@ void initFPGAMon()
     fpga_args.n_devices = 1;
     set_ku_index(0);
   }
+  else {
+    set_vu_index(0);
+    set_ku_index(1);
+  }
 
 }

--- a/projects/cm_mcu/SoftUartTask.c
+++ b/projects/cm_mcu/SoftUartTask.c
@@ -23,6 +23,8 @@
 #include "Tasks.h"
 #include "MonitorTask.h"
 
+#define SZ 20
+
 // Data Format
 // https://github.com/apollo-lhc/SM_ZYNQ_FW/blob/develop/src/CM_interface/CM_Monitoring_data_format.txt
 
@@ -49,10 +51,11 @@ void format_data(const uint8_t sensor, const uint16_t data, uint8_t message[4])
   message[3] |= data & 0x3F;
 }
 
+#ifdef SUART_TEST_MODE
 static uint8_t  testaddress = 0x0;
 static uint16_t testdata    = 0xaaff;
-static bool inTestMode = false;
-static uint8_t testmode = 0;
+static bool inTestMode = true;
+static uint8_t testmode = 2;
 void setSUARTTestData(uint8_t sensor, uint16_t value)
 {
   testaddress = sensor;
@@ -73,7 +76,9 @@ uint16_t getSUARTTestData()
 {
   return testdata;
 }
-
+#else //
+const static bool inTestMode = false;
+#endif // SUART_TEST_MODE
 //
 // The buffer used to hold the transmit data.
 //
@@ -88,7 +93,7 @@ unsigned char g_pucTxBuffer[16];
 //
 unsigned long g_ulBitTime;
 
-#define TARGET_BAUD_RATE 115200
+#define TARGET_BAUD_RATE 38400
 
 tSoftUART g_sUART;
 
@@ -109,18 +114,18 @@ void SoftUartTask(void *parameters)
   // Configure the pins used for the software UART.
   //
   SoftUARTTxGPIOSet(&g_sUART, GPIO_PORTM_BASE, GPIO_PIN_6);
-  //SoftUARTRxGPIOSet(&g_sUART, GPIO_PORTE_BASE, GPIO_PIN_1);
+  // SoftUARTRxGPIOSet(&g_sUART, GPIO_PORTE_BASE, GPIO_PIN_1);
   //
   // Configure the data buffers used as the transmit and receive buffers.
   //
   SoftUARTTxBufferSet(&g_sUART, g_pucTxBuffer, 16);
-  //SoftUARTRxBufferSet(&g_sUART, g_pusRxBuffer, 16);
+  // SoftUARTRxBufferSet(&g_sUART, g_pusRxBuffer, 16);
   //
   // Enable the GPIO modules that contains the GPIO pins to be used by
   // the software UART.
   //
-  //MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOD);
-  //MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
+  // MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOD);
+  // MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
   //
   // Configure the software UART module: 8 data bits, no parity, and one
   // stop bit.
@@ -132,16 +137,15 @@ void SoftUartTask(void *parameters)
   //
   // Compute the bit time for the chosen baud rate
   //
-  g_ulBitTime = (g_ui32SysClock / TARGET_BAUD_RATE ) - 1;
+  g_ulBitTime = (g_ui32SysClock / TARGET_BAUD_RATE) - 1;
   //
   // Configure the timers used to generate the timing for the software
   // UART.  The interface in this example is run at 38,400 baud,
   // requiring a timer tick at 38,400 Hz.
   //
   MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_TIMER0);
-  MAP_TimerConfigure(TIMER0_BASE,
-                 (TIMER_CFG_SPLIT_PAIR | TIMER_CFG_A_PERIODIC |
-                  TIMER_CFG_B_PERIODIC));
+  MAP_TimerConfigure(TIMER0_BASE, (TIMER_CFG_SPLIT_PAIR | TIMER_CFG_A_PERIODIC |
+                                   TIMER_CFG_B_PERIODIC));
   MAP_TimerLoadSet(TIMER0_BASE, TIMER_A, g_ulBitTime);
   MAP_TimerIntEnable(TIMER0_BASE, TIMER_TIMA_TIMEOUT | TIMER_TIMB_TIMEOUT);
   MAP_TimerEnable(TIMER0_BASE, TIMER_A);
@@ -151,31 +155,30 @@ void SoftUartTask(void *parameters)
   // receiver edge interrupt is higher priority than the receiver timer
   // interrupt.
   //
-  //MAP_IntPrioritySet(INT_GPIOE, 0x00);
-  //MAP_IntPrioritySet(INT_TIMER0B, 0x40);
+  // MAP_IntPrioritySet(INT_GPIOE, 0x00);
+  // MAP_IntPrioritySet(INT_TIMER0B, 0x40);
   MAP_IntPrioritySet(INT_TIMER0A, configKERNEL_INTERRUPT_PRIORITY);
   //
   // Enable the interrupts associated with the software UART.
   //
-  //MAP_IntEnable(INT_GPIOE);
-  //MAP_IntEnable(INT_TIMER0A);
-  //MAP_IntEnable(INT_TIMER0B);
+  // MAP_IntEnable(INT_GPIOE);
+  // MAP_IntEnable(INT_TIMER0A);
+  // MAP_IntEnable(INT_TIMER0B);
 
   //
   // Enable the transmit FIFO half full interrupt in the software UART.
   //
   SoftUARTIntEnable(&g_sUART, SOFTUART_INT_TX);
 
-  uint8_t message[4] = {0x9c,0x2c,0x2b,0x3e};
+  uint8_t message[4] = {0x9c, 0x2c, 0x2b, 0x3e};
 
   bool enable = true;
-
 
   // Loop forever
   for (;;) {
     uint32_t qmessage;
     // check for a new item in the queue but don't wait
-    if ( xQueueReceive(xSoftUartQueue, &qmessage, 0) ) {
+    if (xQueueReceive(xSoftUartQueue, &qmessage, 0)) {
       switch (qmessage) {
       case SOFTUART_ENABLE_TRANSMIT:
         enable = true;
@@ -183,123 +186,162 @@ void SoftUartTask(void *parameters)
       case SOFTUART_DISABLE_TRANSMIT:
         enable = false;
         break;
+#ifdef SUART_TEST_MODE
       case SOFTUART_TEST_SINGLE:
         inTestMode = true;
-	testmode = 0;
+        enable = true;
+        testmode = 0;
         break;
       case SOFTUART_TEST_INCREMENT:
         inTestMode = true;
-	testmode = 1;
+        enable = true;
+        testmode = 1;
         break;
       case SOFTUART_TEST_OFF:
         inTestMode = false;
         break;
+      case SOFTUART_TEST_SEND_ONE:
+        inTestMode = true;
+        enable = true;
+        testmode = 0;
+        break;
+      case SOFTUART_TEST_RAW:
+        message[0] = 0x9c;
+        message[1] = 0x2c;
+        message[2] = 0x2b;
+        message[3] = 0x3e;
+        inTestMode = true;
+        enable = true;
+        testmode = 2;
+        break;
+#endif // SUART_TEST_MODE
       }
     }
     if (enable) {
       // Enable the interrupts during transmission
       MAP_IntEnable(INT_TIMER0A);
 
-      if ( inTestMode ) {
-        for ( int jj = 0; jj < testmode*10+1; ++jj ) {
-          if ( testmode == 1 ) {
+      if (inTestMode) {
+#ifdef SUART_TEST_MODE
+        // non-incrementing, single word
+        if (testmode == 0) {
+          format_data(testaddress, testdata, message);
+          for (int i = 0; i < 4; ++i) {
+            SoftUARTCharPut(&g_sUART, message[i]);
+          }
+          // one shot mode -- disable 
+          if (qmessage == SOFTUART_TEST_SEND_ONE)
+            enable = false;
+        }
+        // increment test mode, send
+        else if (testmode == 1) {
+          for (int jj = 0; jj < 10; ++jj) {
             testdata++;
             testaddress++;
-          }
-          format_data(testaddress, testdata, message);
-        }
-        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(5000));
-        continue;
-      }
-
-      // Fireflies
-      for ( int j = 0; j < NFIREFLIES; ++j) {
-        int16_t temperature = getFFvalue(j);
-        format_data(j, temperature, message);
-        // send data buffer
-        for (int i = 0; i < 4; ++i ) {
-          SoftUARTCharPut(&g_sUART, message[i]);
-        }
-      }
-      typedef union {
-        uint16_t us;
-        __fp16 f;
-      } convert_16_t;
-      // MonitorTask values -- power supply
-      const int offsetMonitor= 32;
-      const int num_uart_psmon_registers = 8; // ugh
-      int offset = offsetMonitor;
-      for ( int j = 0; j < dcdc_args.n_devices; ++j) { // loop over supplies
-        for ( int l = 0; l < dcdc_args.n_pages; ++l) { // loop over register pages
-          for ( int k = 0; k < dcdc_args.n_commands; ++k ) { // loop over commands
-            // HACK -- skip status command
-            if ( k == 5 )
-              continue;
-            int index = j*(dcdc_args.n_commands*dcdc_args.n_pages)
-                    +l*dcdc_args.n_commands+k;
-            convert_16_t u;
-            u.f= dcdc_args.pm_values[index];
-            int reg = offset + k;
-            format_data(reg, u.us, message);
-            for (int i = 0; i < 4; ++i ) {
+            format_data(testaddress, testdata, message);
+            for (int i = 0; i < 4; ++i) {
               SoftUARTCharPut(&g_sUART, message[i]);
             }
           }
-          offset += num_uart_psmon_registers;
         }
-      }
-      // ADC values
-      const int offsetADC = 96;
-      for ( int j = 0; j < ADC_CHANNEL_COUNT; ++j) {
-        convert_16_t u;
-        u.f = getADCvalue(j);
-        format_data(j+offsetADC, u.us, message);
-        for (int i = 0; i < 4; ++i ) {
-          SoftUARTCharPut(&g_sUART, message[i]);
+        else if ( testmode == 2 ) { // test mode, no formatting
+          for (int i = 0; i < 4; ++i) {
+            SoftUARTCharPut(&g_sUART, message[i]);
+          }
         }
-      }
-      // MonitorTask -- FPGA values
-      // THIS WILL BREAK IF WE HAVE MORE THAN ONE PAGE OR IF WE HAVE
-      // MORE THAN A SIMPLE SET OF COMMANDS -- NOTA BENE
-      const int offsetFPGA = 128;
-      for ( int j =0; j < fpga_args.n_commands*fpga_args.n_devices; ++j) {
-        convert_16_t u;
-        u.f= fpga_args.pm_values[j];
-        format_data(j+offsetFPGA, u.us, message);
-        for (int i = 0; i < 4; ++i ) {
-          SoftUARTCharPut(&g_sUART, message[i]);
-        }
-      }
-      // git version
-      const int offsetGIT = 118;
-#define SZ 20
-      char buff[SZ];
-      memset(buff, 0, SZ); // technically not needed
-      strncpy(buff, gitVersion(), SZ);
-      uint16_t *p = (uint16_t*)buff;
-      // each message sends two chars
-      for ( int j = 0; j < SZ/2; j++ ) {
-        format_data(j+offsetGIT, *p, message);
-        ++p;
-        for (int i = 0; i < 4; ++i ) {
-          SoftUARTCharPut(&g_sUART, message[i]);
-        }
+#endif // SUART_TEST_MODE
+      }      // end test mode
+      else { // normal mode 
 
-      }
-      // uptime
-      const int offsetUPTIME = 192;
-      TickType_t now =  xTaskGetTickCount()/(configTICK_RATE_HZ*60); // time in minutes
-      uint16_t now_16 = now & 0xFFFFU; // lower 16 bits
-      format_data(offsetUPTIME, now_16, message);
-      for (int i = 0; i < 4; ++i ) {
-        SoftUARTCharPut(&g_sUART, message[i]);
-      }
-      now_16 = (now>>16) & 0xFFFFU; // upper 16 bits
-      format_data(offsetUPTIME+1, now_16, message);
-      for (int i = 0; i < 4; ++i ) {
-        SoftUARTCharPut(&g_sUART, message[i]);
-      }
-
+        // Fireflies
+        for (int j = 0; j < NFIREFLIES; ++j) {
+          int16_t temperature = getFFvalue(j);
+          format_data(j, temperature, message);
+          // send data buffer
+          for (int i = 0; i < 4; ++i) {
+            SoftUARTCharPut(&g_sUART, message[i]);
+          }
+        }
+        typedef union {
+          uint16_t us;
+          __fp16 f;
+        } convert_16_t;
+        // MonitorTask values -- power supply
+        const int offsetMonitor = 32;
+        const int num_uart_psmon_registers = 8; // ugh
+        int offset = offsetMonitor;
+        for (int j = 0; j < dcdc_args.n_devices; ++j) { // loop over supplies
+          for (int l = 0; l < dcdc_args.n_pages;
+               ++l) { // loop over register pages
+            for (int k = 0; k < dcdc_args.n_commands;
+                 ++k) { // loop over commands
+              // HACK -- skip status command
+              if (k == 5)
+                continue;
+              int index = j * (dcdc_args.n_commands * dcdc_args.n_pages) +
+                          l * dcdc_args.n_commands + k;
+              convert_16_t u;
+              u.f = dcdc_args.pm_values[index];
+              int reg = offset + k;
+              format_data(reg, u.us, message);
+              for (int i = 0; i < 4; ++i) {
+                SoftUARTCharPut(&g_sUART, message[i]);
+              }
+            }
+            offset += num_uart_psmon_registers;
+          }
+        }
+        // ADC values
+        const int offsetADC = 96;
+        for (int j = 0; j < ADC_CHANNEL_COUNT; ++j) {
+          convert_16_t u;
+          u.f = getADCvalue(j);
+          format_data(j + offsetADC, u.us, message);
+          for (int i = 0; i < 4; ++i) {
+            SoftUARTCharPut(&g_sUART, message[i]);
+          }
+        }
+        // MonitorTask -- FPGA values
+        // THIS WILL BREAK IF WE HAVE MORE THAN ONE PAGE OR IF WE HAVE
+        // MORE THAN A SIMPLE SET OF COMMANDS -- NOTA BENE
+        const int offsetFPGA = 128;
+        for (int j = 0; j < fpga_args.n_commands * fpga_args.n_devices; ++j) {
+          convert_16_t u;
+          u.f = fpga_args.pm_values[j];
+          format_data(j + offsetFPGA, u.us, message);
+          for (int i = 0; i < 4; ++i) {
+            SoftUARTCharPut(&g_sUART, message[i]);
+          }
+        }
+        // git version
+        const int offsetGIT = 118;
+        char buff[SZ];
+        memset(buff, 0, SZ); // technically not needed
+        strncpy(buff, gitVersion(), SZ);
+        uint16_t *p = (uint16_t *)buff;
+        // each message sends two chars
+        for (int j = 0; j < SZ / 2; j++) {
+          format_data(j + offsetGIT, *p, message);
+          ++p;
+          for (int i = 0; i < 4; ++i) {
+            SoftUARTCharPut(&g_sUART, message[i]);
+          }
+        }
+        // uptime
+        const int offsetUPTIME = 192;
+        TickType_t now =
+            xTaskGetTickCount() / (configTICK_RATE_HZ * 60); // time in minutes
+        uint16_t now_16 = now & 0xFFFFU;                     // lower 16 bits
+        format_data(offsetUPTIME, now_16, message);
+        for (int i = 0; i < 4; ++i) {
+          SoftUARTCharPut(&g_sUART, message[i]);
+        }
+        now_16 = (now >> 16) & 0xFFFFU; // upper 16 bits
+        format_data(offsetUPTIME + 1, now_16, message);
+        for (int i = 0; i < 4; ++i) {
+          SoftUARTCharPut(&g_sUART, message[i]);
+        }
+      } // if not test mode 
 
       // wait for the transmission to finish
       vTaskDelay(pdMS_TO_TICKS(10));
@@ -309,9 +351,9 @@ void SoftUartTask(void *parameters)
         vTaskDelay(pdMS_TO_TICKS(10));
 
       MAP_IntDisable(INT_TIMER0A);
-    }
+    } // if ( enabled)
     // wait here for the x msec, where x is 2nd argument below.
-    vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 5000 ) );
+    vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(5000));
   }
 
   return;

--- a/projects/cm_mcu/SoftUartTask.c
+++ b/projects/cm_mcu/SoftUartTask.c
@@ -93,7 +93,7 @@ unsigned char g_pucTxBuffer[16];
 //
 unsigned long g_ulBitTime;
 
-#define TARGET_BAUD_RATE 38400
+#define TARGET_BAUD_RATE 115200
 
 tSoftUART g_sUART;
 
@@ -157,7 +157,13 @@ void SoftUartTask(void *parameters)
   //
   // MAP_IntPrioritySet(INT_GPIOE, 0x00);
   // MAP_IntPrioritySet(INT_TIMER0B, 0x40);
-  MAP_IntPrioritySet(INT_TIMER0A, configKERNEL_INTERRUPT_PRIORITY);
+  // 0x80 corresponds to 4 << (8-5)
+  // Remember that on the TM4C only 3 highest bits
+  // are used for setting interrupt priority, and numerically lower
+  // values are logically higher.
+  // this is lower that configMAX_SYSCALL_INTERRUPT_PRIORITY but the ISR
+  // does not call any FreeRTOS functions so this will work.
+  MAP_IntPrioritySet(INT_TIMER0A, 0x80); // THIS NEEDS TO BE at a HIGH PRIORITY!!!! DONOT CHANGE
   //
   // Enable the interrupts associated with the software UART.
   //
@@ -206,10 +212,10 @@ void SoftUartTask(void *parameters)
         testmode = 0;
         break;
       case SOFTUART_TEST_RAW:
-        message[0] = 0x9c;
-        message[1] = 0x2c;
-        message[2] = 0x2b;
-        message[3] = 0x3e;
+        message[0] = 0x55;
+        message[1] = 0xaa;
+        message[2] = 0x55;
+        message[3] = 0xaa;
         inTestMode = true;
         enable = true;
         testmode = 2;

--- a/projects/cm_mcu/SoftUartTask.c
+++ b/projects/cm_mcu/SoftUartTask.c
@@ -53,13 +53,13 @@ static uint8_t  testaddress = 0x0;
 static uint16_t testdata    = 0xaaff;
 static bool inTestMode = false;
 static uint8_t testmode = 0;
-void setSUARTTestData(uint8_t sensor, uint8_t value)
+void setSUARTTestData(uint8_t sensor, uint16_t value)
 {
   testaddress = sensor;
   testdata = value;  
 }
 
-uint8_t getSUARTMode()
+uint8_t getSUARTTestMode()
 {
   return testmode;
 }
@@ -185,9 +185,14 @@ void SoftUartTask(void *parameters)
         break;
       case SOFTUART_TEST_SINGLE:
         inTestMode = true;
+	testmode = 0;
         break;
       case SOFTUART_TEST_INCREMENT:
         inTestMode = true;
+	testmode = 1;
+        break;
+      case SOFTUART_TEST_OFF:
+        inTestMode = false;
         break;
       }
     }
@@ -196,10 +201,13 @@ void SoftUartTask(void *parameters)
       MAP_IntEnable(INT_TIMER0A);
 
       if ( inTestMode ) {
-        if ( testmode == 1 ) {
-          testdata++;
+        for ( int jj = 0; jj < testmode*10+1; ++jj ) {
+          if ( testmode == 1 ) {
+            testdata++;
+            testaddress++;
+          }
+          format_data(testaddress, testdata, message);
         }
-        format_data(testaddress, testdata, message);
         vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(5000));
         continue;
       }

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -162,12 +162,13 @@ void EEPROMTask(void *parameters);
 #define SOFTUART_DISABLE_TRANSMIT 0x2
 #define SOFTUART_TEST_SINGLE      0x3
 #define SOFTUART_TEST_INCREMENT   0x4
+#define SOFTUART_TEST_OFF         0x5
 
 extern QueueHandle_t xSoftUartQueue;
 void SoftUartTask(void *parameters);
 
-void setSUARTTestData(uint8_t sensor, uint8_t value);
-uint8_t getSUARTMode();
+void setSUARTTestData(uint8_t sensor, uint16_t value);
+uint8_t getSUARTTestMode();
 uint8_t getSUARTTestSensor();
 uint16_t getSUARTTestData();
 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -158,21 +158,29 @@ void EEPROMTask(void *parameters);
 
 // Soft UART Task
 // SoftUart queue messages
-#define SOFTUART_ENABLE_TRANSMIT 0x1
+#define SOFTUART_ENABLE_TRANSMIT  0x1
 #define SOFTUART_DISABLE_TRANSMIT 0x2
+#define SOFTUART_TEST_SINGLE      0x3
+#define SOFTUART_TEST_INCREMENT   0x4
+
 extern QueueHandle_t xSoftUartQueue;
 void SoftUartTask(void *parameters);
 
-// utility functions
-const uint32_t * getSystemStack();
-int SystemStackWaterHighWaterMark();
+void setSUARTTestData(uint8_t sensor, uint8_t value);
+uint8_t getSUARTMode();
+uint8_t getSUARTTestSensor();
+uint16_t getSUARTTestData();
 
-// Xilinx MonitorTask
-int get_ku_index();
-int get_vu_index();
-//void set_ku_index(int index);
-//void set_vu_index(int index);
-void initFPGAMon();
+  // utility functions
+  const uint32_t *getSystemStack();
+  int SystemStackWaterHighWaterMark();
+
+  // Xilinx MonitorTask
+  int get_ku_index();
+  int get_vu_index();
+  // void set_ku_index(int index);
+  // void set_vu_index(int index);
+  void initFPGAMon();
 
 
 #endif /* PROJECTS_CM_MCU_TASKS_H_ */

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -158,30 +158,35 @@ void EEPROMTask(void *parameters);
 
 // Soft UART Task
 // SoftUart queue messages
+//#define SUART_TEST_MODE
+
 #define SOFTUART_ENABLE_TRANSMIT  0x1
 #define SOFTUART_DISABLE_TRANSMIT 0x2
 #define SOFTUART_TEST_SINGLE      0x3
 #define SOFTUART_TEST_INCREMENT   0x4
 #define SOFTUART_TEST_OFF         0x5
+#define SOFTUART_TEST_SEND_ONE    0x6
+#define SOFTUART_TEST_RAW         0x7
 
 extern QueueHandle_t xSoftUartQueue;
 void SoftUartTask(void *parameters);
 
+#ifdef SUART_TEST_MODE
 void setSUARTTestData(uint8_t sensor, uint16_t value);
 uint8_t getSUARTTestMode();
 uint8_t getSUARTTestSensor();
 uint16_t getSUARTTestData();
+#endif // SUART_TEST_MODE
 
-  // utility functions
-  const uint32_t *getSystemStack();
-  int SystemStackWaterHighWaterMark();
+// utility functions
+const uint32_t *getSystemStack();
+int SystemStackWaterHighWaterMark();
 
-  // Xilinx MonitorTask
-  int get_ku_index();
-  int get_vu_index();
-  // void set_ku_index(int index);
-  // void set_vu_index(int index);
-  void initFPGAMon();
-
+// Xilinx MonitorTask
+int get_ku_index();
+int get_vu_index();
+// void set_ku_index(int index);
+// void set_vu_index(int index);
+void initFPGAMon();
 
 #endif /* PROJECTS_CM_MCU_TASKS_H_ */

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -185,7 +185,7 @@ void SystemInitInterrupts()
   setupActiveLowPins();
 
   // SYSTICK timer -- this is already enabled in the portable layer
-return;
+  return;
 
 
 }
@@ -260,7 +260,7 @@ int main( void )
   xTaskCreate(I2CSlaveTask,  "I2CS0", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
   xTaskCreate(EEPROMTask,    "EPRM",  configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+4, NULL);
   xTaskCreate(InitTask,      "INIT",  configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
-  xTaskCreate(SoftUartTask,  "SUART", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+3, NULL);
+  xTaskCreate(SoftUartTask,  "SUART", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
 
 
   // -------------------------------------------------


### PR DESCRIPTION
Incorrect setting of the timer interrupt for the soft UART for the MCU->Zynq monitoring data path caused data corruption. This has been fixed. Some debugging software (currently ifdef'd out) is also included in this PR. 

