### PR TITLE
Initialization code for LGA80D power supplies 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ deploy:
     - projects/cm_mcu/gcc/cm_mcu.bin
     - projects/boot_loader/gcc/bl_main.axf
     - projects/boot_loader/gcc/bl_main.bin
+    - cm_mcu_noecn001.bin
+    - cm_mcu_noecn001.axf
   skip_cleanup: true
   on:
     tags: true
@@ -67,5 +69,10 @@ install:
 before_script:
   - arm-none-eabi-gcc --version
 
+# build version with and without code for ECN001
 script:
-  - make -k 
+  - make -k NO_ECN001=1 
+  - cp projects/cm_mcu/gcc/cm_mcu.bin cm_mcu_noecn001.bin
+  - cp projects/cm_mcu/gcc/cm_mcu.axf cm_mcu_noecn001.axf
+  - make clean
+  - make -k

--- a/common/power_ctl.h
+++ b/common/power_ctl.h
@@ -51,9 +51,23 @@ int getLowestEnabledPSPriority();
 #define PS_ENS_VU_MASK  0xC332U
 #define PS_ENS_KU_MASK  0x3CC1U
 
+// OK masks for various stages of the turn-on.
+// these are indices into the oks[] array 
+// L1-L5, note NO L3!!! no PG on the L3 supplies
+#define PS_OKS_KU_MASK_L1 0x0003U
+#define PS_OKS_KU_MASK_L2 0x0030U // these are common to VU and KU
+#define PS_OKS_KU_MASK_L4 0x0300U
+#define PS_OKS_KU_MASK_L5 0x0C00U
+#define PS_OKS_VU_MASK_L1 0x000CU
+#define PS_OKS_VU_MASK_L2 PS_OKS_KU_MASK_L2
+#define PS_OKS_VU_MASK_L4 0x00C0U
+#define PS_OKS_VU_MASK_L5 0x3000U
+
 bool turn_on_ps(uint16_t);
 bool check_ps(void);
 bool disable_ps(void);
+void turn_on_ps_at_prio(bool vu_enable, bool ku_enable, int prio);
+void blade_power_ok(bool isok);
 
 
 #endif /* COMMON_POWER_CTL_H_ */

--- a/makedefs
+++ b/makedefs
@@ -162,6 +162,10 @@ else
 CFLAGS+=-Os 
 endif
 
+ifdef NO_ECN001
+CFLAGS+= -DNO_ECN001 
+endif
+
 
 #
 # Add the tool specific CFLAGS.

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -537,7 +537,7 @@ static BaseType_t bl_ctl(int argc, char ** argv)
 static BaseType_t clock_ctl(int argc, char ** argv)
 {
   int copied = 0;
-  int status;
+  int status = -1; // shut up clang compiler warning
   BaseType_t i = strtol(argv[1], NULL, 10);
   if ( ! ((i==1)||(i==2) )) {
     copied += snprintf(m+copied, SCRATCH_SIZE-copied, "Invalid mode %d for clock, only 1 (reset) and 2 (program) supported\r\n", i);

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -229,8 +229,8 @@ static BaseType_t power_ctl(int argc, char ** argv)
                          "%s:\r\nVU_ENABLE:\t%d\r\n"
                          "KU_ENABLE:\t%d\r\n",
                          argv[0], vu_enable, ku_enable);
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                         "State machine state: %d\r\n", getPowerControlState());
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "State machine state: %s\r\n",
+                         getPowerControlStateName(getPowerControlState()));
     }
     for (; i < N_PS_OKS; ++i ) {
       enum ps_state j = getPSStatus(i);

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -177,6 +177,9 @@ header file. */
 
 #define SYSTEM_STACK_SIZE 128
 #define I2C_PULLUP_BUG
+#ifndef NO_ECN001
+#define ECN001
+#endif // NO_ECN001 
 
 #define pdTICKS_TO_MS( xTicks )    ( ( ( TickType_t ) ( xTicks ) * 1000u ) / configTICK_RATE_HZ )
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -56,7 +56,7 @@ struct MonitorTaskArgs_t fpga_args = {
     .n_pages = 1,
     .smbus = &g_sMaster6,
     .smbus_status = &eStatus6,
-    .initfcn = NULL,
+    .xSem = NULL,
 };
 
 // Power supply arguments for Monitoring task
@@ -133,7 +133,7 @@ struct pm_command_t extra_cmds[] = {
 void snapdump(struct dev_i2c_addr_t *add, uint8_t page,
               uint8_t snapshot[32], bool reset)
 {
-  while(xSemaphoreTake(xMonSem, (TickType_t) 10) == pdFALSE)
+  while(xSemaphoreTake(dcdc_args.xSem, (TickType_t) 10) == pdFALSE)
     ;
   // page register
   int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
@@ -147,19 +147,19 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page,
   r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
       false, add, &extra_cmds[4], &cmd);
   if ( r ) {
-    Print("error in scdump 1\r\n");
+    Print("error in snapdump 1\r\n");
   }
   // actual command -- read snapshot
   tSMBusStatus r2 = SMBusMasterBlockRead(&g_sMaster1, add->dev_addr,
       extra_cmds[3].command, &snapshot[0]);
   if ( r2 != SMBUS_OK ) {
-    Print("error setting up block read (scdump 2)\r\n");
+    Print("error setting up block read (snapdump 2)\r\n");
   }
   while ( (r2 = SMBusStatusGet(&g_sMaster1)) == SMBUS_TRANSFER_IN_PROGRESS) {
     vTaskDelay( pdMS_TO_TICKS( 10 )); // wait
   }
   if ( r2 != SMBUS_TRANSFER_COMPLETE ) {
-    Print("error in scdump(3)\r\n");
+    Print("error in snapdump(3)\r\n");
   }
   if ( reset ) {
     // reset SNAPSHOT. This will fail if the device is on.
@@ -167,51 +167,58 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page,
     r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
         false, add,&extra_cmds[4],  &cmd);
     if ( r ) {
-      Print("error in scdump 4\r\n");
+      Print("error in snapdump 4\r\n");
     }
   }
-  xSemaphoreGive(xMonSem);
+  xSemaphoreGive(dcdc_args.xSem);
 }
  
 // Initialization function for the LGA80D. These settings
 // need to be called when the supply output is OFF
 // this is currently not ensured in this code.
