### PR TITLE
Minor cleanups 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,8 @@
 ---
 Checks: -*,
+  ,cppcoreguidelines-*,
+  ,-cppcoreguidelines-avoid-magic-numbers,
+  ,cppcoreguidelines-pro-bounds-constant-array-index,
   ,boost-use-to-string,
   ,misc-string-compare,
   ,misc-uniqueptr-reset-release,

--- a/common/power_ctl.c
+++ b/common/power_ctl.c
@@ -68,7 +68,7 @@ struct gpio_pin_t oks[] = {
     { V_MGTY2_AVTT_OK, 5}
 };
 // clang-format on
-const int num_priorities = 5;
+#define PS_NUM_PRIORITIES 5
 
 // static enum ps_state new_states[N_PS_OKS] = { PWR_UNKNOWN };
 #ifdef NOTDEF
@@ -298,7 +298,7 @@ bool disable_ps(void)
   vTaskDelay(pdMS_TO_TICKS(500));
 
   // disable in reverse order
-  for (int prio = num_priorities; prio > 0; --prio) {
+  for (int prio = PS_NUM_PRIORITIES; prio > 0; --prio) {
     // disable the supplies at the relevant priority
     for (int e = 0; e < N_PS_ENABLES; ++e) {
       if (enables[e].priority == prio) {
@@ -346,7 +346,7 @@ bool turn_on_ps(uint16_t ps_en_mask)
   }
 
   // loop over the enables
-  for (int prio = 1; prio <= num_priorities; ++prio) {
+  for (int prio = 1; prio <= PS_NUM_PRIORITIES; ++prio) {
     // enable the supplies at the relevant priority
     for (int e = 0; e < N_PS_ENABLES; ++e) {
       if (enables[e].priority == prio) {

--- a/common/utils.c
+++ b/common/utils.c
@@ -112,17 +112,18 @@ uint8_t toggle_gpio_pin(int pin)
 }
 
 // Set up all the active low pins to be off (i.e., high)
+static const int pins[] = {
+    _FPGA_I2C_RESET,     //
+    _PWR_I2C_RESET,      //
+    _CLOCKS_I2C_RESET,   //
+    _V_OPTICS_I2C_RESET, //
+    _K_OPTICS_I2C_RESET, //
+};
+#define NPINS (sizeof(pins) / pins[0])
+
 void setupActiveLowPins(void)
 {
-  const int pins[] = {
-      _FPGA_I2C_RESET,     //
-      _PWR_I2C_RESET,      //
-      _CLOCKS_I2C_RESET,   //
-      _V_OPTICS_I2C_RESET, //
-      _K_OPTICS_I2C_RESET, //
-  };
-  const int8_t npins = sizeof(pins) / pins[0];
-  for (int8_t i = 0; i < npins; ++i) {
+  for (int8_t i = 0; i < NPINS; ++i) {
     write_gpio_pin(pins[i], 0x1);
   }
 }

--- a/projects/boot_loader/bl_startup_gcc.S
+++ b/projects/boot_loader/bl_startup_gcc.S
@@ -640,6 +640,22 @@ Delay:
     bx      lr
 
 //*****************************************************************************
+// Updated loop: turn on RED LED before going into an infinite loop
+// address of GPIO pin data register for the RED LED 
+// we use address bits a[9:2] to mask which bits are written (here only bit position 1)
+// see TM4C1290NCPDT data sheet section 10.3.1.2 "Data Register Operation" 
+//*****************************************************************************
+#define RED_LED_GPIO_WHICH_BIT 0x2 // (0x1<<1) // pin 1 
+#define GPIO_PORTP_DATA_BITS_R 0x40065000
+#define RED_LED_GPIO_DATA_BITS (GPIO_PORTP_DATA_BITS_R | (RED_LED_GPIO_WHICH_BIT<<2))
+    .thumb_func
+IntDefHandler2:
+    ldr r4, =RED_LED_GPIO_DATA_BITS // register address 
+    ldr r5, =RED_LED_GPIO_WHICH_BIT // which bit to turn on 
+    str r5, [r4] // toggle bit on
+    b       . // loop forever 
+
+//*****************************************************************************
 //
 // This is the end of the file.
 //

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -103,14 +103,15 @@ static BaseType_t i2c_ctl_set_dev(int argc, char **argv)
   return pdFALSE;
 }
 
+#define I2C_CTL_MAX_BYTES 4
+
 static BaseType_t i2c_ctl_r(int argc, char **argv)
 {
   int s = SCRATCH_SIZE;
   BaseType_t address, nbytes;
   address = strtol(argv[1], NULL, 16);
   nbytes = strtol(argv[2], NULL, 10);
-  const int MAX_BYTES = 4;
-  uint8_t data[MAX_BYTES];
+  uint8_t data[I2C_CTL_MAX_BYTES];
 
   int status = apollo_i2c_ctl_r(address, nbytes, data);
   if (status == 0) {
@@ -135,8 +136,7 @@ static BaseType_t i2c_ctl_reg_r(int argc, char **argv)
   address = strtol(argv[1], NULL, 16);
   reg_address = strtol(argv[2], NULL, 16);
   nbytes = strtol(argv[3], NULL, 10);
-  const int MAX_BYTES = 4;
-  uint8_t data[MAX_BYTES];
+  uint8_t data[I2C_CTL_MAX_BYTES];
   uint8_t txdata = reg_address;
 
   int status = apollo_i2c_ctl_reg_r(address, txdata, nbytes, data);
@@ -1128,19 +1128,18 @@ static BaseType_t errbuff_in(int argc, char **argv)
 
   return pdFALSE;
 }
-
+#define EBUFFOUT_MAX_ENTRIES 64
 static BaseType_t errbuff_out(int argc, char **argv)
 {
   int copied = 0;
 
-  const uint8_t max_entries = 64;
   uint32_t num = strtoul(argv[1], NULL, 10);
-  if (num > max_entries) {
+  if (num > EBUFFOUT_MAX_ENTRIES) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please enter a number 64 or less \r\n");
     return pdFALSE;
   }
-  uint32_t arr[max_entries];
-  uint32_t(*arrptr)[max_entries] = &arr;
+  uint32_t arr[EBUFFOUT_MAX_ENTRIES];
+  uint32_t(*arrptr)[EBUFFOUT_MAX_ENTRIES] = &arr;
   errbuffer_get(num, arrptr);
 
   static int i = 0;

--- a/projects/cm_mcu/FireFlyTask.c
+++ b/projects/cm_mcu/FireFlyTask.c
@@ -207,7 +207,7 @@ static int read_ff_register(const char *name, uint8_t reg_addr, uint16_t *value,
   data[0] = 0x1U << ff_i2c_addrs[ff].mux_bit;
   tSMBusStatus r = SMBusMasterI2CWrite(smbus, ff_i2c_addrs[ff].mux_addr, data, 1);
   if (r != SMBUS_OK) {
-    Print("write_ff_reg: I2CBus command failed  (setting mux)\r\n");
+    Print("read_ff_reg: I2CBus command failed  (setting mux)\r\n");
     return 1;
   }
   while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
@@ -224,15 +224,15 @@ static int read_ff_register(const char *name, uint8_t reg_addr, uint16_t *value,
   // increment size to account for the register address
   r = SMBusMasterI2CWriteRead(smbus, ff_i2c_addrs[ff].dev_addr, &reg_addr, 1, data, size);
   if (r != SMBUS_OK) {
-    Print("write_ff_reg: I2CBus command failed  (FF register)\r\n");
+    Print("write_ff_reg: I2CBus command failed (FF register)\r\n");
     return 1;
   }
   while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
     vTaskDelay(pdMS_TO_TICKS(10)); // wait
   }
   if (*p_status != SMBUS_OK) {
-    char tmp[64];
-    snprintf(tmp, 64, "%s: FF writing error %d  (ff=%s) ...\r\n", __func__, *p_status,
+    char tmp[128];
+    snprintf(tmp, 64, "%s: FF WriteRead error %d  (ff=%s) ...\r\n", __func__, *p_status,
              ff_i2c_addrs[ff].name);
     Print(tmp);
     return 1;
@@ -318,7 +318,7 @@ static int write_ff_register(const char *name, uint8_t reg, uint16_t value, int 
 //     ECU0_25G_XVCR_CDR_REG,
 // };
 
-static int disable_transmit(bool disable, int num_ff) // todo: actually test this
+static int disable_transmit(bool disable, int num_ff) 
 {
   int ret = 0, i = num_ff, imax = num_ff + 1;
   // i and imax are used as limits for the loop below. By default, only iterate once, with i=num_ff.
@@ -366,7 +366,7 @@ static int disable_receivers(bool disable, int num_ff)
   return ret;
 }
 
-static int set_xcvr_cdr(uint8_t value, int num_ff) // todo: actually test this
+static int set_xcvr_cdr(uint8_t value, int num_ff) 
 {
   int ret = 0, i = num_ff, imax = num_ff + 1;
   // i and imax are used as limits for the loop below. By default, only iterate once, with i=num_ff.

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -171,8 +171,8 @@ header file. */
 #define configCOMMAND_INT_MAX_OUTPUT_SIZE 1
 
 // non-standard, park this here for now
-#define CLI_UART UART4_BASE // Front panel
-//#define CLI_UART UART1_BASE // Zynq
+//#define CLI_UART UART4_BASE // Front panel
+#define CLI_UART UART1_BASE // Zynq
 
 #define SYSTEM_STACK_SIZE 128
 #define I2C_PULLUP_BUG

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -158,6 +158,7 @@ header file. */
 #else
 #define APOLLO_ASSERT(exp)                                                                         \
   if (!(exp)) {                                                                                    \
+    taskDISABLE_INTERRUPTS();                                                                      \
     APOLLO_ASSERT_RECORD();                                                                        \
     ROM_SysCtlReset();                                                                             \
   }

--- a/projects/cm_mcu/startup_gcc.c
+++ b/projects/cm_mcu/startup_gcc.c
@@ -292,7 +292,8 @@ static void NmiSR(void)
 //
 // This is the code that gets called when the processor receives a fault
 // interrupt.  This simply enters an infinite loop, preserving the system state
-// for examination by a debugger.
+// for examination by a debugger, except in production code, where it just 
+// invokes a restart.
 //
 //*****************************************************************************
 static void


### PR DESCRIPTION
Minor code cleanups, including

- comment clarification
- change default UART to Zynq from front panel
- new default interrupt handler for boot loader which turns on red LED (not currently enabled)