### PR TITLE
Fix error handling for power supply mask

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,4 @@ IndentWidth: 2
 BreakBeforeBraces: Stroustrup
 AllowShortFunctionsOnASingleLine: false
 IndentCaseLabels: true
+SortIncludes: false

--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,4 @@ BasedOnStyle: LLVM
 IndentWidth: 2
 BreakBeforeBraces: Stroustrup
 AllowShortFunctionsOnASingleLine: false
-
+IndentCaseLabels: true

--- a/common/utils.c
+++ b/common/utils.c
@@ -442,8 +442,8 @@ void errbuffer_temp_high(uint8_t tm4c, uint8_t fpga, uint8_t ffly, uint8_t dcdc)
 
 void errbuffer_power_fail(uint16_t failmask)
 {
-  errbuffer_put(EBUF_PWR_FAILURE, failmask&0xFFU);
-  errbuffer_put(EBUF_CONTINUATION, (failmask>>8)&0xFFU);
+  errbuffer_put(EBUF_PWR_FAILURE, (failmask >> 8) & 0xFFU);
+  errbuffer_put(EBUF_CONTINUATION, failmask & 0xFFU);
 }
 
 // These register locations are defined by the ARM Cortex-M4F

--- a/common/utils.c
+++ b/common/utils.c
@@ -440,6 +440,11 @@ void errbuffer_temp_high(uint8_t tm4c, uint8_t fpga, uint8_t ffly, uint8_t dcdc)
   return;
 }
 
+void errbuffer_power_fail(uint16_t failmask)
+{
+  errbuffer_put(EBUF_PWR_FAILURE, failmask&0xFFU);
+  errbuffer_put(EBUF_CONTINUATION, (failmask>>8)&0xFFU);
+}
 
 // These register locations are defined by the ARM Cortex-M4F
 // specification and do not depend on the TM4C1290NCPDT

--- a/common/utils.h
+++ b/common/utils.h
@@ -34,9 +34,9 @@ uint64_t read_eeprom_multi(uint32_t addr);
 #define EBUF_MINBLK 2
 #define EBUF_MAXBLK 5
 
-#define ERRDATA_OFFSET 7	// Number of bits reserved for error data
-#define ERRCODE_OFFSET 5	// Number of bits reserved for error codes
-#define COUNTER_OFFSET (16-ERRDATA_OFFSET-ERRCODE_OFFSET)	// Number of bits reserved for message counter
+#define ERRDATA_OFFSET 8 // Number of bits reserved for error data
+#define ERRCODE_OFFSET 5 // Number of bits reserved for error codes
+#define COUNTER_OFFSET (16 - ERRDATA_OFFSET - ERRCODE_OFFSET) // Number of bits reserved for message counter
 
 #define ERRDATA_MASK ((1<<(ERRDATA_OFFSET))-1)
 #define ERRCODE_MASK ((1<<(ERRDATA_OFFSET+ERRCODE_OFFSET))-1-ERRDATA_MASK)
@@ -45,12 +45,12 @@ uint64_t read_eeprom_multi(uint32_t addr);
 #define EBUF_COUNTER_UPDATE 4	//Number of repeated entries that initiates a hardware counter update (re-write entry)
 
 // error codes without data
-#define EBUF_RESTART			1
-#define EBUF_RESET_BUFFER		2
-#define EBUF_POWER_OFF			3
-#define EBUF_POWER_OFF_TEMP		4
-#define EBUF_POWER_ON			5
-#define EBUF_TEMP_NORMAL		6
+#define EBUF_RESTART        1
+#define EBUF_RESET_BUFFER   2
+#define EBUF_POWER_OFF      3
+#define EBUF_POWER_OFF_TEMP 4
+#define EBUF_POWER_ON       5
+#define EBUF_TEMP_NORMAL    6
 #define EBUF_HARDFAULT      7
 #define EBUF_ASSERT         8
 #define EBUF_STACKOVERFLOW  9
@@ -60,6 +60,7 @@ uint64_t read_eeprom_multi(uint32_t addr);
 #define EBUF_CONTINUATION		10
 #define EBUF_PWR_FAILURE		11
 #define EBUF_TEMP_HIGH			12
+#define EBUF_MARK               13
 
 // Restart Reasons, values of reset cause (RESC) register,
 // at 0x5c offset in TM4C1290NCPDT
@@ -105,6 +106,8 @@ int errbuffer_get_messagestr(const uint32_t word, char *m, size_t s );
 
 // specific error functions
 void errbuffer_temp_high(uint8_t tm4c, uint8_t fpga, uint8_t ffly, uint8_t dcdc);