-void dcdc_initfcn(void)
+void LGA80D_init(void)
 {
-  Print("dcdc_initfcn\r\n");
+  while (xSemaphoreTake(dcdc_args.xSem, (TickType_t)10) == pdFALSE)
+    ;
+  Print("LGA80D_init\r\n");
   // set up the switching frequency
   uint16_t freqlin11 = float_to_linear11(457.14f);
   //uint16_t freqlin11 = float_to_linear11(800.f);
   uint16_t drooplin11 = float_to_linear11(0.0700f);
-  for ( int dev = 1; dev < 5; dev += 1 ) {
+  for ( int dev = 1; dev < 5; dev += 2 ) {
     for (uint8_t page = 0; page < 2; ++ page ) {
       // page register
+      char tmp[256];
       int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
           false, pm_addrs_dcdc+dev, &extra_cmds[0], &page);
       if ( r ) {
-        Print("error in dcdc_initfcn (0)\r\n");
+        snprintf(tmp, 256, "dev = %d, page = %d, r= %d\r\n", dev, page, r);
+        Print(tmp);
+        Print("error in LGA80D_init (0)\r\n");
       }
       // actual command -- frequency switch
       r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
           false, pm_addrs_dcdc+dev,&extra_cmds[2],  (uint8_t*)&freqlin11);
       if ( r ) {
-        Print("error in dcdc_initfcn (1)\r\n");
+        Print("error in LGA80D_init (1)\r\n");
       }
       // actual command -- vout_droop switch
       r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
           false, pm_addrs_dcdc+dev,&extra_cmds[5],  (uint8_t*)&drooplin11);
       if ( r ) {
-        Print("error in dcdc_initfcn (2)\r\n");
+        Print("error in LGA80D_init (2)\r\n");
       }
       // actual command -- multiphase_ramp_gain switch
       uint8_t val = 0x7; // by suggestion of Artesian
       r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
           false, pm_addrs_dcdc+dev,&extra_cmds[6],  &val);
       if ( r ) {
-        Print("error in dcdc_initfcn (3)\r\n");
+        Print("error in LGA80D_init (3)\r\n");
       }
     }
   }
+  xSemaphoreGive(dcdc_args.xSem);
+
   return;
 }
 
@@ -237,6 +244,7 @@ struct pm_command_t pm_command_dcdc[] = {
         { 0xD5, 1, "MULTIPHASE_RAMP_GAIN", "", PM_STATUS},
       };
 float dcdc_values[NSUPPLIES_PS*NPAGES_PS*NCOMMANDS_PS];
