### PR TITLE
Zynq monitoring path: bug fix to address updated address table/missing data

### DIFF
--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -97,7 +97,7 @@ ${COMPILER}/cm_mcu.axf: ${COMPILER}/I2CSlaveTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/AlarmTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/LedTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/microrl.o
-${COMPILER}/cm_mcu.axf: ${COMPILER}/SoftUartTask.o
+${COMPILER}/cm_mcu.axf: ${COMPILER}/ZynqMonTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/InterruptHandlers.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/InitTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/LocalTasks.o

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -172,7 +172,7 @@ void EEPROMTask(void *parameters);
 #define SOFTUART_TEST_RAW         0x7
 
 extern QueueHandle_t xSoftUartQueue;
-void SoftUartTask(void *parameters);
+void ZynqMonTask(void *parameters);
 
 #ifdef SUART_TEST_MODE
 void setSUARTTestData(uint8_t sensor, uint16_t value);

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -261,7 +261,7 @@ int main( void )
   xTaskCreate(I2CSlaveTask,  "I2CS0", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
   xTaskCreate(EEPROMTask,    "EPRM",  configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+4, NULL);
   xTaskCreate(InitTask,      "INIT",  configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
-  xTaskCreate(SoftUartTask,  "SUART", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
+  xTaskCreate(ZynqMonTask,  "SUART", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY+5, NULL);
 
 
   // -------------------------------------------------


### PR DESCRIPTION
this fix adds two missing supplies and also gets rid of extra data that was being sent erroneously. 

Also rename the SoftUartTask to ZynqMonTask to describe what it does, not how it does it.