### PR TITLE
Ensure that NaNs and/or -55 (int) are sent when data is stale

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -183,13 +183,13 @@ int errbuffer_get_messagestr(const uint32_t word, char *m, size_t s )
       copied += snprintf(m+copied, s-copied, "(POR)");
     break;
   case EBUF_HARDFAULT:
-    copied += snprintf(m+copied, s-copied, "(ISRNUM= 0x%x)", errdata);
+    copied += snprintf(m+copied, s-copied, "(ISRNUM= 0x%02x)", errdata);
     break;
   case EBUF_PWR_FAILURE:
-    copied += snprintf(m+copied, s-copied, "(supply mask 0x%x)", errdata);
+    copied += snprintf(m+copied, s-copied, "(supply mask) 0x%02x", errdata);
     break;
   case EBUF_ASSERT:
-    copied += snprintf(m+copied, s-copied, "(pc 0x%x)", errdata);
+    copied += snprintf(m+copied, s-copied, "(pc) 0x%02x", errdata);
     break;
   default:
     if (errcode>EBUF_WITH_DATA){

--- a/common/utils.c
+++ b/common/utils.c
@@ -285,18 +285,20 @@ void errbuffer_reset()
 void errbuffer_put(uint16_t errcode, uint16_t errdata)
 {
   const uint16_t oldcount = ebuf->counter;
-
+  // special handling for continuation code
   if (errcode == EBUF_CONTINUATION) {
-    ebuf->n_continue = ebuf->n_continue + 1;
+    ebuf->n_continue++;
+#if 0
     if((oldcount == 0) || (oldcount - 1) % EBUF_COUNTER_UPDATE == 0) {
       write_eeprom(errbuffer_entry(errcode, errdata), ebuf->head);
       ebuf->head = increase_head();
       write_eeprom(0, increase_head());
     }
     return;
+#endif
   }
-  // If duplicated error code, and error code should use counter (excluding ps failure)
-  if((errcode == ebuf->last) && (errcode != EBUF_PWR_FAILURE)) {
+  // If duplicated error code, and error code should use counter (excluding continuation)
+  if((errcode == ebuf->last) && (errcode != EBUF_CONTINUATION)) {
 
     // if counter is not a multiple of COUNTER_UPDATE, don't write new entry
     if(oldcount % EBUF_COUNTER_UPDATE != 0) {
@@ -338,8 +340,8 @@ void errbuffer_put(uint16_t errcode, uint16_t errdata)
 void errbuffer_put_raw(uint16_t errcode, uint16_t errdata)
 {
   uint16_t oldcount = ebuf->counter;
-  // If duplicated error code...
-  if(errcode == ebuf->last) {
+  // If duplicated error code (except continuation)...
+  if(errcode == ebuf->last && errcode != EBUF_CONTINUATION) {
 
     // if counter is not a multiple of COUNTER_UPDATE, don't write new entry
     if(oldcount % EBUF_COUNTER_UPDATE != 0) {

--- a/common/utils.c
+++ b/common/utils.c
@@ -282,6 +282,11 @@ void errbuffer_reset()
   return;
 }
 
+// Nota Bene
+// this _put (and _put_raw below) need to be checked if
+// the writing of codes only every EBUF_COUNTER_UPDATE
+// works with continuation codes.
+// Maybe this is an unneeded complication.
 void errbuffer_put(uint16_t errcode, uint16_t errdata)
 {
   const uint16_t oldcount = ebuf->counter;

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -1138,7 +1138,7 @@ static BaseType_t errbuff_out(int argc, char **argv)
     // if this is a continuation and it's not the first entry we see
     if (errcode == EBUF_CONTINUATION && i != 0) {
       uint16_t errdata = EBUF_DATA(word);
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " %02u (0x%02x)", errdata, errdata);
+    	copied += snprintf(m+copied, SCRATCH_SIZE-copied, " 0x%02x", errdata);
     }
     else {
       copied += errbuffer_get_messagestr(word, m + copied, SCRATCH_SIZE - copied);

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -1168,13 +1168,13 @@ static BaseType_t errbuff_info(int argc, char **argv)
   counter = errbuffer_counter();
   n_continue = errbuffer_continue();
 
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity: 0x%8x words\r\n", cap);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address: 0x%8x\r\n", minaddr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address: 0x%8x\r\n", maxaddr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address: 0x%8x\r\n", head);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry: 0x%x\r\n", last);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: 0x%x\r\n", counter);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes: 0x%x\r\n", n_continue);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry:      0x%0x\r\n", last);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: %d\r\n", counter);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes:  %d\r\n", n_continue);
 
   return pdFALSE;
 }

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -144,7 +144,10 @@ header file. */
 #define APOLLO_ASSERT_RECORD()     \
     volatile void *pc;                  \
     GET_PC(pc);                \
-    errbuffer_put_raw(EBUF_ASSERT,0)
+    errbuffer_put_raw(EBUF_ASSERT, ((uint32_t)pc>>24)&0xFFU); \
+    errbuffer_put_raw(EBUF_CONTINUATION, ((uint32_t)pc>>16)&0xFFU); \
+    errbuffer_put_raw(EBUF_CONTINUATION, ((uint32_t)pc>>8)&0xFFU); \
+    errbuffer_put_raw(EBUF_CONTINUATION, (uint32_t)pc&0xFFU)
 
 #ifdef DEBUG
 #define APOLLO_ASSERT(exp) \

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -25,7 +25,6 @@
 #include "FreeRTOSConfig.h"
 #include "queue.h"
 
-#define APOLLO10_HACK
 // Holds the handle of the created queue for the power supply task.
 QueueHandle_t xPwrQueue = NULL;
 


### PR DESCRIPTION
* Ensure stale data gets marked as such for the zynq monitoring data path
* also try to fix the error logger for asserts 