+void errbuffer_power_fail(uint16_t failmask);
+
 // timers used for FreeRTOS accounting
 void stopwatch_reset(void);
 uint32_t stopwatch_getticks();

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -1118,38 +1118,38 @@ static BaseType_t errbuff_out(int argc, char **argv)
 {
   int copied = 0;
 
-  const uint8_t max_entries=25;
-  uint32_t num = strtoul(argv[1],NULL,10);
-  if (num>max_entries){
-	  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Please enter a number 25 or less \r\n");
-	  return pdFALSE;
+  const uint8_t max_entries = 64;
+  uint32_t num = strtoul(argv[1], NULL, 10);
+  if (num > max_entries) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please enter a number 64 or less \r\n");
+    return pdFALSE;
   }
   uint32_t arr[max_entries];
-  uint32_t (*arrptr)[max_entries]=&arr;
-  errbuffer_get(num,arrptr);
+  uint32_t(*arrptr)[max_entries] = &arr;
+  errbuffer_get(num, arrptr);
 
-  static int i=0;
-  if (i==0) {
-	  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Entries in EEPROM buffer:\r\n");
+  static int i = 0;
+  if (i == 0) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Entries in EEPROM buffer:\r\n");
   }
-  for (; i<num; ++i) {
+  for (; i < num; ++i) {
     uint32_t word = (*arrptr)[i];
     uint16_t errcode = EBUF_ERRCODE(word);
     // if this is a continuation and it's not the first entry we see
-    if (errcode == EBUF_CONTINUATION && i != 0 ){
+    if (errcode == EBUF_CONTINUATION && i != 0) {
       uint16_t errdata = EBUF_DATA(word);
-    	copied += snprintf(m+copied, SCRATCH_SIZE-copied, " %02u", errdata);
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " %02u (0x%02x)", errdata, errdata);
     }
-    else{
-      copied += errbuffer_get_messagestr(word, m+copied, SCRATCH_SIZE-copied);
+    else {
+      copied += errbuffer_get_messagestr(word, m + copied, SCRATCH_SIZE - copied);
     }
-    if ((SCRATCH_SIZE-copied)<30 && (i<num)){	// this should catch when buffer is close to full
-    	++i;
-    	return pdTRUE;
+    if ((SCRATCH_SIZE - copied) < 30 && (i < num)) { // catch when buffer is almost full
+      ++i;
+      return pdTRUE;
     }
   }
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "\r\n");
-  i=0;
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+  i = 0;
   return pdFALSE;
 }
 
@@ -1168,13 +1168,13 @@ static BaseType_t errbuff_info(int argc, char **argv)
   counter = errbuffer_counter();
   n_continue = errbuffer_continue();
 
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Capacity: %8x words\r\n",cap);
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Min address: %8x\r\n",minaddr);
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Max address: %8x\r\n",maxaddr);
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Head address: %8x\r\n",head);
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Last entry: %x\r\n",last);
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Message counter: %x\r\n",counter);
-  copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Continue codes: %x\r\n",n_continue);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity: 0x%8x words\r\n", cap);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address: 0x%8x\r\n", minaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address: 0x%8x\r\n", maxaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address: 0x%8x\r\n", head);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry: 0x%x\r\n", last);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: 0x%x\r\n", counter);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes: 0x%x\r\n", n_continue);
 
   return pdFALSE;
 }

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -104,27 +104,26 @@ void PowerSupplyTask(void *parameters)
     // first check for message on the queue and collect all messages.
     // non-blocking call.
     uint32_t message;
-    if (xQueueReceive(xPwrQueue, &message,
-                      0)) { // TODO: what if I receive more than one message
+    if (xQueueReceive(xPwrQueue, &message, 0)) { // TODO: more than one message
       switch (message) {
-      case PS_OFF:
-        cli_powerdown_request = true;
-        break;
-      case TEMP_ALARM:
-        external_alarm = true;
-        break;
-      case TEMP_ALARM_CLEAR:
-        external_alarm = false;
-        break;
-      case PS_ON:
-        cli_powerdown_request = false;
-        break;
-      case PS_ANYFAIL_ALARM_CLEAR:
-        power_supply_alarm = false;
-        failed_mask = 0x0U;
-        break;
-      default:
-        break;
+        case PS_OFF:
+          cli_powerdown_request = true;
+          break;
+        case TEMP_ALARM:
+          external_alarm = true;
+          break;
+        case TEMP_ALARM_CLEAR:
+          external_alarm = false;
+          break;
+        case PS_ON:
+          cli_powerdown_request = false;
+          break;
+        case PS_ANYFAIL_ALARM_CLEAR:
+          power_supply_alarm = false;
+          failed_mask = 0x0U;
+          break;
+        default:
+          break;
       }
     }
     // Check the state of BLADE_POWER_EN.


### PR DESCRIPTION
Closes #60 

This PR fixes the bug that the supply mask for the failing supplies is too big to fit into the error logger data field (7 bits previously.) In this PR the bitfield is changed to 8 bits and the error logging for the supply mask now uses a continuation code.  Since the number of repeats is limited to 4 (2 bits) there was no reason to have 4 bits for that code.

Other changes include allowing up to 64 entries in the output of the error logger (previously on my recommendation this was limited to 25, but this meant that the additional error entries were effectively invisible.)

Other minor formatting changes. 