+
 struct MonitorTaskArgs_t dcdc_args = {
     .name = "PSMON",
     .devices = pm_addrs_dcdc,
@@ -248,8 +256,7 @@ struct MonitorTaskArgs_t dcdc_args = {
     .n_pages = NPAGES_PS,
     .smbus = &g_sMaster1,
     .smbus_status = &eStatus1,
-    .initfcn = &dcdc_initfcn,
-    //.initfcn = NULL,
+    .xSem = NULL,
 };
 
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -208,7 +208,7 @@ void LGA80D_init(void)
         Print("error in LGA80D_init (2)\r\n");
       }
       // actual command -- multiphase_ramp_gain switch
-      uint8_t val = 0x7; // by suggestion of Artesian
+      uint8_t val = 0x7U; // by suggestion of Artesian
       r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, pm_addrs_dcdc + dev, &extra_cmds[6], &val);
       if ( r ) {
         Print("error in LGA80D_init (3)\r\n");

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -183,35 +183,33 @@ void LGA80D_init(void)
   Print("LGA80D_init\r\n");
   // set up the switching frequency
   uint16_t freqlin11 = float_to_linear11(457.14f);
-  //uint16_t freqlin11 = float_to_linear11(800.f);
   uint16_t drooplin11 = float_to_linear11(0.0700f);
-  for ( int dev = 1; dev < 5; dev += 2 ) {
+  for (int dev = 1; dev < 5; dev += 1) {
     for (uint8_t page = 0; page < 2; ++ page ) {
       // page register
       char tmp[256];
-      int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
-          false, pm_addrs_dcdc+dev, &extra_cmds[0], &page);
+      int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, pm_addrs_dcdc + dev, &extra_cmds[0],
+                              &page);
       if ( r ) {
         snprintf(tmp, 256, "dev = %d, page = %d, r= %d\r\n", dev, page, r);
         Print(tmp);
         Print("error in LGA80D_init (0)\r\n");
       }
       // actual command -- frequency switch
-      r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
-          false, pm_addrs_dcdc+dev,&extra_cmds[2],  (uint8_t*)&freqlin11);
+      r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, pm_addrs_dcdc + dev, &extra_cmds[2],
+                          (uint8_t *)&freqlin11);
       if ( r ) {
         Print("error in LGA80D_init (1)\r\n");
       }
       // actual command -- vout_droop switch
-      r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
-          false, pm_addrs_dcdc+dev,&extra_cmds[5],  (uint8_t*)&drooplin11);
+      r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, pm_addrs_dcdc + dev, &extra_cmds[5],
+                          (uint8_t *)&drooplin11);
       if ( r ) {
         Print("error in LGA80D_init (2)\r\n");
       }
       // actual command -- multiphase_ramp_gain switch
       uint8_t val = 0x7; // by suggestion of Artesian
-      r = apollo_pmbus_rw(&g_sMaster1, &eStatus1,
-          false, pm_addrs_dcdc+dev,&extra_cmds[6],  &val);
+      r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, pm_addrs_dcdc + dev, &extra_cmds[6], &val);
       if ( r ) {
         Print("error in LGA80D_init (3)\r\n");
       }
@@ -240,8 +238,10 @@ struct pm_command_t pm_command_dcdc[] = {
         { 0x44, 2, "VOUT_UV_FAULT_LIMIT", "V", PM_LINEAR16U},
         { 0x37, 2, "INTERLEAVE", "", PM_STATUS},
         { 0x80, 1, "STATUS_MFR_SPECIFIC", "", PM_STATUS},
-        { 0x28, 2, "VOUT_DROOP", "", PM_LINEAR11},
+        { 0x28, 2, "VOUT_DROOP", "V/A", PM_LINEAR11},
         { 0xD5, 1, "MULTIPHASE_RAMP_GAIN", "", PM_STATUS},
+        { 0x57, 2, "VIN_UV_WARN_LIMIT", "V", PM_LINEAR11},
+        { 0x58, 2, "VIN_UV_FAULT_LIMIT", "V", PM_LINEAR11},
       };
 float dcdc_values[NSUPPLIES_PS*NPAGES_PS*NCOMMANDS_PS];
 

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -103,7 +103,11 @@ void MonitorTask(void *parameters)
     // since that is the I2C pullups. This will be changed with next
     // rev of the board.
     // HACK -- THIS TEST IS ONLY USED FOR THE XILINX TASK (name starts with 'X')
-    if ( getPSStatus(5) != PWR_ON  && args->name[0] == 'X') {
+    if (getPSStatus(5) != PWR_ON
+#ifdef ECN001
+        && args->name[0] == 'X'
+#endif // NO_ECN001
+    ) {
       if ( good ) {
         snprintf(tmp, TMPBUFFER_SZ, "MON(%s): 3V3 died. Skipping I2C monitoring.\r\n",
             args->name);

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -107,7 +107,7 @@ void MonitorTask(void *parameters)
     // check if the 3.3V is there or not. If it disappears then nothing works
     // since that is the I2C pullups. This will be changed with next
     // rev of the board.
-    if ( getPSStatus(5) != PWR_ON) {
+    if ( getPSStatus(5) != PWR_ON  && args->name[0] == 'X') {
       if ( good ) {
         snprintf(tmp, TMPBUFFER_SZ, "MON(%s): 3V3 died. Skipping I2C monitoring.\r\n",
             args->name);
@@ -126,7 +126,7 @@ void MonitorTask(void *parameters)
     // loop over devices
     for ( uint8_t ps = 0; ps < args->n_devices; ++ ps ) {
 #ifdef I2C_PULLUP_BUG
-      if ( getPSStatus(5) != PWR_ON)
+      if ( getPSStatus(5) != PWR_ON && args->name[0] == 'X')
         break;
 #endif // I2C_PULLUP_BUG
 

--- a/projects/cm_mcu/MonitorTask.h
+++ b/projects/cm_mcu/MonitorTask.h
@@ -47,7 +47,7 @@ struct MonitorTaskArgs_t {
   tSMBus *smbus;
   volatile tSMBusStatus *smbus_status;
   volatile TickType_t updateTick;
-  void (*initfcn) (void);
+  SemaphoreHandle_t xSem;
 };
 // DC-DC converter
 #define NSUPPLIES_PS (5) // 5 devices, 2 pages each

--- a/projects/cm_mcu/MonitorTask.h
+++ b/projects/cm_mcu/MonitorTask.h
@@ -20,11 +20,11 @@ extern SemaphoreHandle_t xMonSem;
 enum { PM_VOLTAGE, PM_NONVOLTAGE, PM_STATUS, PM_LINEAR11, PM_LINEAR16U, PM_LINEAR16S } pm_types ;
 
 struct pm_command_t {
-  unsigned char command;
-  int size;
-  char *name;
-  char *units;
-  int type;
+  unsigned char command; // I2c register address
+  int size;              // number of bytes to read
+  char *name;            // text describing command
+  char *units;           // units for pretty printing
+  int type;              // how to decode command (L11 or bitfield or ...)
 };
 
 // how to find an I2C device, with a mux infront of it.
@@ -36,22 +36,22 @@ struct dev_i2c_addr_t {
 };
 
 struct MonitorTaskArgs_t {
-  const char *name;
-  struct dev_i2c_addr_t * devices;
-  int n_devices;
-  struct pm_command_t * commands;
-  const int n_commands;
-  float *pm_values;
-  const int n_values;
-  const int n_pages;
-  tSMBus *smbus;
-  volatile tSMBusStatus *smbus_status;
-  volatile TickType_t updateTick;
-  SemaphoreHandle_t xSem;
+  const char *name;                    // name to be assigned to the task
+  struct dev_i2c_addr_t *devices;      // list of devices to query
+  int n_devices;                       // number of devices
+  struct pm_command_t *commands;       // list of commands
+  const int n_commands;                // number of commands
+  float *pm_values;                    // place to store results
+  const int n_values;                  // number of results
+  const int n_pages;                   // number of pages to loop over
+  tSMBus *smbus;                       // pointer to I2C controller
+  volatile tSMBusStatus *smbus_status; // pointer to I2C status
+  volatile TickType_t updateTick;      // last update time, in ticks
+  SemaphoreHandle_t xSem;              // semaphore for controlling access to device
 };
 // DC-DC converter
 #define NSUPPLIES_PS (5) // 5 devices, 2 pages each
-#define NCOMMANDS_PS 15 // number of entries in dcdc_ array
+#define NCOMMANDS_PS 17 // number of entries in dcdc_ array
 #define NPAGES_PS    2 // number of pages on the power supplies.
 
 extern struct MonitorTaskArgs_t dcdc_args;

--- a/projects/cm_mcu/MonitorTask.h
+++ b/projects/cm_mcu/MonitorTask.h
@@ -51,7 +51,7 @@ struct MonitorTaskArgs_t {
 };
 // DC-DC converter
 #define NSUPPLIES_PS (5) // 5 devices, 2 pages each
-#define NCOMMANDS_PS 13 // number of entries in dcdc_ array
+#define NCOMMANDS_PS 15 // number of entries in dcdc_ array
 #define NPAGES_PS    2 // number of pages on the power supplies.
 
 extern struct MonitorTaskArgs_t dcdc_args;

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -81,6 +81,7 @@ void PowerSupplyTask(void *parameters)
     supply_ok_mask |= PS_OKS_VU_MASK;
     supply_en_mask |= PS_ENS_VU_MASK;
   }
+//#define APOLLO10_HACK
   #ifdef APOLLO10_HACK
   // APOLLO 10 HACK
   // this set of mask hacks enables the VU VCCINT and VCCAUX to be on

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -100,6 +100,12 @@ void PowerSupplyTask(void *parameters)
   Print(tmp);
   #endif // APOLLO10_HACK
 
+  // configure the LGA80D supplies
+  LGA80D_init();
+  // waiting less than this amount of time appears to cause
+  // the power-on sequence to fail. 
+  vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(325));
+
   bool power_supply_alarm = false;
   uint16_t failed_mask = 0x0U;
   // this loop never exits

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -120,8 +120,10 @@ void PowerSupplyTask(void *parameters)
     supply_ok_mask_L5 |= supply_ok_mask_L4 | PS_OKS_VU_MASK_L5;
   }
 
-  // // configure the LGA80D supplies
+#ifdef ECN001
+  // configure the LGA80D supplies. This call takes some time.
   LGA80D_init();
+#endif // ECN001
 
   bool power_supply_alarm = false;
   uint16_t failed_mask = 0x0U;

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -53,15 +53,42 @@ static uint16_t check_ps_oks(void)
   return status;
 }
 
+#ifdef DEBUG
+void printfail(uint16_t failed_mask, uint16_t supply_ok_mask, uint16_t supply_bitset)
+{
+  char tmp[64];
+  snprintf(tmp, 64, "failure set: fail, supply_mask,bitset =  %x,%x,%x\r\n", failed_mask,
+           supply_ok_mask, supply_bitset);
+  Print(tmp);
+}
+#endif // DEBUG
+
+static
+char* power_system_state_names[] = 
+{
+  "FAIL",
+  "INIT",
+  "OFF",
+  "L1ON",
+  "L2ON",
+  "L3ON",
+  "L4ON",
+  "L5ON",
+  "ON",
+};
+
+const char* getPowerControlStateName(enum power_system_state s)
+{
+  return power_system_state_names[s];
+}
+
+
 // monitor and control the power supplies
 void PowerSupplyTask(void *parameters)
 {
   // compile-time sanity check
   static_assert(PS_ENS_MASK == (PS_ENS_GEN_MASK|PS_ENS_VU_MASK|PS_ENS_KU_MASK), "mask");
   static_assert(PS_OKS_MASK == (PS_OKS_GEN_MASK|PS_OKS_VU_MASK|PS_OKS_KU_MASK), "mask");
-
-  // initialize to the current tick time
-  TickType_t xLastWakeTime = xTaskGetTickCount();
 
   // alarm from outside this task
   bool external_alarm = false;
@@ -71,50 +98,36 @@ void PowerSupplyTask(void *parameters)
   // masks to enable/check appropriate supplies
   uint16_t supply_ok_mask = PS_OKS_GEN_MASK;
   uint16_t supply_en_mask = PS_ENS_GEN_MASK;
+  uint16_t supply_ok_mask_L1 = 0U, supply_ok_mask_L2 = 0U, 
+           supply_ok_mask_L4 = 0U, supply_ok_mask_L5 = 0U;
+
   bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
   bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
   if (ku_enable) {
     supply_ok_mask |= PS_OKS_KU_MASK;
     supply_en_mask |= PS_ENS_KU_MASK;
+    supply_ok_mask_L1 = PS_OKS_KU_MASK_L1;
+    supply_ok_mask_L2 = supply_ok_mask_L1 | PS_OKS_KU_MASK_L2;
+    supply_ok_mask_L4 = supply_ok_mask_L2 | PS_OKS_KU_MASK_L4;
+    supply_ok_mask_L5 = supply_ok_mask_L4 | PS_OKS_KU_MASK_L5;
   }
   if (vu_enable) {
     supply_ok_mask |= PS_OKS_VU_MASK;
     supply_en_mask |= PS_ENS_VU_MASK;
+    supply_ok_mask_L1 |= PS_OKS_VU_MASK_L1;
+    supply_ok_mask_L2 |= supply_ok_mask_L1 | PS_OKS_VU_MASK_L2;
+    supply_ok_mask_L4 |= supply_ok_mask_L2 | PS_OKS_VU_MASK_L4;
+    supply_ok_mask_L5 |= supply_ok_mask_L4 | PS_OKS_VU_MASK_L5;
   }
-//#define APOLLO10_HACK
-  #ifdef APOLLO10_HACK
-  // APOLLO 10 HACK
-  // this set of mask hacks enables the VU VCCINT and VCCAUX to be on
-  // but others (AVTT and AVCC) to be off
-  supply_ok_mask &= ~(1<<6);
-  supply_ok_mask &= ~(1<<7);
-  supply_ok_mask &= ~(1<<12);
-  supply_ok_mask &= ~(1<<13);
 
-  supply_en_mask &= ~(1<<8);
-  supply_en_mask &= ~(1<<9);
-  supply_en_mask &= ~(1<<14);
-  supply_en_mask &= ~(1<<15);
-  char tmp[64];
-  snprintf(tmp, 64, "PowerSupplyTask: hack mask is %x\r\n", supply_ok_mask);
-  Print(tmp);
-  #endif // APOLLO10_HACK
-
-  // configure the LGA80D supplies
-  char tmp[64];
-  snprintf(tmp, 64, "tick before: %d\r\n", pdTICKS_TO_MS( xTaskGetTickCount()));
-  Print(tmp);
-  //LGA80D_init();
-  vTaskDelay(pdMS_TO_TICKS(640));
-  snprintf(tmp, 64, "tick after: %d\r\n", pdTICKS_TO_MS(xTaskGetTickCount()));
-  Print(tmp);
-  // waiting less than this amount of time appears to cause
-  // the power-on sequence to fail. 
-  vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(325));
-  //vTaskDelay(pdMS_TO_TICKS(1000));
+  // // configure the LGA80D supplies
+  LGA80D_init();
 
   bool power_supply_alarm = false;
   uint16_t failed_mask = 0x0U;
+
+   // initialize to the current tick time *after the initialization*
+  TickType_t xLastWakeTime = xTaskGetTickCount();
   // this loop never exits
   for (;;) {
     // first check for message on the queue and collect all messages.
@@ -153,49 +166,42 @@ void PowerSupplyTask(void *parameters)
     }
 
     // MAIN POWER SUPPLY TASK STATE MACHINE
-    // +------------+
-    // | POWER_INIT +--------------------------------------+
-    // +---+--------+                                      |
-    //     |                                               v
-    //     |          +-----------+                  +-----+-----+
-    //     |          |           +----------------> |           |
-    //     +--------->+ POWER_ON  |                  | POWER_OFF |
-    //                |           | <----------------+           |
-    //                +----+------+                  +-------+---+
-    //                     |                                 ^
-    //                     |        +----------------+       |
-    //                     |        |                |       |
-    //                     +------->+  POWER_FAILURE +-------+
-    //                              |                |
-    //                              +----------------+
+    // ON1 .. ON5 are the five states of the turn-on sequence
+    // OFF1 .. OFF5 are the five states of the turn-off sequence
+    // in the transition to FAIL we turn off all the supplies in sequence,
+    // even if they were not yet tured on (i.e., transition from ON3 -> FAIL)
+    //                     +-------------------+
+    //              +------+       FAIL        +<-----+
+    // +-------+    |      +--+-------------+--+      |
+    // | INIT  |    |         ^             ^         |
+    // +---+---+    v         |             |         |
+    //     |     ---+--+   +--+-+         +-+--+  +---+--+
+    //     +---->+ OFF +---> ON1+-> ....  | ON5+->+  ON  |
+    //           +--+--+   +----+         +----+  +---+--+
+    //              |                                 |
+    //              +---------------------------------+
+
+    // Nota Bene:
+    // ON3 does not have a FAIL transition because those supplies 
+    // do not have a PWR_GOOD in Rev 1 of the CM
+
     // the state you are in is the current state, so for instance
-    // there is no power_off transition in the power_off state; 
+    // there is no power_off transition in the power_off state;
     // instead it's in the POWER_ON state (e.g.)
     enum power_system_state nextState;
     switch (currentState) {
       case POWER_INIT: {
         // only run on first boot
-        if (blade_power_enable) {
-          turn_on_ps(supply_en_mask);
-          errbuffer_put(EBUF_POWER_ON, 0);
-          nextState = POWER_ON;
-          supply_off = false;
-        }
-        else {
-          nextState = POWER_OFF;
-        }
+        nextState = POWER_OFF;
         break;
       }
       case POWER_ON: {
         if (supply_off) {
           // log erroring supplies
           failed_mask = (~supply_bitset) & supply_ok_mask;
-          char tmp[64];
-          snprintf(tmp, 64,
-                   "failure set: fail, supply_mask,bitset =  %x,%x,%x\r\n",
-                   failed_mask, supply_ok_mask, supply_bitset);
-          Print(tmp);
-
+#ifdef DEBUG
+          printfail(failed_mask, supply_ok_mask, supply_bitset);
+#endif // DEBUG
           errbuffer_power_fail(failed_mask);
           // turn off all supplies
           disable_ps();
@@ -219,15 +225,97 @@ void PowerSupplyTask(void *parameters)
         break;
       }
       case POWER_OFF: {
+        // start power-on sequence
         if (blade_power_enable && !cli_powerdown_request && !external_alarm &&
             !power_supply_alarm) {
-          turn_on_ps(supply_en_mask);
+          turn_on_ps_at_prio(vu_enable,ku_enable,1);
           errbuffer_put(EBUF_POWER_ON, 0);
-          nextState = POWER_ON;
+          nextState = POWER_L1ON;
         }
         else {
           nextState = POWER_OFF;
         }
+        break;
+      }
+      case POWER_L1ON: {
+        if ( (supply_bitset & supply_ok_mask_L1)  != supply_ok_mask_L1 ) {
+          failed_mask = (~supply_bitset) & supply_ok_mask_L1;
+#ifdef DEBUG
+          printfail(failed_mask, supply_ok_mask_L1, supply_bitset);
+#endif // DEBUG
+          errbuffer_power_fail(failed_mask);
+          disable_ps();
+          power_supply_alarm = true;
+          nextState = POWER_FAILURE;
+        }
+        else {
+          turn_on_ps_at_prio(vu_enable,ku_enable,2);
+          nextState = POWER_L2ON;
+        }
+
+        break;
+      }
+      case POWER_L2ON: {
+        if ( (supply_bitset & supply_ok_mask_L2)  != supply_ok_mask_L2 ) {
+          failed_mask = (~supply_bitset) & supply_ok_mask_L2;
+#ifdef DEBUG
+          printfail(failed_mask, supply_ok_mask_L2, supply_bitset);
+#endif // DEBUG
+          errbuffer_power_fail(failed_mask);
+          disable_ps();
+          power_supply_alarm = true;
+          nextState = POWER_FAILURE;
+        }
+        else {
+          turn_on_ps_at_prio(vu_enable, ku_enable, 3);
+          nextState = POWER_L3ON;
+        }
+
+        break;
+      }
+      case POWER_L3ON: {
+        // NO ENABLES AT L3. We always go to L4.
+        turn_on_ps_at_prio(vu_enable, ku_enable, 4);
+        nextState = POWER_L4ON;
+
+        break;
+      }
+      case POWER_L4ON: {
+        if ( (supply_bitset & supply_ok_mask_L4)  != supply_ok_mask_L4 ) {
+          failed_mask = (~supply_bitset) & supply_ok_mask_L4;
+#ifdef DEBUG
+          printfail(failed_mask, supply_ok_mask_L4, supply_bitset);
+#endif // DEBUG
+          errbuffer_power_fail(failed_mask);
+
+          disable_ps();
+          power_supply_alarm = true;
+          nextState = POWER_FAILURE;
+        }
+        else {
+          turn_on_ps_at_prio(vu_enable,ku_enable,5);
+          nextState = POWER_L5ON;
+        }
+
+        break;
+      }
+      case POWER_L5ON: {
+        if ( (supply_bitset & supply_ok_mask_L5)  != supply_ok_mask_L5 ) {
+          failed_mask = (~supply_bitset) & supply_ok_mask_L5;
+#ifdef DEBUG
+          printfail(failed_mask, supply_ok_mask_L5, supply_bitset);
+#endif // DEBUG
+          errbuffer_power_fail(failed_mask);
+
+          disable_ps();
+          power_supply_alarm = true;
+          nextState = POWER_FAILURE;
+        }
+        else {
+          blade_power_ok(true);
+          nextState = POWER_ON;
+        }
+
         break;
       }
       case POWER_FAILURE: { // we go through POWER_OFF state before turning on.
@@ -286,12 +374,14 @@ void PowerSupplyTask(void *parameters)
         }
       }
     }
+#ifdef DEBUG
     if (currentState != nextState) {
       char tmp[64];
-      snprintf(tmp, 64, "PowerSupplyTask: change from state %d to %d\r\n",
-               currentState, nextState);
+      snprintf(tmp, 64, "PowerSupplyTask: change from state %s to %s\r\n",
+               power_system_state_names[currentState], power_system_state_names[nextState]);
       Print(tmp);
     }
+#endif
     currentState = nextState;
 
     // wait here for the x msec, where x is 2nd argument below.

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -101,10 +101,17 @@ void PowerSupplyTask(void *parameters)
   #endif // APOLLO10_HACK
 
   // configure the LGA80D supplies
-  LGA80D_init();
+  char tmp[64];
+  snprintf(tmp, 64, "tick before: %d\r\n", pdTICKS_TO_MS( xTaskGetTickCount()));
+  Print(tmp);
+  //LGA80D_init();
+  vTaskDelay(pdMS_TO_TICKS(640));
+  snprintf(tmp, 64, "tick after: %d\r\n", pdTICKS_TO_MS(xTaskGetTickCount()));
+  Print(tmp);
   // waiting less than this amount of time appears to cause
   // the power-on sequence to fail. 
   vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(325));
+  //vTaskDelay(pdMS_TO_TICKS(1000));
 
   bool power_supply_alarm = false;
   uint16_t failed_mask = 0x0U;

--- a/projects/cm_mcu/README.md
+++ b/projects/cm_mcu/README.md
@@ -31,11 +31,6 @@ POW		2		<1%
 
 
 ## Next steps
-* Extend I2C to other I2C controllers
-* I2C monitoring task. Define what to store in a local memory
-* I2C slave for access from Zynq
-* PMBus implementation
-* digitize and store ADC voltages for access via CON and I2C
 
 ### Possible future extensions
 * Explore FreeRTOS-MPU for more robust OS (uses Cortex-M4 MPU facility)

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -60,6 +60,7 @@ void PowerSupplyTask(void *parameters);
 extern QueueHandle_t xPwrQueue;
 enum power_system_state { POWER_INIT, POWER_ON, POWER_OFF, POWER_FAILURE };
 enum power_system_state getPowerControlState();
+void LGA80D_init(void);
 
 
 // --- Semi-generic PMBUS based I2C task

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -58,8 +58,20 @@ void LedTask(void *parameters);
 // --- Power Supply management task
 void PowerSupplyTask(void *parameters);
 extern QueueHandle_t xPwrQueue;
-enum power_system_state { POWER_INIT, POWER_ON, POWER_OFF, POWER_FAILURE };
+//enum power_system_state { POWER_INIT, POWER_ON, POWER_OFF, POWER_FAILURE };
+enum power_system_state {
+  POWER_FAILURE,
+  POWER_INIT,
+  POWER_OFF,
+  POWER_L1ON,
+  POWER_L2ON,
+  POWER_L3ON,
+  POWER_L4ON,
+  POWER_L5ON,
+  POWER_ON,
+};
 enum power_system_state getPowerControlState();
+const char* getPowerControlStateName(enum power_system_state);
 void LGA80D_init(void);
 
 

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -228,8 +228,8 @@ int main( void )
 
   // mutex for the UART output
   xUARTMutex = xSemaphoreCreateMutex();
-  xMonSem    = xSemaphoreCreateMutex();
-
+  // mutex for I2C controller for the power supplies
+  dcdc_args.xSem = xSemaphoreCreateMutex();
 
   //  Create the stream buffers that sends data from the interrupt to the
   //  task, and create the task.

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -300,6 +300,9 @@ int main( void )
   Print("Staring Apollo CM MCU firmware " FIRMWARE_VERSION
         "\r\n\t\t (FreeRTOS scheduler about to start)\r\n");
   Print("Built on " __TIME__", " __DATE__ "\r\n");
+#ifdef ECN001
+  Print("Includes ECN001 code mods\r\n");
+#endif // ECN001
   Print("----------------------------\r\n");
 
   errbuffer_init(EBUF_MINBLK,EBUF_MAXBLK);


### PR DESCRIPTION
This change requires ECN001 and ECN002 (though strictly only ECN001). It initializes the LGA80D as recommended by the vendor. 