### PR TITLE
Cltask cleanup

### DIFF
--- a/common/power_ctl.c
+++ b/common/power_ctl.c
@@ -28,6 +28,12 @@ void Print(const char *); // needs to be implemented in each project
 
 // clang-format off
 // if you update this you need to update N_PS_ENABLES
+#ifndef REV2
+// ------------------------------------------
+//
+// REV 1 
+//
+// ------------------------------------------
 static const struct gpio_pin_t enables[] = {
     {  CTRL_K_VCCINT_PWR_EN, 1},
     {  CTRL_V_VCCINT_PWR_EN, 1},
@@ -67,19 +73,18 @@ struct gpio_pin_t oks[] = {
     { V_MGTY1_AVTT_OK, 5},
     { V_MGTY2_AVTT_OK, 5}
 };
+#else // REV2
+// ------------------------------------------
+//
+// REV 2
+//
+// ------------------------------------------
+// add here
+#error "Missing power control definitions for Rev 2"
+#endif // REV2 
+
 // clang-format on
 #define PS_NUM_PRIORITIES 5
-
-// static enum ps_state new_states[N_PS_OKS] = { PWR_UNKNOWN };
-#ifdef NOTDEF
-// this variable holds the current lowest enabled power supply
-static int lowest_enabled_ps_prio = 0;
-
-int getLowestEnabledPSPriority()
-{
-  return lowest_enabled_ps_prio;
-}
-#endif // 0
 
 // these arrays hold the current and old status of these power supplies
 static enum ps_state states[N_PS_OKS] = {PWR_UNKNOWN};
@@ -96,190 +101,7 @@ void setPSStatus(int i, enum ps_state theState)
     return;
   states[i] = theState;
 }
-#ifdef NOTDEF
-bool update_failed_ps(int prio)
-{
 
-  bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-  bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
-  bool failure = false;
-
-  for (int o = 0; o < N_PS_OKS; ++o) {
-    if (oks[o].priority <= prio) {
-      int8_t val = read_gpio_pin(oks[o].name);
-      if (val == 0) {
-        // if this is a VU7P supply and dip switch says ignore it, continue
-        if (!vu_enable && (strncmp(pin_names[oks[o].name], "V_", 2) == 0)) {
-          new_states[o] = PWR_DISABLED;
-          continue;
-        }
-        // ditto for KU15P
-        if (!ku_enable && (strncmp(pin_names[oks[o].name], "K_", 2) == 0)) {
-          new_states[o] = PWR_DISABLED;
-          continue;
-        }
-        // remember the VCC_ supplies
-        if ((states[o] == PWR_ON) || (states[o] == PWR_UNKNOWN)) {
-          new_states[o] = PWR_FAILED;
-          errbuffer_put(EBUF_PWR_FAILURE, o);
-          failure = true;
-        }
-        else {
-          new_states[o] = PWR_OFF;
-        }
-      }
-      else {
-        new_states[o] = PWR_ON;
-      }
-    }
-  }
-  memcpy(states, new_states, sizeof(states));
-  return failure;
-}
-#endif // 0
-#ifdef NOTDEF
-//
-// check the power supplies and turn them on one by one
-// Assert BLADE_POWER_OK if you are successful.
-// Return immediately if BLADE_POWER_EN is not asserted by the SM.
-bool set_ps()
-{
-  // read two dip switches to see if we are powering either or both FPGAs
-  bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-  bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
-
-  // if blade_power_en is false, return with failure
-  bool blade_power_en = (read_gpio_pin(BLADE_POWER_EN) == 1);
-  if (!blade_power_en) {
-    write_gpio_pin(BLADE_POWER_OK, 0x0);
-    return false;
-  }
-
-  // loop over the enables
-  for (int prio = 1; prio <= num_priorities; ++prio) {
-    // enable the supplies at the relevant priority
-    // lowest_enabled_ps_prio = prio;
-    for (int e = 0; e < N_PS_ENABLES; ++e) {
-      if (enables[e].priority == prio) {
-        // if the supply is for VU7P and dip switch says ignore it, continue
-        if (!vu_enable && (strncmp(pin_names[enables[e].name], "CTRL_V_", 7) == 0))
-          continue;
-        // ditto for KU15P
-        if (!ku_enable && (strncmp(pin_names[enables[e].name], "CTRL_K_", 7) == 0))
-          continue;
-        // remember that there are some VCC_ supplies too!
-        write_gpio_pin(enables[e].name, 0x1);
-      }
-    }
-
-    ShortDelay();
-
-    // check power good at this level or higher priority (lower number)
-    // bool ps_failure = update_failed_ps(prio);
-
-    // loop over 'ok' bits
-    if (ps_failure) {
-
-      Print("turn_on_ps: Power supply check failed. ");
-      Print("Turning off all supplies at this level or lower.\r\n");
-      // turn off all supplies at current priority level or lower
-      // that is probably overkill since they should not all be
-      // lowest_enabled_ps_prio = oks[o].priority - 1;
-      for (int e = 0; e < N_PS_ENABLES; ++e) {
-        if (enables[e].priority >= prio)
-          write_gpio_pin(enables[e].name, 0x0);
-      }
-      for (int o = 0; o < N_PS_OKS; ++o) {
-        if (states[o] == PWR_DISABLED)
-          continue;
-        if (oks[o].priority >= prio) {
-          states[o] = PWR_OFF;
-        }
-      }
-      // turn off the state variable too
-      success = false;
-      break;
-    }
-  } // loop over priorities
-  write_gpio_pin(BLADE_POWER_OK, 0x1);
-  return true;
-}
-
-// check_ps(Void)
-// in this function we check the status of the supplies. The function returns
-// true if all supplies it expects to be good, are good. That means that if one
-// supply is disabled then it will not check it and return 'good' even if the
-// supply is not good (in fact it will not be checked.)
-//
-// BLADE_POWER_OK will be asserted if this function returns successfully
-bool check_ps(void)
-{
-
-  bool success = true;
-
-  bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-  bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
-
-  // first check all the GPIO pins for various status bits
-  for (int o = 0; o < N_PS_OKS; ++o) {
-    // if this is a VU7P supply and dip switch says ignore it, continue
-    if (!vu_enable && (strncmp(pin_names[oks[o].name], "V_", 2) == 0)) {
-      new_states[o] = PWR_DISABLED;
-      continue;
-    }
-    // ditto for KU15P
-    else if (!ku_enable && (strncmp(pin_names[oks[o].name], "K_", 2) == 0)) {
-      new_states[o] = PWR_DISABLED;
-      continue;
-    }
-    else {
-      int8_t val = read_gpio_pin(oks[o].name);
-      if (val == 0) {
-        new_states[o] = PWR_OFF;
-        success = false;
-      }
-      else {
-        new_states[o] = PWR_ON;
-      }
-    }
-  } // loop over N_PS_OKS
-
-  // find out if any of the failures are new failures or not
-  for (int o = 0; o < N_PS_OKS; ++o) {
-    if ((new_states[o] != states[o]) && (states[o] != PWR_UNKNOWN) && (states[o] != PWR_DISABLED)) {
-      errbuffer_put(EBUF_PWR_FAILURE, o);
-      char tmp[128];
-      snprintf(tmp, 128, "check_ps: New failed supply %s (level %d)\r\n", pin_names[oks[o].name],
-               oks[o].priority);
-      Print(tmp);
-    }
-    states[o] = new_states[o];
-  }
-
-  // now find the lowest priority pin that is off
-  int min_good_prio = 99;
-  for (int o = 0; o < N_PS_OKS; ++o) {
-    if (states[o] == PWR_OFF) {
-      if (oks[o].priority < min_good_prio)
-        min_good_prio = oks[o].priority;
-    }
-  }
-  if (!success) {
-    // turn off all supplies at current priority level or lower
-    for (int e = 0; e < N_PS_ENABLES; ++e) {
-      if (enables[e].priority > min_good_prio) {
-        write_gpio_pin(enables[e].name, 0x0);
-      }
-    }
-  } // loop over priorities
-  if (success)
-    write_gpio_pin(BLADE_POWER_OK, 0x1);
-  else
-    write_gpio_pin(BLADE_POWER_OK, 0x0);
-
-  return success;
-}
-#endif // NOTDEF
 // turn off all power supplies in the proper order
 // de-assert BLADE_POWER_OK on successful exit.
 bool disable_ps(void)
@@ -363,7 +185,7 @@ bool turn_on_ps(uint16_t ps_en_mask)
 }
 
 // Enable supply at some priority. Also send in vu and ku enable.
-void turn_on_ps_at_prio(bool vu_enable, bool ku_enable, int prio)
+void turn_on_ps_at_prio(bool f2_enable, bool f1_enable, int prio)
 {
   // loop over the enables
   for (int e = 0; e < N_PS_ENABLES; ++e) {
@@ -377,8 +199,8 @@ void turn_on_ps_at_prio(bool vu_enable, bool ku_enable, int prio)
       // or it's a VU supply and the enable is set, or it's a KU supply
       // and the enable is set.
       bool enableSupply = (currmask & PS_ENS_GEN_MASK) ||               // general
-                          ((currmask & PS_ENS_VU_MASK) && vu_enable) || // vu
-                          ((currmask & PS_ENS_KU_MASK) && ku_enable);   // ku
+                          ((currmask & PS_ENS_F2_MASK) && f2_enable) || // f2
+                          ((currmask & PS_ENS_F1_MASK) && f1_enable);   // f1
       if (enableSupply) {
         write_gpio_pin(enables[e].name, 0x1);
       }

--- a/common/power_ctl.h
+++ b/common/power_ctl.h
@@ -34,8 +34,14 @@
 enum ps_state { PWR_UNKNOWN, PWR_ON, PWR_OFF, PWR_DISABLED, PWR_FAILED };
 enum ps_state getPSStatus(int i);
 void setPSStatus(int i, enum ps_state theState);
-int getLowestEnabledPSPriority();
+//int getLowestEnabledPSPriority();
 
+#ifndef REV2 
+// -----------------------------------------------------
+//
+// Rev 1
+//
+// -----------------------------------------------------
 // Number of enable and power good/OK pins
 #define N_PS_ENABLES 16
 #define N_PS_OKS     14
@@ -43,30 +49,40 @@ int getLowestEnabledPSPriority();
 // bits, for the pins defined in the enables[]
 // and oks[] arrays.
 #define PS_OKS_MASK     ((1U << N_PS_OKS) - 1)
-#define PS_OKS_KU_MASK  0x0F03U
-#define PS_OKS_VU_MASK  0x30CCU
+#define PS_OKS_F1_MASK  0x0F03U
+#define PS_OKS_F2_MASK  0x30CCU
 #define PS_OKS_GEN_MASK 0x0030U
 #define PS_ENS_MASK     ((1U << N_PS_ENABLES) - 1)
 #define PS_ENS_GEN_MASK 0x000CU
-#define PS_ENS_VU_MASK  0xC332U
-#define PS_ENS_KU_MASK  0x3CC1U
+#define PS_ENS_F2_MASK  0xC332U
+#define PS_ENS_F1_MASK  0x3CC1U
 
 // OK masks for various stages of the turn-on.
 // these are indices into the oks[] array
 // L1-L5, note NO L3!!! no PG on the L3 supplies
-#define PS_OKS_KU_MASK_L1 0x0003U
-#define PS_OKS_KU_MASK_L2 0x0030U // these are common to VU and KU
-#define PS_OKS_KU_MASK_L4 0x0300U
-#define PS_OKS_KU_MASK_L5 0x0C00U
-#define PS_OKS_VU_MASK_L1 0x000CU
-#define PS_OKS_VU_MASK_L2 PS_OKS_KU_MASK_L2
-#define PS_OKS_VU_MASK_L4 0x00C0U
-#define PS_OKS_VU_MASK_L5 0x3000U
+#define PS_OKS_F1_MASK_L1 0x0003U
+#define PS_OKS_F1_MASK_L2 0x0030U // these are common to VU and KU
+#define PS_OKS_F1_MASK_L4 0x0300U
+#define PS_OKS_F1_MASK_L5 0x0C00U
+#define PS_OKS_F2_MASK_L1 0x000CU
+#define PS_OKS_F2_MASK_L2 PS_OKS_F1_MASK_L2
+#define PS_OKS_F2_MASK_L4 0x00C0U
+#define PS_OKS_F2_MASK_L5 0x3000U
+
+#else // Rev 2
+// -----------------------------------------------------
+//
+// Rev 2
+//
+// -----------------------------------------------------
+// to be added here 
+#error "Missing Rev 2 PS masks"
+#endif // REV 2 
 
 bool turn_on_ps(uint16_t);
 bool check_ps(void);
 bool disable_ps(void);
-void turn_on_ps_at_prio(bool vu_enable, bool ku_enable, int prio);
+void turn_on_ps_at_prio(bool f2_enable, bool f1_enable, int prio);
 void blade_power_ok(bool isok);
 
 #endif /* COMMON_POWER_CTL_H_ */

--- a/projects/cm_mcu/ADCMonitorTask.c
+++ b/projects/cm_mcu/ADCMonitorTask.c
@@ -57,6 +57,13 @@ struct ADC_Info_t {
 #define ADCs_ADC0_ENTRIES           8
 #define ADCs_ADC0_FIRST_SEQ_LENGTH  4
 #define ADCs_ADC0_SECOND_SEQ_LENGTH 4
+
+// -------------------------------------------------
+//
+// REV 1
+//
+// -------------------------------------------------
+
 // This array holds the list of ADCs with the AIN channels on the TM4C1290NCPDT
 // on Apollo CM v1, and whatever scaling is needed to get the value correct.
 // We also read out the internal temperature sensor, which has a special
@@ -87,6 +94,13 @@ struct ADC_Info_t ADCs[] = {
     {ADC_CTL_TS,   "TM4C_TEMP", 1.f, 0.f}, // this one is special, temp in C
 };
 // clang-format on
+
+// -------------------------------------------------
+//
+// REV 2
+//
+// -------------------------------------------------
+// To be added here 
 
 static __fp16 fADCvalues[ADC_CHANNEL_COUNT]; // ADC values in volts
 

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -5,498 +5,17 @@
  *      Author: wittich, rzou
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include "inc/hw_types.h"
-#include "inc/hw_memmap.h"
-#include "inc/hw_nvic.h"
-#include "driverlib/rom.h"
-#include "driverlib/rom_map.h"
-#include "driverlib/systick.h"
-#include "driverlib/sysctl.h"
-#include "driverlib/eeprom.h"
+// Include commands
+#include "commands/BoardCommands.h"
+#include "commands/BufferCommands.h"
+#include "commands/EEPROMCommands.h"
+#include "commands/I2CCommands.h"
+#include "commands/SensorControl.h"
 
-// local includes
-#include "common/i2c_reg.h"
-#include "common/uart.h"
-#include "common/power_ctl.h"
-#include "common/pinsel.h"
-#include "common/smbus.h"
-#include "common/utils.h"
-#include "common/microrl.h"
-
-// FreeRTOS includes
-#include "FreeRTOSConfig.h"
-#include "FreeRTOS.h"
-#include "stream_buffer.h"
-#include "queue.h"
-
-// strlen, strtol, and strncpy
-#include <string.h>
-#include <stdlib.h>
-
-// TivaWare includes
-#include "driverlib/uart.h"
-
-#include "MonitorTask.h"
-#include "CommandLineTask.h"
-#include "I2CCommunication.h"
-#include "Tasks.h"
-#include "AlarmUtilities.h"
-
-#include "clocksynth.h"
-
-#ifdef DEBUG_CON
-// prototype of mutex'd print
-#define DPRINT(x) Print(x)
-#else // DEBUG_CON
-#define DPRINT(x)
-#endif // DEBUG_CON
-
-void Print(const char *str);
-
-// local sprintf prototype
-int snprintf(char *buf, unsigned int count, const char *format, ...);
-
-#define MAX_INPUT_LENGTH  50
-#define MAX_OUTPUT_LENGTH 512
-
-extern tSMBus g_sMaster1;
-extern tSMBusStatus eStatus1;
-extern tSMBus g_sMaster2;
-extern tSMBusStatus eStatus2;
-extern tSMBus g_sMaster3;
-extern tSMBusStatus eStatus3;
-extern tSMBus g_sMaster4;
-extern tSMBusStatus eStatus4;
-extern tSMBus g_sMaster6;
-extern tSMBusStatus eStatus6;
-static tSMBus *p_sMaster = &g_sMaster4;
-static tSMBusStatus *p_eStatus = &eStatus4;
-
-#define SCRATCH_SIZE 512
 static char m[SCRATCH_SIZE];
 
-// Ugly hack for now -- I don't understand how to reconcile these
-// two parts of the FreeRTOS-Plus code w/o casts-o-plenty
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat" // because of our mini-sprintf
-
-static BaseType_t i2c_ctl_set_dev(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  BaseType_t i = strtol(argv[1], NULL, 10); // device number
-
-  int status = apollo_i2c_ctl_set_dev(i);
-  if (status == 0) {
-    snprintf(m, s, "Setting i2c device to %d\r\n", i);
-  }
-  else if (status == -1) {
-    snprintf(m, s, "Invalid i2c device %d (%s), only 1,2,3, 4 and 6 supported\r\n", i, argv[1]);
-  }
-  else if (status == -2) {
-    snprintf(m, s, "%s: huh? line %d\r\n", argv[0], __LINE__);
-  }
-  else {
-    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
-  }
-  return pdFALSE;
-}
-
-#define I2C_CTL_MAX_BYTES 4
-
-static BaseType_t i2c_ctl_r(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  BaseType_t address, nbytes;
-  address = strtol(argv[1], NULL, 16);
-  nbytes = strtol(argv[2], NULL, 10);
-  uint8_t data[I2C_CTL_MAX_BYTES];
-
-  int status = apollo_i2c_ctl_r(address, nbytes, data);
-  if (status == 0) {
-    snprintf(m, s, "%s: add: 0x%02x: value 0x%02x %02x %02x %02x\r\n", argv[0], address, data[3],
-             data[2], data[1], data[0]);
-  }
-  else if (status == -1) {
-    snprintf(m, s, "%s: operation failed (1)\r\n", argv[0]);
-  }
-  else if (status == -2) {
-    snprintf(m, s, "%s: operation failed (2, value=%d)\r\n", argv[0], *p_eStatus);
-  }
-  else {
-    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
-  }
-  return pdFALSE;
-}
-static BaseType_t i2c_ctl_reg_r(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  BaseType_t address, reg_address, nbytes;
-  address = strtol(argv[1], NULL, 16);
-  reg_address = strtol(argv[2], NULL, 16);
-  nbytes = strtol(argv[3], NULL, 10);
-  uint8_t data[I2C_CTL_MAX_BYTES];
-  uint8_t txdata = reg_address;
-
-  int status = apollo_i2c_ctl_reg_r(address, txdata, nbytes, data);
-  if (status == 0) {
-    snprintf(m, s, "i2cr: add: 0x%02x, reg 0x%02x: value 0x%02x %02x %02x %02x\r\n", address,
-             reg_address, data[3], data[2], data[1], data[0]);
-  }
-  else if (status == -1) {
-    snprintf(m, s, "%s: operation failed (1)\r\n", argv[0]);
-  }
-  else if (status == -2) {
-    snprintf(m, s, "%s: operation failed (2, value=%d)\r\n", argv[0], *p_eStatus);
-  }
-  else {
-    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
-  }
-  return pdFALSE;
-}
-
-static BaseType_t i2c_ctl_reg_w(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  // first byte is the register, others are the data
-  BaseType_t address, reg_address, nbytes, packed_data;
-  address = strtol(argv[1], NULL, 16);     // address
-  reg_address = strtol(argv[2], NULL, 16); // register
-  nbytes = strtol(argv[3], NULL, 16);      // number of bytes
-  packed_data = strtol(argv[4], NULL, 16); // data
-
-  int status = apollo_i2c_ctl_reg_w(address, reg_address, nbytes, packed_data);
-  if (status == 0) {
-    snprintf(m, s, "%s: Wrote to address 0x%x, register 0x%x, value 0x%08x (%d bytes)\r\n", argv[0],
-             address, reg_address, packed_data, nbytes - 1);
-  }
-  else if (status == -1) {
-    snprintf(m, s, "%s: operation failed (1)\r\n", argv[0]);
-  }
-  else if (status == -2) {
-    snprintf(m, s, "%s: operation failed (2)\r\n", argv[0]);
-  }
-  else {
-    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
-  }
-
-  return pdFALSE;
-}
-
-static BaseType_t i2c_ctl_w(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  BaseType_t address, nbytes, value;
-  address = strtol(argv[1], NULL, 16);
-  nbytes = strtol(argv[2], NULL, 16);
-  value = strtol(argv[3], NULL, 16);
-
-  int status = apollo_i2c_ctl_w(address, nbytes, value);
-  if (status == 0) {
-    snprintf(m, s, "i2cwr: Wrote to address 0x%x, value 0x%08x (%d bytes)\r\n", address, value,
-             nbytes);
-  }
-  else if (status == -1) {
-    snprintf(m, s, "%s: write failed (1)\r\n", argv[0]);
-  }
-  else if (status == -2) {
-    snprintf(m, s, "%s: write failed (2)\r\n", argv[0]);
-  }
-  else {
-    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
-  }
-  return pdFALSE;
-}
-
-extern struct gpio_pin_t oks[];
-
-// send power control commands
-static BaseType_t power_ctl(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-
-  uint32_t message;
-  if (strncmp(argv[1], "on", 2) == 0) {
-    message = PS_ON; // turn on power supply
-  }
-  else if (strncmp(argv[1], "off", 3) == 0) {
-    message = PS_OFF; // turn off power supply
-  }
-  else if (strncmp(argv[1], "clearfail", 9) == 0) {
-    message = PS_ANYFAIL_ALARM_CLEAR;
-  }
-  else if (strncmp(argv[1], "status", 5) == 0) { // report status to UART
-    int copied = 0;
-    bool f1_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-    bool f2_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
-    static int i = 0;
-    if (i == 0) {
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                         "%s:\r\nF1_ENABLE:\t%d\r\n"
-                         "F2_ENABLE:\t%d\r\n",
-                         argv[0], f1_enable, f2_enable);
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "State machine state: %s\r\n",
-                         getPowerControlStateName(getPowerControlState()));
-    }
-    for (; i < N_PS_OKS; ++i) {
-      enum ps_state j = getPSStatus(i);
-      char *c;
-      switch (j) {
-        case PWR_UNKNOWN:
-          c = "PWR_UNKNOWN";
-          break;
-        case PWR_ON:
-          c = "PWR_ON";
-          break;
-        case PWR_OFF:
-          c = "PWR_OFF";
-          break;
-        case PWR_DISABLED:
-          c = "PWR_DISABLED";
-          break;
-        case PWR_FAILED:
-          c = "PWR_FAILED";
-          break;
-        default:
-          c = "UNKNOWN";
-          break;
-      }
-
-      copied +=
-          snprintf(m + copied, SCRATCH_SIZE - copied, "%15s: %s\r\n", pin_names[oks[i].name], c);
-      if ((SCRATCH_SIZE - copied) < 20 && (i < N_PS_OKS)) {
-        ++i;
-        return pdTRUE;
-      }
-    }
-    i = 0;
-    return pdFALSE;
-  }
-  else {
-    snprintf(m, s, "power_ctl: invalid argument %s received\r\n", argv[1]);
-    return pdFALSE;
-  }
-  // Send a message to the power supply task, if needed
-  xQueueSendToBack(xPwrQueue, &message, pdMS_TO_TICKS(10));
-  m[0] = '\0'; // no output from this command
-
-  return pdFALSE;
-}
-
-// takes 1-2 arguments
-static BaseType_t alarm_ctl(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  if (argc < 2) {
-    snprintf(m, s, "%s: need one or more arguments\r\n", argv[0]);
-    return pdFALSE;
-  }
-
-  uint32_t message;
-  if (strncmp(argv[1], "clear", 4) == 0) {
-    message = ALM_CLEAR_ALL; // clear all alarms
-    xQueueSendToBack(tempAlarmTask.xAlmQueue, &message, pdMS_TO_TICKS(10));
-    m[0] = '\0'; // no output from this command
-
-    return pdFALSE;
-  }
-  else if (strncmp(argv[1], "status", 5) == 0) { // report status to UART
-    int copied = 0;
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: ALARM status\r\n", argv[0]);
-    int32_t stat = getAlarmStatus();
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Raw: 0x%08x\r\n", stat);
-
-    float ff_val = getAlarmTemperature(FF);
-    int tens, frac;
-    float_to_ints(ff_val, &tens, &frac);
-    copied +=
-        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP FFLY: %s \t Threshold: %02d.%02d\r\n",
-                 (stat & ALM_STAT_FIREFLY_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
-
-    float fpga_val = getAlarmTemperature(FPGA);
-    float_to_ints(fpga_val, &tens, &frac);
-    copied +=
-        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP FPGA: %s \t Threshold: %02d.%02d\r\n",
-                 (stat & ALM_STAT_FPGA_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
-
-    float dcdc_val = getAlarmTemperature(DCDC);
-    float_to_ints(dcdc_val, &tens, &frac);
-    copied +=
-        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP DCDC: %s \t Threshold: %02d.%02d\r\n",
-                 (stat & ALM_STAT_DCDC_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
-
-    float tm4c_val = getAlarmTemperature(TM4C);
-    float_to_ints(tm4c_val, &tens, &frac);
-    copied +=
-        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP TM4C: %s \t Threshold: %02d.%02d\r\n",
-                 (stat & ALM_STAT_TM4C_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
-    configASSERT(copied < SCRATCH_SIZE);
-
-    return pdFALSE;
-  }
-  else if (strcmp(argv[1], "settemp") == 0) {
-    if (argc != 4) {
-      snprintf(m, s, "Invalid command\r\n");
-      return pdFALSE;
-    }
-    float newtemp = (float)strtol(argv[3], NULL, 10);
-    char *device = argv[2];
-    if (!strcmp(device, "ff")) {
-      setAlarmTemperature(FF, newtemp);
-      snprintf(m, s, "%s: set Firefly alarm temperature to %s\r\n", argv[0], argv[3]);
-      return pdFALSE;
-    }
-    if (!strcmp(device, "fpga")) {
-      setAlarmTemperature(FPGA, newtemp);
-      snprintf(m, s, "%s: set FPGA alarm temperature to %s\r\n", argv[0], argv[3]);
-      return pdFALSE;
-    }
-    if (!strcmp(device, "dcdc")) {
-      setAlarmTemperature(DCDC, newtemp);
-      snprintf(m, s, "%s: set DCDC alarm temperature to %s\r\n", argv[0], argv[3]);
-      return pdFALSE;
-    }
-    if (!strcmp(device, "tm4c")) {
-      setAlarmTemperature(TM4C, newtemp);
-      snprintf(m, s, "%s: set TM4C alarm temperature to %s\r\n", argv[0], argv[3]);
-      return pdFALSE;
-    }
-    else {
-      snprintf(m, s, "%s is not a valid device.\r\n", argv[2]);
-      return pdFALSE;
-    }
-  }
-  else {
-    snprintf(m, s, "%s: invalid argument %s received\r\n", argv[0], argv[1]);
-    return pdFALSE;
-  }
-  return pdFALSE;
-}
-
-static BaseType_t i2c_scan(int argc, char **argv)
-{
-  // takes no arguments
-  int copied = 0;
-  copied += snprintf(m, SCRATCH_SIZE - copied, "i2c bus scan\r\n");
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                     "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\r\n00:         ");
-  for (uint8_t i = 0x3; i < 0x78; ++i) {
-    uint8_t data;
-    if (i % 16 == 0)
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n%2x:", i);
-    tSMBusStatus r = SMBusMasterI2CRead(p_sMaster, i, &data, 1);
-    if (r != SMBUS_OK) {
-      Print("i2c_scan: Probe failed 1\r\n");
-    }
-    while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
-      vTaskDelay(pdMS_TO_TICKS(10)); // wait
-    }
-    if (*p_eStatus == SMBUS_OK)
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " %2x", i);
-    else
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " --");
-    configASSERT(copied < SCRATCH_SIZE);
-  }
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-  configASSERT(copied < SCRATCH_SIZE);
-
-  return pdFALSE;
-}
-
-// send LED commands
-static BaseType_t led_ctl(int argc, char **argv)
-{
-
-  BaseType_t i1 = strtol(argv[1], NULL, 10);
-  configASSERT(i1 != 99);
-
-  uint32_t message = HUH; // default: message not understood
-  if (i1 == 0) {          // ToDo: make messages less clunky. break out color.
-    message = RED_LED_OFF;
-  }
-  else if (i1 == 1) {
-    message = RED_LED_ON;
-  }
-  else if (i1 == 2) {
-    message = RED_LED_TOGGLE;
-  }
-  else if (i1 == 3) {
-    message = RED_LED_TOGGLE3;
-  }
-  else if (i1 == 4) {
-    message = RED_LED_TOGGLE4;
-  }
-  // Send a message to the LED task
-  xQueueSendToBack(xLedQueue, &message, pdMS_TO_TICKS(10));
-  m[0] = '\0'; // no output from this command
-
-  return pdFALSE;
-}
-
-// dump monitor information
-static BaseType_t psmon_ctl(int argc, char **argv)
-{
-  int s = SCRATCH_SIZE;
-  BaseType_t i1 = strtol(argv[1], NULL, 10);
-
-  if (i1 < 0 || i1 >= dcdc_args.n_commands) {
-    snprintf(m, s, "%s: Invalid argument, must be between 0 and %d\r\n", argv[0],
-             dcdc_args.n_commands - 1);
-    return pdFALSE;
-  }
-  // update times, in seconds
-  TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
-  TickType_t last = pdTICKS_TO_MS(dcdc_args.updateTick) / 1000;
-  int copied = 0;
-  if ((now - last) > 60) {
-    int mins = (now - last) / 60;
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                       "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
-  }
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s\r\n", dcdc_args.commands[i1].name);
-  for (int ps = 0; ps < dcdc_args.n_devices; ++ps) {
-    copied +=
-        snprintf(m + copied, SCRATCH_SIZE - copied, "SUPPLY %s\r\n", dcdc_args.devices[ps].name);
-    for (int page = 0; page < dcdc_args.n_pages; ++page) {
-      float val = dcdc_args.pm_values[ps * (dcdc_args.n_commands * dcdc_args.n_pages) +
-                                      page * dcdc_args.n_commands + i1];
-      int tens, frac;
-      float_to_ints(val, &tens, &frac);
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "VALUE %02d.%02d\t", tens, frac);
-    }
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-  }
-
-  return pdFALSE;
-}
-
-// this command takes no arguments
-static BaseType_t adc_ctl(int argc, char **argv)
-{
-  int copied = 0;
-
-  static int whichadc = 0;
-  if (whichadc == 0) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "ADC outputs\r\n");
-  }
-  for (; whichadc < 21; ++whichadc) {
-    float val = getADCvalue(whichadc);
-    int tens, frac;
-    float_to_ints(val, &tens, &frac);
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%14s: %02d.%02d\r\n",
-                       getADCname(whichadc), tens, frac);
-    if ((SCRATCH_SIZE - copied) < 20 && (whichadc < 20)) {
-      ++whichadc;
-      return pdTRUE;
-    }
-  }
-  whichadc = 0;
-  return pdFALSE;
-}
-
 // this command takes no arguments and never returns.
-static BaseType_t bl_ctl(int argc, char **argv)
+static BaseType_t bl_ctl(int argc, char **argv, char* m)
 {
   Print("Jumping to boot loader.\r\n");
   ROM_SysCtlDelay(100000);
@@ -532,7 +51,7 @@ static BaseType_t bl_ctl(int argc, char **argv)
 }
 
 // this command takes one argument
-static BaseType_t clock_ctl(int argc, char **argv)
+static BaseType_t clock_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
   int status = -1; // shut up clang compiler warning
@@ -566,7 +85,7 @@ static BaseType_t clock_ctl(int argc, char **argv)
 }
 
 // this command takes no arguments
-static BaseType_t ver_ctl(int argc, char **argv)
+static BaseType_t ver_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Version %s built at %s.\r\n", gitVersion(),
@@ -576,233 +95,6 @@ static BaseType_t ver_ctl(int argc, char **argv)
   return pdFALSE;
 }
 
-// this command takes up to two arguments
-static BaseType_t ff_ctl(int argc, char **argv)
-{
-  // argument handling
-  int copied = 0;
-  static int whichff = 0;
-
-  if (whichff == 0) {
-    // check for stale data
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
-    TickType_t last = pdTICKS_TO_MS(getFFupdateTick()) / 1000;
-    if ((now - last) > 60) {
-      int mins = (now - last) / 60;
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                         "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
-    }
-  }
-  // parse command based on how many arguments it has
-  if (argc == 1) { // default command: temps
-    uint32_t ff_config = read_eeprom_single(EEPROM_ID_FF_ADDR);
-    if (whichff == 0) {
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FF temperatures\r\n");
-    }
-    for (; whichff < NFIREFLIES; ++whichff) {
-      int8_t val = getFFtemp(whichff);
-      const char *name = getFFname(whichff);
-      if ((1 << whichff) & ff_config) // val > 0 )
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2d", name, val);
-      else // dummy value
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2s", name, "--");
-      bool isTx = (strstr(name, "Tx") != NULL);
-      if (isTx)
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-      else
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-      if ((SCRATCH_SIZE - copied) < 20) {
-        ++whichff;
-        return pdTRUE;
-      }
-    }
-    if (whichff % 2 == 1) {
-      m[copied++] = '\r';
-      m[copied++] = '\n';
-      m[copied] = '\0';
-    }
-    whichff = 0;
-  } // argc == 1
-  else {
-    int whichFF = 0;
-    // handle the channel number first
-    if (strncmp(argv[argc - 1], "all", 3) == 0) {
-      whichFF = NFIREFLIES;
-    }
-    else { // commands with arguments. The last argument is always which FF module.
-      whichFF = strtol(argv[argc - 1], NULL, 10);
-      if (whichFF >= NFIREFLIES || (whichFF == 0 && strncmp(argv[argc - 1], "0", 1) != 0)) {
-        snprintf(m + copied, SCRATCH_SIZE - copied, "%s: choose ff number less than %d\r\n",
-                 argv[0], NFIREFLIES);
-        return pdFALSE;
-      }
-    }
-    // now process various commands.
-    if (argc == 4) { // command + three arguments
-      bool receiveAnswer = false;
-      uint8_t code;
-      uint32_t data = (whichFF & FF_MESSAGE_CODE_REG_FF_MASK) << FF_MESSAGE_CODE_REG_FF_OFFSET;
-      ;
-      ;
-      if (strncmp(argv[1], "cdr", 3) == 0) {
-        code = FFLY_DISABLE_CDR; // default: disable
-        if (strncmp(argv[2], "on", 2) == 0) {
-          code = FFLY_ENABLE_CDR;
-        }
-      }
-      else if (strncmp(argv[1], "xmit", 4) == 0) {
-        code = FFLY_DISABLE_TRANSMITTER;
-        if (strncmp(argv[2], "on", 2) == 0) {
-          code = FFLY_ENABLE_TRANSMITTER;
-        }
-      }
-      else if (strncmp(argv[1], "rcvr", 4) == 0) {
-        code = FFLY_DISABLE;
-        if (strncmp(argv[2], "on", 2) == 0) {
-          code = FFLY_ENABLE;
-        }
-      }
-      // Add here
-      else if (strncmp(argv[1], "regr", 4) == 0) {
-        code = FFLY_READ_REGISTER;
-        receiveAnswer = true;
-        if (whichFF == NFIREFLIES) {
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: cannot read all registers\r\n",
-                             argv[0]);
-          return pdFALSE;
-        }
-        // register number
-        uint8_t regnum = strtol(argv[2], NULL, 16);
-        copied +=
-            snprintf(m + copied, SCRATCH_SIZE - copied, "%s: reading FF %s, register 0x%x\r\n",
-                     argv[0], getFFname(whichFF), regnum);
-        // pack channel and register into the data
-        data |= ((regnum & FF_MESSAGE_CODE_REG_REG_MASK) << FF_MESSAGE_CODE_REG_REG_OFFSET);
-      }
-      else {
-        snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s not recognized\r\n", argv[0],
-                 argv[1]);
-        return pdFALSE;
-      }
-      uint32_t message =
-          ((code & FF_MESSAGE_CODE_MASK) << FF_MESSAGE_CODE_OFFSET) | (data & FF_MESSAGE_DATA_MASK);
-      xQueueSendToBack(xFFlyQueueIn, &message, pdMS_TO_TICKS(10));
-      snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s %s sent.\r\n", argv[0], argv[1],
-               argv[2]);
-      if (receiveAnswer) {
-        BaseType_t f = xQueueReceive(xFFlyQueueOut, &message, pdMS_TO_TICKS(500));
-        if (f == pdTRUE)
-          snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Command returned 0x%x.\r\n", argv[0],
-                   message & 0xFFU);
-        else
-          snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Command failed.\r\n", argv[0]);
-      }
-    }                     // argc == 4
-    else if (argc == 5) { // command + five arguments
-      // register write. model:
-      // ff regw reg# val (0-23|all)
-      // register read/write commands
-      if (strncmp(argv[1], "regw", 4) == 0) {
-        uint8_t code = FFLY_WRITE_REGISTER;
-        // the two additional arguments
-        // register number
-        // value to be written
-        uint8_t regnum = strtol(argv[2], NULL, 16);
-        uint16_t value = strtol(argv[3], NULL, 16);
-        uint8_t channel = whichFF;
-        if (channel == NFIREFLIES) {
-          channel = 0; // silently fall back to first channel
-        }
-        // pack channel, register and value into the data
-        uint32_t data =
-            ((regnum & FF_MESSAGE_CODE_REG_REG_MASK) << FF_MESSAGE_CODE_REG_REG_OFFSET) |
-            ((value & FF_MESSAGE_CODE_REG_DAT_MASK) << FF_MESSAGE_CODE_REG_DAT_OFFSET) |
-            ((channel & FF_MESSAGE_CODE_REG_FF_MASK) << FF_MESSAGE_CODE_REG_FF_OFFSET);
-        uint32_t message = ((code & FF_MESSAGE_CODE_MASK) << FF_MESSAGE_CODE_OFFSET) |
-                           ((data & FF_MESSAGE_DATA_MASK) << FF_MESSAGE_DATA_OFFSET);
-        xQueueSendToBack(xFFlyQueueIn, &message, pdMS_TO_TICKS(10));
-        snprintf(m + copied, SCRATCH_SIZE - copied,
-                 "%s: write val 0x%x to register 0x%x, FF %d.\r\n", argv[0], value, regnum,
-                 channel);
-
-      } // end regw
-      else {
-        snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s not understood\r\n", argv[0],
-                 argv[1]);
-        return pdFALSE;
-      }
-    } // argc == 5
-    else {
-      snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s not understood\r\n", argv[0],
-               argv[1]);
-      return pdFALSE;
-    }
-  }
-  return pdFALSE;
-}
-
-// this command takes up to one argument
-static BaseType_t fpga_ctl(int argc, char **argv)
-{
-  if (argc == 2) {
-    if (strncmp(argv[1], "done", 4) == 0) { // print out value of done pins
-      int f1_done_ = read_gpio_pin(_K_FPGA_DONE);
-      int f2_done_ = read_gpio_pin(_V_FPGA_DONE);
-      snprintf(m, SCRATCH_SIZE, "F1_DONE* = %d\r\nF2_DONE* = %d\r\n", f1_done_, f2_done_);
-      return pdFALSE;
-    }
-    else {
-      snprintf(m, SCRATCH_SIZE, "%s: invalid command %s\r\n", argv[0], argv[1]);
-      return pdFALSE;
-    }
-  }
-  else if (argc != 1) {
-    // error, invalid
-    snprintf(m, SCRATCH_SIZE, "%s: invalid argument count %d\r\n", argv[0], argc);
-    return pdFALSE;
-  }
-  else {
-    int copied = 0;
-    static int whichfpga = 0;
-    int howmany = fpga_args.n_devices * fpga_args.n_pages;
-    if (whichfpga == 0) {
-      TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
-      TickType_t last = pdTICKS_TO_MS(getFFupdateTick()) / 1000;
-      if ((now - last) > 60) {
-        int mins = (now - last) / 60;
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                           "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
-      }
-
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA monitors\r\n");
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s\r\n", fpga_args.commands[0].name);
-    }
-
-    for (; whichfpga < howmany; ++whichfpga) {
-      float val = fpga_args.pm_values[whichfpga];
-      int tens, frac;
-      float_to_ints(val, &tens, &frac);
-
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%5s: %02d.%02d",
-                         fpga_args.devices[whichfpga].name, tens, frac);
-      if (whichfpga % 2 == 1)
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-      else
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-      if ((SCRATCH_SIZE - copied) < 20) {
-        ++whichfpga;
-        return pdTRUE;
-      }
-    }
-    if (whichfpga % 2 == 1) {
-      m[copied++] = '\r';
-      m[copied++] = '\n';
-      m[copied] = '\0';
-    }
-    whichfpga = 0;
-    return pdFALSE;
-  }
-}
 #include "common/smbus_units.h"
 void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bool reset);
 
@@ -827,7 +119,7 @@ typedef struct __attribute__((packed)) {
 
 extern struct dev_i2c_addr_t pm_addrs_dcdc[];
 
-static BaseType_t snapshot(int argc, char **argv)
+static BaseType_t snapshot(int argc, char **argv, char* m)
 {
   _Static_assert(sizeof(snapshot_t) == 32, "sizeof snapshot_t");
   int copied = 0;
@@ -886,325 +178,8 @@ static BaseType_t snapshot(int argc, char **argv)
   return pdFALSE;
 }
 
-// this command takes no arguments since there is only one command
-// right now.
-static BaseType_t sensor_summary(int argc, char **argv)
-{
-  int copied = 0;
-  // collect all sensor information
-  // highest temperature for each
-  // Firefly
-  // FPGA
-  // DCDC
-  // TM4C
-  float tm4c_temp = getADCvalue(ADC_INFO_TEMP_ENTRY);
-  int tens, frac;
-  float_to_ints(tm4c_temp, &tens, &frac);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "MCU %02d.%02d\r\n", tens, frac);
-  // Fireflies. These are reported as ints but we are asked
-  // to report a float.
-  int8_t imax_temp = -99.0;
-  for (int i = 0; i < NFIREFLIES; ++i) {
-    int8_t v = getFFtemp(i);
-    if (v > imax_temp)
-      imax_temp = v;
-  }
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY %02d.0\r\n", imax_temp);
-  // FPGAs.
-  float max_fpga;
-  if (fpga_args.n_devices == 2)
-    max_fpga = MAX(fpga_args.pm_values[0], fpga_args.pm_values[1]);
-  else
-    max_fpga = fpga_args.pm_values[0];
-  float_to_ints(max_fpga, &tens, &frac);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA %02d.%02d\r\n", tens, frac);
-
-  // DCDC. The first command is READ_TEMPERATURE_1.
-  // I am assuming it stays that way!!!!!!!!
-  float max_temp = -99.0;
-  for (int ps = 0; ps < dcdc_args.n_devices; ++ps) {
-    for (int page = 0; page < dcdc_args.n_pages; ++page) {
-      float thistemp = dcdc_args.pm_values[ps * (dcdc_args.n_commands * dcdc_args.n_pages) +
-                                           page * dcdc_args.n_commands + 0];
-      if (thistemp > max_temp)
-        max_temp = thistemp;
-    }
-  }
-  float_to_ints(max_temp, &tens, &frac);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "REG %02d.%02d\r\n", tens, frac);
-
-  return pdFALSE;
-}
-
-// This command takes no arguments
-static BaseType_t ff_status(int argc, char **argv)
-{
-  int copied = 0;
-
-  static int whichff = 0;
-  if (whichff == 0) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY STATUS:\r\n");
-  }
-  for (; whichff < 25; ++whichff) {
-    int8_t status = getFFstatus(whichff);
-    const char *name = getFFname(whichff);
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s %02d", name, status);
-
-    bool isTx = (strstr(name, "Tx") != NULL);
-    if (isTx)
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-    else
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-
-    if ((SCRATCH_SIZE - copied) < 20 && (whichff < 25)) {
-      ++whichff;
-      return pdTRUE;
-    }
-  }
-  whichff = 0;
-  return pdFALSE;
-}
-
-// This command takes no arguments
-static BaseType_t restart_mcu(int argc, char **argv)
-{
-  int copied = 0;
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Restarting MCU\r\n");
-  MAP_SysCtlReset(); // This function does not return
-  return pdFALSE;
-}
-
-#ifdef REV2
-#error "this function needs updating"
-#endif // REV2 
-// This command takes 1 argument, either k or v
-static BaseType_t fpga_reset(int argc, char **argv)
-{
-  int copied = 0;
-  const TickType_t delay = 1 / portTICK_PERIOD_MS; // 1 ms delay
-
-  if (strcmp(argv[1], "v") == 0) {
-    write_gpio_pin(V_FPGA_PROGRAM, 0x1);
-    vTaskDelay(delay);
-    write_gpio_pin(V_FPGA_PROGRAM, 0x0);
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "VU7P has been reset\r\n");
-  }
-  if (strcmp(argv[1], "k") == 0) {
-    write_gpio_pin(K_FPGA_PROGRAM, 0x1);
-    vTaskDelay(delay);
-    write_gpio_pin(K_FPGA_PROGRAM, 0x0);
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "KU15P has been reset\r\n");
-  }
-  return pdFALSE;
-}
-
-// This command takes 1 arg, the address
-static BaseType_t eeprom_read(int argc, char **argv)
-{
-  int copied = 0;
-
-  uint32_t addr;
-  addr = strtol(argv[1], NULL, 16);
-  uint32_t block = EEPROMBlockFromAddr(addr);
-
-  uint64_t data = read_eeprom_multi(addr);
-  uint32_t data2 = (uint32_t)(data >> 32);
-  uint32_t data1 = (uint32_t)data;
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                     "Data read from EEPROM block %d: %08x %08x\r\n", block, data1, data2);
-
-  return pdFALSE;
-}
-
-// This command takes 2 args, the address and 4 bytes of data to be written
-static BaseType_t eeprom_write(int argc, char **argv)
-{
-  int copied = 0;
-
-  uint32_t data, addr;
-  data = strtoul(argv[2], NULL, 16);
-  addr = strtoul(argv[1], NULL, 16);
-  uint32_t block = EEPROMBlockFromAddr(addr);
-  if ((block == 1) || ((EBUF_MINBLK <= block) && (block <= EBUF_MAXBLK))) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please choose available block\r\n");
-    return pdFALSE;
-  }
-  write_eeprom(data, addr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM block %d: %08x\r\n",
-                     block, data);
-
-  return pdFALSE;
-}
-
-// Takes 0 arguments
-static BaseType_t eeprom_info(int argc, char **argv)
-{
-  int copied = 0;
-
-  copied +=
-      snprintf(m + copied, SCRATCH_SIZE - copied, "EEPROM has 96 blocks of 64 bytes each.\r\n");
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Block 0 \t 0x0000-0x0040 \t Free.\r\n");
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                     "Block 1 \t 0x0040-0x007c \t Apollo ID Information. Password: 0x12345678\r\n");
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                     "Blocks %u-%u \t 0x%04x-0x%04x \t Error buffer.\r\n", EBUF_MINBLK, EBUF_MAXBLK,
-                     EEPROMAddrFromBlock(EBUF_MINBLK), EEPROMAddrFromBlock(EBUF_MAXBLK + 1) - 4);
-
-  return pdFALSE;
-}
-
-// Takes 3 arguments
-static BaseType_t set_board_id(int argc, char **argv)
-{
-  int copied = 0;
-
-  uint64_t pass, addr, data;
-  pass = strtoul(argv[1], NULL, 16);
-  addr = strtoul(argv[2], NULL, 16);
-  data = strtoul(argv[3], NULL, 16);
-  uint64_t block = EEPROMBlockFromAddr(addr);
-  if (block != 1) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please input address in Block 1\r\n");
-    return pdFALSE;
-  }
-
-  uint64_t unlock = EPRMMessage((uint64_t)EPRM_UNLOCK_BLOCK, block, pass);
-  xQueueSendToBack(xEPRMQueue_in, &unlock, portMAX_DELAY);
-
-  uint64_t message = EPRMMessage((uint64_t)EPRM_WRITE_SINGLE, addr, data);
-  xQueueSendToBack(xEPRMQueue_in, &message, portMAX_DELAY);
-
-  uint64_t lock = EPRMMessage((uint64_t)EPRM_LOCK_BLOCK, block << 32, 0);
-  xQueueSendToBack(xEPRMQueue_in, &lock, portMAX_DELAY);
-
-  if (pass != 0x12345678) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                       "Wrong password. Type eeprom_info to get password.");
-  } // data not printing correctly?
-
-  return pdFALSE;
-}
-
-// one-time use, has one function and takes 0 arguments
-static BaseType_t set_board_id_password(int argc, char **argv)
-{
-  int copied = 0;
-
-  uint64_t message = EPRMMessage((uint64_t)EPRM_PASS_SET, 0, 0x12345678);
-  xQueueSendToBack(xEPRMQueue_in, &message, portMAX_DELAY);
-
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Block locked\r\n");
-
-  return pdFALSE;
-}
-
-static BaseType_t board_id_info(int argc, char **argv)
-{
-  int copied = 0;
-  ;
-
-  uint32_t sn = read_eeprom_single(EEPROM_ID_SN_ADDR);
-  uint32_t ff = read_eeprom_single(EEPROM_ID_FF_ADDR);
-
-  uint32_t num = (uint32_t)sn >> 16;
-  uint32_t rev = ((uint32_t)sn) & 0xff;
-
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "ID:%08x\r\n", (uint32_t)sn);
-
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Board number: %x\r\n", num);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Revision: %x\r\n", rev);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Firefly config: %x\r\n", ff);
-
-  return pdFALSE;
-}
-
-// This command takes 1 arg, the data to be written to the buffer
-static BaseType_t errbuff_in(int argc, char **argv)
-{
-  int copied = 0;
-
-  uint32_t data;
-  data = strtoul(argv[1], NULL, 16);
-  errbuffer_put(data, 0);
-  copied +=
-      snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM buffer: %x\r\n", data);
-
-  return pdFALSE;
-}
-#define EBUFFOUT_MAX_ENTRIES 64
-static BaseType_t errbuff_out(int argc, char **argv)
-{
-  int copied = 0;
-
-  uint32_t num = strtoul(argv[1], NULL, 10);
-  if (num > EBUFFOUT_MAX_ENTRIES) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please enter a number 64 or less \r\n");
-    return pdFALSE;
-  }
-  uint32_t arr[EBUFFOUT_MAX_ENTRIES];
-  uint32_t(*arrptr)[EBUFFOUT_MAX_ENTRIES] = &arr;
-  errbuffer_get(num, arrptr);
-
-  static int i = 0;
-  if (i == 0) {
-    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Entries in EEPROM buffer:\r\n");
-  }
-  for (; i < num; ++i) {
-    uint32_t word = (*arrptr)[i];
-    uint16_t errcode = EBUF_ERRCODE(word);
-    // if this is a continuation and it's not the first entry we see
-    if (errcode == EBUF_CONTINUATION && i != 0) {
-      uint16_t errdata = EBUF_DATA(word);
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " 0x%02x", errdata);
-    }
-    else {
-      copied += errbuffer_get_messagestr(word, m + copied, SCRATCH_SIZE - copied);
-    }
-    if ((SCRATCH_SIZE - copied) < 30 && (i < num)) { // catch when buffer is almost full
-      ++i;
-      return pdTRUE;
-    }
-  }
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-  i = 0;
-  return pdFALSE;
-}
-
-// Takes no arguments
-static BaseType_t errbuff_info(int argc, char **argv)
-{
-  int copied = 0;
-  uint32_t cap, minaddr, maxaddr, head;
-  uint16_t last, counter, n_continue;
-
-  cap = errbuffer_capacity();
-  minaddr = errbuffer_minaddr();
-  maxaddr = errbuffer_maxaddr();
-  head = errbuffer_head();
-  last = errbuffer_last();
-  counter = errbuffer_counter();
-  n_continue = errbuffer_continue();
-
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry:      0x%0x\r\n", last);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: %d\r\n", counter);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes:  %d\r\n", n_continue);
-
-  return pdFALSE;
-}
-
-// Takes no arguments
-static BaseType_t errbuff_reset(int argc, char **argv)
-{
-  errbuffer_reset();
-  return pdFALSE;
-}
-
 // takes no arguments
-static BaseType_t stack_ctl(int argc, char **argv)
+static BaseType_t stack_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
   int i = SystemStackWaterHighWaterMark();
@@ -1269,7 +244,7 @@ static void TaskGetRunTimeStats(char *pcWriteBuffer, size_t bufferLength)
   }
 }
 
-static BaseType_t uptime(int argc, char **argv)
+static BaseType_t uptime(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   TickType_t now = xTaskGetTickCount() / (configTICK_RATE_HZ * 60); // time in minutes
@@ -1280,7 +255,7 @@ static BaseType_t uptime(int argc, char **argv)
 #pragma GCC diagnostic pop
 // WARNING: this command easily leads to stack overflows. It does not correctly
 // ensure that there are no overwrites to pcCommandString.
-static BaseType_t TaskStatsCommand(int argc, char **argv)
+static BaseType_t TaskStatsCommand(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   const char *const pcHeader = "            Time     %\r\n"
@@ -1315,64 +290,64 @@ static BaseType_t TaskStatsCommand(int argc, char **argv)
   return pdFALSE;
 }
 
-static BaseType_t help_command_fcn(int argc, char **);
+static BaseType_t help_command_fcn(int argc, char **, char* m);
 
-static BaseType_t zmon_ctl(int argc, char **argv)
+static BaseType_t suart_ctl(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE, copied = 0;
   bool understood = true;
   uint32_t message = 0;
   if (argc == 2) {
     if (strncmp(argv[1], "on", 2) == 0) {
-      message = ZYNQMON_ENABLE_TRANSMIT;
+      message = SOFTUART_ENABLE_TRANSMIT;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: transmit on\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "off", 3) == 0) {
-      message = ZYNQMON_DISABLE_TRANSMIT;
+      message = SOFTUART_DISABLE_TRANSMIT;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: transmit off\r\n", argv[0]);
     }
-#ifdef ZYNQMON_TEST_MODE
+#ifdef SUART_TEST_MODE
     else if (strncmp(argv[1], "debug1", 6) == 0) {
-      message = ZYNQMON_TEST_SINGLE;
+      message = SOFTUART_TEST_SINGLE;
       copied +=
           snprintf(m + copied, SCRATCH_SIZE - copied, "%s: debug mode 1 (single)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "debugraw", 8) == 0) {
-      message = ZYNQMON_TEST_RAW;
+      message = SOFTUART_TEST_RAW;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: debug raw (single)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "debug2", 6) == 0) {
-      message = ZYNQMON_TEST_INCREMENT;
+      message = SOFTUART_TEST_INCREMENT;
       copied +=
           snprintf(m + copied, SCRATCH_SIZE - copied, "%s: debug mode 2 (increment)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "normal", 5) == 0) {
-      message = ZYNQMON_TEST_OFF;
+      message = SOFTUART_TEST_OFF;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: regular mode\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "sendone", 7) == 0) {
-      message = ZYNQMON_TEST_SEND_ONE;
+      message = SOFTUART_TEST_SEND_ONE;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: send one\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "status", 5) == 0) {
-      uint8_t mode = getZYNQMonTestMode();
-      uint8_t sensor = getZYNQMonTestSensor();
-      uint16_t data = getZYNQMonTestData();
+      uint8_t mode = getSUARTTestMode();
+      uint8_t sensor = getSUARTTestSensor();
+      uint16_t data = getSUARTTestData();
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: test mode = %s, sensor = 0x%x, data = 0x%x\r\n", argv[0],
                          mode == 0 ? "single" : "increment", sensor, data);
     }
-#endif // ZYNQMON_TEST_MODE
+#endif // SUART_TEST_MODE
     else {
       understood = false;
     }
   }
-#ifdef ZYNQMON_TEST_MODE
+#ifdef SUART_TEST_MODE
   else if (argc == 4) {
     if (strncmp(argv[1], "settest", 7) == 0) {
       uint8_t sensor = strtol(argv[2], NULL, 16);
       uint16_t data = strtol(argv[3], NULL, 16);
-      setZYNQMonTestData(sensor, data);
+      setSUARTTestData(sensor, data);
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: set test sensor, data to 0x%x, 0x%x\r\n", argv[0], sensor, data);
     }
@@ -1380,7 +355,7 @@ static BaseType_t zmon_ctl(int argc, char **argv)
       understood = false;
     }
   }
-#endif // ZYNQMON_TEST_MODE
+#endif // SUART_TEST_MODE
   else {
     understood = false;
   }
@@ -1393,8 +368,8 @@ static BaseType_t zmon_ctl(int argc, char **argv)
   if (message) {
     copied +=
         snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Sending message %s\r\n", argv[0], argv[1]);
-    // Send a message to the zmon task
-    xQueueSendToBack(xZynqMonQueue, &message, pdMS_TO_TICKS(10));
+    // Send a message to the SUART task
+    xQueueSendToBack(xSoftUartQueue, &message, pdMS_TO_TICKS(10));
   }
   return pdFALSE;
 }
@@ -1404,7 +379,7 @@ static const char *const pcWelcomeMessage =
 
 struct command_t {
   const char *commandstr;
-  BaseType_t (*interpreter)(int argc, char **);
+  BaseType_t (*interpreter)(int argc, char **, char* m);
   const char *helpstr;
   const int num_args;
 };
@@ -1497,14 +472,14 @@ static struct command_t commands[] = {
         0,
     },
     {
-        "zmon",
-        zmon_ctl,
-#ifdef ZYNQMON_TEST_MODE
-        "zmon (on|off|status|debug1|debug2|debugraw|normal|sendone|(settest <sensor> <val>))\r\n"
+        "suart",
+        suart_ctl,
+#ifdef SUART_TEST_MODE
+        "suart (on|off|status|debug1|debug2|debugraw|normal|sendone|(settest <sensor> <val>))\r\n"
 #else
-        "zmon (on|off)\r\n"
-#endif // ZYNQMON_TEST_MODE
-        " Control ZynqMon task.\r\n",
+        "suart (on|off)\r\n"
+#endif // SUART_TEST_MODE
+        " Control soft uart.\r\n",
         -1,
     },
     {
@@ -1532,7 +507,7 @@ struct microrl_user_data_t {
   uint32_t uart_base;
 };
 
-static BaseType_t help_command_fcn(int argc, char **argv)
+static BaseType_t help_command_fcn(int argc, char **argv, char* m)
 {
   int copied = 0;
   static int i = 0;
@@ -1574,11 +549,11 @@ static int execute(void *p, int argc, char **argv)
   for (int i = 0; i < NUM_COMMANDS; ++i) {
     if (strncmp(commands[i].commandstr, argv[0], 256) == 0) {
       if ((argc == commands[i].num_args + 1) || commands[i].num_args < 0) {
-        int retval = commands[i].interpreter(argc, argv);
+        int retval = commands[i].interpreter(argc, argv, m);
         if (m[0] != '\0')
           UARTPrint(userdata->uart_base, m);
         while (retval == pdTRUE) {
-          retval = commands[i].interpreter(argc, argv);
+          retval = commands[i].interpreter(argc, argv, m);
           if (m[0] != '\0')
             UARTPrint(userdata->uart_base, m);
         }

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -14,8 +14,7 @@
 
 static char m[SCRATCH_SIZE];
 
-// this command takes no arguments and never returns.
-static BaseType_t bl_ctl(int argc, char **argv, char* m)
+static BaseType_t bl_ctl(int argc, char **argv, char m)
 {
   Print("Jumping to boot loader.\r\n");
   ROM_SysCtlDelay(100000);
@@ -51,7 +50,7 @@ static BaseType_t bl_ctl(int argc, char **argv, char* m)
 }
 
 // this command takes one argument
-static BaseType_t clock_ctl(int argc, char **argv, char* m)
+static BaseType_t clock_ctl(int argc, char **argv, char m)
 {
   int copied = 0;
   int status = -1; // shut up clang compiler warning
@@ -85,7 +84,7 @@ static BaseType_t clock_ctl(int argc, char **argv, char* m)
 }
 
 // this command takes no arguments
-static BaseType_t ver_ctl(int argc, char **argv, char* m)
+static BaseType_t ver_ctl(int argc, char **argv, char m)
 {
   int copied = 0;
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Version %s built at %s.\r\n", gitVersion(),
@@ -119,7 +118,7 @@ typedef struct __attribute__((packed)) {
 
 extern struct dev_i2c_addr_t pm_addrs_dcdc[];
 
-static BaseType_t snapshot(int argc, char **argv, char* m)
+static BaseType_t snapshot(int argc, char **argv, char m)
 {
   _Static_assert(sizeof(snapshot_t) == 32, "sizeof snapshot_t");
   int copied = 0;
@@ -179,7 +178,7 @@ static BaseType_t snapshot(int argc, char **argv, char* m)
 }
 
 // takes no arguments
-static BaseType_t stack_ctl(int argc, char **argv, char* m)
+static BaseType_t stack_ctl(int argc, char **argv, char m)
 {
   int copied = 0;
   int i = SystemStackWaterHighWaterMark();

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -228,14 +228,14 @@ static BaseType_t power_ctl(int argc, char **argv)
   }
   else if (strncmp(argv[1], "status", 5) == 0) { // report status to UART
     int copied = 0;
-    bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-    bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
+    bool f1_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
+    bool f2_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
     static int i = 0;
     if (i == 0) {
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-                         "%s:\r\nVU_ENABLE:\t%d\r\n"
-                         "KU_ENABLE:\t%d\r\n",
-                         argv[0], vu_enable, ku_enable);
+                         "%s:\r\nF1_ENABLE:\t%d\r\n"
+                         "F2_ENABLE:\t%d\r\n",
+                         argv[0], f1_enable, f2_enable);
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "State machine state: %s\r\n",
                          getPowerControlStateName(getPowerControlState()));
     }
@@ -746,9 +746,9 @@ static BaseType_t fpga_ctl(int argc, char **argv)
 {
   if (argc == 2) {
     if (strncmp(argv[1], "done", 4) == 0) { // print out value of done pins
-      int ku_done_ = read_gpio_pin(_K_FPGA_DONE);
-      int vu_done_ = read_gpio_pin(_V_FPGA_DONE);
-      snprintf(m, SCRATCH_SIZE, "KU_DONE* = %d\r\nVU_DONE* = %d\r\n", ku_done_, vu_done_);
+      int f1_done_ = read_gpio_pin(_K_FPGA_DONE);
+      int f2_done_ = read_gpio_pin(_V_FPGA_DONE);
+      snprintf(m, SCRATCH_SIZE, "F1_DONE* = %d\r\nF2_DONE* = %d\r\n", f1_done_, f2_done_);
       return pdFALSE;
     }
     else {
@@ -974,6 +974,9 @@ static BaseType_t restart_mcu(int argc, char **argv)
   return pdFALSE;
 }
 
+#ifdef REV2
+#error "this function needs updating"
+#endif // REV2 
 // This command takes 1 argument, either k or v
 static BaseType_t fpga_reset(int argc, char **argv)
 {
@@ -1314,62 +1317,62 @@ static BaseType_t TaskStatsCommand(int argc, char **argv)
 
 static BaseType_t help_command_fcn(int argc, char **);
 
-static BaseType_t suart_ctl(int argc, char **argv)
+static BaseType_t zmon_ctl(int argc, char **argv)
 {
   int s = SCRATCH_SIZE, copied = 0;
   bool understood = true;
   uint32_t message = 0;
   if (argc == 2) {
     if (strncmp(argv[1], "on", 2) == 0) {
-      message = SOFTUART_ENABLE_TRANSMIT;
+      message = ZYNQMON_ENABLE_TRANSMIT;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: transmit on\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "off", 3) == 0) {
-      message = SOFTUART_DISABLE_TRANSMIT;
+      message = ZYNQMON_DISABLE_TRANSMIT;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: transmit off\r\n", argv[0]);
     }
-#ifdef SUART_TEST_MODE
+#ifdef ZYNQMON_TEST_MODE
     else if (strncmp(argv[1], "debug1", 6) == 0) {
-      message = SOFTUART_TEST_SINGLE;
+      message = ZYNQMON_TEST_SINGLE;
       copied +=
           snprintf(m + copied, SCRATCH_SIZE - copied, "%s: debug mode 1 (single)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "debugraw", 8) == 0) {
-      message = SOFTUART_TEST_RAW;
+      message = ZYNQMON_TEST_RAW;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: debug raw (single)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "debug2", 6) == 0) {
-      message = SOFTUART_TEST_INCREMENT;
+      message = ZYNQMON_TEST_INCREMENT;
       copied +=
           snprintf(m + copied, SCRATCH_SIZE - copied, "%s: debug mode 2 (increment)\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "normal", 5) == 0) {
-      message = SOFTUART_TEST_OFF;
+      message = ZYNQMON_TEST_OFF;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: regular mode\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "sendone", 7) == 0) {
-      message = SOFTUART_TEST_SEND_ONE;
+      message = ZYNQMON_TEST_SEND_ONE;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: send one\r\n", argv[0]);
     }
     else if (strncmp(argv[1], "status", 5) == 0) {
-      uint8_t mode = getSUARTTestMode();
-      uint8_t sensor = getSUARTTestSensor();
-      uint16_t data = getSUARTTestData();
+      uint8_t mode = getZYNQMonTestMode();
+      uint8_t sensor = getZYNQMonTestSensor();
+      uint16_t data = getZYNQMonTestData();
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: test mode = %s, sensor = 0x%x, data = 0x%x\r\n", argv[0],
                          mode == 0 ? "single" : "increment", sensor, data);
     }
-#endif // SUART_TEST_MODE
+#endif // ZYNQMON_TEST_MODE
     else {
       understood = false;
     }
   }
-#ifdef SUART_TEST_MODE
+#ifdef ZYNQMON_TEST_MODE
   else if (argc == 4) {
     if (strncmp(argv[1], "settest", 7) == 0) {
       uint8_t sensor = strtol(argv[2], NULL, 16);
       uint16_t data = strtol(argv[3], NULL, 16);
-      setSUARTTestData(sensor, data);
+      setZYNQMonTestData(sensor, data);
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: set test sensor, data to 0x%x, 0x%x\r\n", argv[0], sensor, data);
     }
@@ -1377,7 +1380,7 @@ static BaseType_t suart_ctl(int argc, char **argv)
       understood = false;
     }
   }
-#endif // SUART_TEST_MODE
+#endif // ZYNQMON_TEST_MODE
   else {
     understood = false;
   }
@@ -1390,8 +1393,8 @@ static BaseType_t suart_ctl(int argc, char **argv)
   if (message) {
     copied +=
         snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Sending message %s\r\n", argv[0], argv[1]);
-    // Send a message to the SUART task
-    xQueueSendToBack(xSoftUartQueue, &message, pdMS_TO_TICKS(10));
+    // Send a message to the zmon task
+    xQueueSendToBack(xZynqMonQueue, &message, pdMS_TO_TICKS(10));
   }
   return pdFALSE;
 }
@@ -1494,14 +1497,14 @@ static struct command_t commands[] = {
         0,
     },
     {
-        "suart",
-        suart_ctl,
-#ifdef SUART_TEST_MODE
-        "suart (on|off|status|debug1|debug2|debugraw|normal|sendone|(settest <sensor> <val>))\r\n"
+        "zmon",
+        zmon_ctl,
+#ifdef ZYNQMON_TEST_MODE
+        "zmon (on|off|status|debug1|debug2|debugraw|normal|sendone|(settest <sensor> <val>))\r\n"
 #else
-        "suart (on|off)\r\n"
-#endif // SUART_TEST_MODE
-        " Control soft uart.\r\n",
+        "zmon (on|off)\r\n"
+#endif // ZYNQMON_TEST_MODE
+        " Control ZynqMon task.\r\n",
         -1,
     },
     {

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -14,7 +14,7 @@
 
 static char m[SCRATCH_SIZE];
 
-static BaseType_t bl_ctl(int argc, char **argv, char m)
+static BaseType_t bl_ctl(int argc, char **argv, char* m)
 {
   Print("Jumping to boot loader.\r\n");
   ROM_SysCtlDelay(100000);
@@ -50,7 +50,7 @@ static BaseType_t bl_ctl(int argc, char **argv, char m)
 }
 
 // this command takes one argument
-static BaseType_t clock_ctl(int argc, char **argv, char m)
+static BaseType_t clock_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
   int status = -1; // shut up clang compiler warning
@@ -84,7 +84,7 @@ static BaseType_t clock_ctl(int argc, char **argv, char m)
 }
 
 // this command takes no arguments
-static BaseType_t ver_ctl(int argc, char **argv, char m)
+static BaseType_t ver_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Version %s built at %s.\r\n", gitVersion(),
@@ -118,7 +118,7 @@ typedef struct __attribute__((packed)) {
 
 extern struct dev_i2c_addr_t pm_addrs_dcdc[];
 
-static BaseType_t snapshot(int argc, char **argv, char m)
+static BaseType_t snapshot(int argc, char **argv, char* m)
 {
   _Static_assert(sizeof(snapshot_t) == 32, "sizeof snapshot_t");
   int copied = 0;
@@ -178,7 +178,7 @@ static BaseType_t snapshot(int argc, char **argv, char m)
 }
 
 // takes no arguments
-static BaseType_t stack_ctl(int argc, char **argv, char m)
+static BaseType_t stack_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
   int i = SystemStackWaterHighWaterMark();

--- a/projects/cm_mcu/I2CSlaveTask.c
+++ b/projects/cm_mcu/I2CSlaveTask.c
@@ -21,6 +21,10 @@
 #include "common/uart.h"
 #include "I2CSlaveTask.h"
 
+// Rev 2:
+// All that needs to be done is rename local_fpga_{v,k}u to 
+// f{1,2} AFAIK. 
+
 // This slave task is designed currently only for access to
 // registers, with a single byte address and a single byte data.
 // This is to respond to the IPMC needs.
@@ -43,7 +47,7 @@ void Print(const char *str);
 // one slave.
 static uint8_t testreg = 0x0U;
 
-static int local_fpga_vu, local_fpga_ku;
+static int local_fpga_f2, local_fpga_f1;
 
 static uint8_t getSlaveData(uint8_t address)
 {
@@ -55,13 +59,13 @@ static uint8_t getSlaveData(uint8_t address)
     case 0x10U:                       // MCU temperature
       value = getADCvalue(20) + 0.5f; // always valid
       break;
-    case 0x12U: // FPGA VU temp
-      value = (uint8_t)local_fpga_vu >= 0 ? fpga_args.pm_values[local_fpga_vu] : 0U;
+    case 0x12U: // FPGA F2 temp
+      value = (uint8_t)local_fpga_f2 >= 0 ? fpga_args.pm_values[local_fpga_f2] : 0U;
       if (value == 0)
         value = 0xFFU; // invalid value
       break;
-    case 0x14U: // FPGA KU temp
-      value = (uint8_t)local_fpga_ku >= 0 ? fpga_args.pm_values[local_fpga_ku] : 0U;
+    case 0x14U: // FPGA F1 temp
+      value = (uint8_t)local_fpga_f1 >= 0 ? fpga_args.pm_values[local_fpga_f1] : 0U;
       if (value == 0)
         value = 0xFFU; // invalid value
       break;
@@ -113,10 +117,9 @@ static void setSlaveData(uint8_t addr, uint8_t val)
 void I2CSlaveTask(void *parameters)
 {
   TaskNotifyI2CSlave = xTaskGetCurrentTaskHandle();
-  // struct I2CSlaveTaskArgs_t * args = parameters;
 
-  local_fpga_ku = get_ku_index();
-  local_fpga_vu = get_vu_index();
+  local_fpga_f1 = get_f1_index();
+  local_fpga_f2 = get_f2_index();
 
   ROM_I2CSlaveEnable(I2C0_BASE);
 

--- a/projects/cm_mcu/I2CSlaveTask.h
+++ b/projects/cm_mcu/I2CSlaveTask.h
@@ -10,9 +10,4 @@
 
 #include "common/smbus.h"
 
-// I2C Slave
-// struct I2CSlaveTaskArgs_t {
-//  tSMBus *smbus;
-//};
-
 #endif /* PROJECTS_CM_MCU_I2CSLAVETASK_H_ */

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -28,11 +28,11 @@ struct dev_i2c_addr_t fpga_addrs[] = {
     {"KU15P", 0x70, 0, 0x36}, // KU15P FPGA
 };
 
-struct dev_i2c_addr_t fpga_addrs_kuonly[] = {
+struct dev_i2c_addr_t fpga_addrs_f1only[] = {
     {"KU15P", 0x70, 0, 0x36},
 };
 
-struct dev_i2c_addr_t fpga_addrs_vuonly[] = {
+struct dev_i2c_addr_t fpga_addrs_f2only[] = {
     {"VU7P", 0x70, 1, 0x36},
 };
 
@@ -249,45 +249,45 @@ struct MonitorTaskArgs_t dcdc_args = {
     .xSem = NULL,
 };
 
-static int fpga_ku = -1;
-static int fpga_vu = -1;
-int get_ku_index()
+static int fpga_f1 = -1;
+static int fpga_f2 = -1;
+int get_f1_index()
 {
-  return fpga_ku;
+  return fpga_f1;
 }
-int get_vu_index()
+int get_f2_index()
 {
-  return fpga_vu;
+  return fpga_f2;
 }
-void set_ku_index(int index)
+void set_f1_index(int index)
 {
-  fpga_ku = index;
+  fpga_f1 = index;
   return;
 }
-void set_vu_index(int index)
+void set_f2_index(int index)
 {
-  fpga_vu = index;
+  fpga_f2 = index;
   return;
 }
 
 void initFPGAMon()
 {
   // check if we are to include both FPGAs or not
-  bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-  bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
-  configASSERT(ku_enable || vu_enable);
-  if (!ku_enable && vu_enable) {
-    fpga_args.devices = fpga_addrs_vuonly;
+  bool f1_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
+  bool f2_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
+  configASSERT(f1_enable || f2_enable);
+  if (!f1_enable && f2_enable) {
+    fpga_args.devices = fpga_addrs_f2only;
     fpga_args.n_devices = 1;
-    set_vu_index(0);
+    set_f2_index(0);
   }
-  else if (!vu_enable && ku_enable) {
-    fpga_args.devices = fpga_addrs_kuonly;
+  else if (!f2_enable && f1_enable) {
+    fpga_args.devices = fpga_addrs_f1only;
     fpga_args.n_devices = 1;
-    set_ku_index(0);
+    set_f1_index(0);
   }
   else {
-    set_vu_index(0);
-    set_ku_index(1);
+    set_f2_index(0);
+    set_f1_index(1);
   }
 }

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -33,6 +33,7 @@ CFLAGS+=-Wno-pointer-compare ## for configASSERT macro
 # Where to find source files that do not live in this directory.
 #
 VPATH=../drivers
+VPATH+=commands
 # board specific 
 VPATH+=../../common
 # FreeRTOS
@@ -104,6 +105,11 @@ ${COMPILER}/cm_mcu.axf: ${COMPILER}/ZynqMonTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/InterruptHandlers.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/InitTask.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/LocalTasks.o
+${COMPILER}/cm_mcu.axf: ${COMPILER}/BoardCommands.o
+${COMPILER}/cm_mcu.axf: ${COMPILER}/BufferCommands.o
+${COMPILER}/cm_mcu.axf: ${COMPILER}/EEPROMCommands.o
+${COMPILER}/cm_mcu.axf: ${COMPILER}/I2CCommands.o
+${COMPILER}/cm_mcu.axf: ${COMPILER}/SensorControl.o
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/startup_${COMPILER}.o
 ## FreeRTOS
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/tasks.o

--- a/projects/cm_mcu/MonitorTask.h
+++ b/projects/cm_mcu/MonitorTask.h
@@ -16,7 +16,7 @@ extern float pm_values[];
 extern SemaphoreHandle_t xMonSem;
 
 // pilfered and adapted from http://billauer.co.il/blog/2018/01/c-pmbus-xilinx-fpga-kc705/
-enum { PM_VOLTAGE, PM_NONVOLTAGE, PM_STATUS, PM_LINEAR11, PM_LINEAR16U, PM_LINEAR16S } pm_types;
+enum pm_types { PM_VOLTAGE, PM_NONVOLTAGE, PM_STATUS, PM_LINEAR11, PM_LINEAR16U, PM_LINEAR16S };
 
 struct pm_command_t {
   unsigned char command; // I2c register address

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -73,9 +73,16 @@ const char *getPowerControlStateName(enum power_system_state s)
 // monitor and control the power supplies
 void PowerSupplyTask(void *parameters)
 {
+
+  // -------------------------------------------------
+  //
+  // REV 1
+  //
+  // -------------------------------------------------
+
   // compile-time sanity check
-  static_assert(PS_ENS_MASK == (PS_ENS_GEN_MASK | PS_ENS_VU_MASK | PS_ENS_KU_MASK), "mask");
-  static_assert(PS_OKS_MASK == (PS_OKS_GEN_MASK | PS_OKS_VU_MASK | PS_OKS_KU_MASK), "mask");
+  static_assert(PS_ENS_MASK == (PS_ENS_GEN_MASK | PS_ENS_F2_MASK | PS_ENS_F1_MASK), "mask");
+  static_assert(PS_OKS_MASK == (PS_OKS_GEN_MASK | PS_OKS_F2_MASK | PS_OKS_F1_MASK), "mask");
 
   // alarm from outside this task
   bool external_alarm = false;
@@ -88,25 +95,30 @@ void PowerSupplyTask(void *parameters)
   uint16_t supply_ok_mask_L1 = 0U, supply_ok_mask_L2 = 0U, supply_ok_mask_L4 = 0U,
            supply_ok_mask_L5 = 0U;
 
-  bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
-  bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
-  if (ku_enable) {
-    supply_ok_mask |= PS_OKS_KU_MASK;
-    supply_en_mask |= PS_ENS_KU_MASK;
-    supply_ok_mask_L1 = PS_OKS_KU_MASK_L1;
-    supply_ok_mask_L2 = supply_ok_mask_L1 | PS_OKS_KU_MASK_L2;
-    supply_ok_mask_L4 = supply_ok_mask_L2 | PS_OKS_KU_MASK_L4;
-    supply_ok_mask_L5 = supply_ok_mask_L4 | PS_OKS_KU_MASK_L5;
+  bool f1_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
+  bool f2_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
+  if (f1_enable) {
+    supply_ok_mask |= PS_OKS_F1_MASK;
+    supply_en_mask |= PS_ENS_F1_MASK;
+    supply_ok_mask_L1 = PS_OKS_F1_MASK_L1;
+    supply_ok_mask_L2 = supply_ok_mask_L1 | PS_OKS_F1_MASK_L2;
+    supply_ok_mask_L4 = supply_ok_mask_L2 | PS_OKS_F1_MASK_L4;
+    supply_ok_mask_L5 = supply_ok_mask_L4 | PS_OKS_F1_MASK_L5;
   }
-  if (vu_enable) {
-    supply_ok_mask |= PS_OKS_VU_MASK;
-    supply_en_mask |= PS_ENS_VU_MASK;
-    supply_ok_mask_L1 |= PS_OKS_VU_MASK_L1;
-    supply_ok_mask_L2 |= supply_ok_mask_L1 | PS_OKS_VU_MASK_L2;
-    supply_ok_mask_L4 |= supply_ok_mask_L2 | PS_OKS_VU_MASK_L4;
-    supply_ok_mask_L5 |= supply_ok_mask_L4 | PS_OKS_VU_MASK_L5;
+  if (f2_enable) {
+    supply_ok_mask |= PS_OKS_F2_MASK;
+    supply_en_mask |= PS_ENS_F2_MASK;
+    supply_ok_mask_L1 |= PS_OKS_F2_MASK_L1;
+    supply_ok_mask_L2 |= supply_ok_mask_L1 | PS_OKS_F2_MASK_L2;
+    supply_ok_mask_L4 |= supply_ok_mask_L2 | PS_OKS_F2_MASK_L4;
+    supply_ok_mask_L5 |= supply_ok_mask_L4 | PS_OKS_F2_MASK_L5;
   }
-
+  // -------------------------------------------------
+  //
+  // REV 2
+  //
+  // -------------------------------------------------
+  // add REV2 here 
 #ifdef ECN001
   // configure the LGA80D supplies. This call takes some time.
   LGA80D_init();
@@ -217,7 +229,7 @@ void PowerSupplyTask(void *parameters)
         // start power-on sequence
         if (blade_power_enable && !cli_powerdown_request && !external_alarm &&
             !power_supply_alarm) {
-          turn_on_ps_at_prio(vu_enable, ku_enable, 1);
+          turn_on_ps_at_prio(f2_enable, f1_enable, 1);
           errbuffer_put(EBUF_POWER_ON, 0);
           nextState = POWER_L1ON;
         }
@@ -238,7 +250,7 @@ void PowerSupplyTask(void *parameters)
           nextState = POWER_FAILURE;
         }
         else {
-          turn_on_ps_at_prio(vu_enable, ku_enable, 2);
+          turn_on_ps_at_prio(f2_enable, f1_enable, 2);
           nextState = POWER_L2ON;
         }
 
@@ -256,7 +268,7 @@ void PowerSupplyTask(void *parameters)
           nextState = POWER_FAILURE;
         }
         else {
-          turn_on_ps_at_prio(vu_enable, ku_enable, 3);
+          turn_on_ps_at_prio(f2_enable, f1_enable, 3);
           nextState = POWER_L3ON;
         }
 
@@ -264,7 +276,7 @@ void PowerSupplyTask(void *parameters)
       }
       case POWER_L3ON: {
         // NO ENABLES AT L3. We always go to L4.
-        turn_on_ps_at_prio(vu_enable, ku_enable, 4);
+        turn_on_ps_at_prio(f2_enable, f1_enable, 4);
         nextState = POWER_L4ON;
 
         break;
@@ -282,7 +294,7 @@ void PowerSupplyTask(void *parameters)
           nextState = POWER_FAILURE;
         }
         else {
-          turn_on_ps_at_prio(vu_enable, ku_enable, 5);
+          turn_on_ps_at_prio(f2_enable, f1_enable, 5);
           nextState = POWER_L5ON;
         }
 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -76,9 +76,17 @@ void LGA80D_init(void);
 void MonitorTask(void *parameters);
 
 // --- Firefly monitoring
-#define NFIREFLIES_KU15P 11
-#define NFIREFLIES_VU7P  14
-#define NFIREFLIES       (NFIREFLIES_KU15P + NFIREFLIES_VU7P)
+// REV1
+#ifndef REV2
+#define NFIREFLIES_F1 11
+#define NFIREFLIES_F2 14
+#else // REV2
+// REV 2
+#define NFIREFLIES_F1    99
+#define NFIREFLIES_F2    99 // Placeholders
+#error "Fix placeholder values"
+#endif // REV 2
+#define NFIREFLIES (NFIREFLIES_F1 + NFIREFLIES_F2)
 
 void FireFlyTask(void *parameters);
 extern QueueHandle_t xFFlyQueueIn;
@@ -173,35 +181,34 @@ extern QueueHandle_t xEPRMQueue_out;
 uint64_t EPRMMessage(uint64_t action, uint64_t addr, uint64_t data);
 void EEPROMTask(void *parameters);
 
-// Soft UART Task
-// SoftUart queue messages
-//#define SUART_TEST_MODE
+// ZynqMon
+//#define ZYNQMON_TEST_MODE
+// ZynqMon queue messages
+#define ZYNQMON_ENABLE_TRANSMIT  0x1
+#define ZYNQMON_DISABLE_TRANSMIT 0x2
+#define ZYNQMON_TEST_SINGLE      0x3
+#define ZYNQMON_TEST_INCREMENT   0x4
+#define ZYNQMON_TEST_OFF         0x5
+#define ZYNQMON_TEST_SEND_ONE    0x6
+#define ZYNQMON_TEST_RAW         0x7
 
-#define SOFTUART_ENABLE_TRANSMIT  0x1
-#define SOFTUART_DISABLE_TRANSMIT 0x2
-#define SOFTUART_TEST_SINGLE      0x3
-#define SOFTUART_TEST_INCREMENT   0x4
-#define SOFTUART_TEST_OFF         0x5
-#define SOFTUART_TEST_SEND_ONE    0x6
-#define SOFTUART_TEST_RAW         0x7
-
-extern QueueHandle_t xSoftUartQueue;
+extern QueueHandle_t xZynqMonQueue;
 void ZynqMonTask(void *parameters);
 
-#ifdef SUART_TEST_MODE
-void setSUARTTestData(uint8_t sensor, uint16_t value);
-uint8_t getSUARTTestMode();
-uint8_t getSUARTTestSensor();
-uint16_t getSUARTTestData();
-#endif // SUART_TEST_MODE
+#ifdef ZYNQMON_TEST_MODE
+void setZYNQMonTestData(uint8_t sensor, uint16_t value);
+uint8_t getZYNQMonTestMode();
+uint8_t getZYNQMonTestSensor();
+uint16_t getZYNQMonTestData();
+#endif // ZYNQMON_TEST_MODE
 
 // utility functions
 const uint32_t *getSystemStack();
 int SystemStackWaterHighWaterMark();
 
 // Xilinx MonitorTask
-int get_ku_index();
-int get_vu_index();
+int get_f1_index();
+int get_f2_index();
 void initFPGAMon();
 
 #endif /* PROJECTS_CM_MCU_TASKS_H_ */

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -23,6 +23,10 @@
 #include "Tasks.h"
 #include "MonitorTask.h"
 
+
+// Rev 2
+// this needs to be split into a SoftUART version (Rev1) and a hard UART version (Rev2)
+
 #define SZ 20
 
 // Data Format
@@ -54,34 +58,34 @@ static void format_data(const uint8_t sensor, const uint16_t data, uint8_t messa
   message[3] |= data & 0x3F;
 }
 
-#ifdef SUART_TEST_MODE
+#ifdef ZYNQMON_TEST_MODE
 static uint8_t testaddress = 0x0;
 static uint16_t testdata = 0xaaff;
 static bool inTestMode = true;
 static uint8_t testmode = 2;
-void setSUARTTestData(uint8_t sensor, uint16_t value)
+void setZYNQMonTestData(uint8_t sensor, uint16_t value)
 {
   testaddress = sensor;
   testdata = value;
 }
 
-uint8_t getSUARTTestMode()
+uint8_t getZYNQMonTestMode()
 {
   return testmode;
 }
 
-uint8_t getSUARTTestSensor()
+uint8_t getZYNQMonTestSensor()
 {
   return testaddress;
 }
 
-uint16_t getSUARTTestData()
+uint16_t getZYNQMonTestData()
 {
   return testdata;
 }
 #else  //
 const static bool inTestMode = false;
-#endif // SUART_TEST_MODE
+#endif // ZYNQMON_TEST_MODE
 //
 // The buffer used to hold the transmit data.
 //
@@ -102,13 +106,11 @@ tSoftUART g_sUART;
 
 extern uint32_t g_ui32SysClock;
 
-QueueHandle_t xSoftUartQueue;
+QueueHandle_t xZynqMonQueue;
 
-void ZynqMonTask(void *parameters)
+// For REV 1
+void InitSUART()
 {
-  // Setup
-  // initialize to the current tick time
-  TickType_t xLastWakeTime = xTaskGetTickCount();
 
   // Initialize the software UART instance data.
   //
@@ -177,43 +179,67 @@ void ZynqMonTask(void *parameters)
   // Enable the transmit FIFO half full interrupt in the software UART.
   //
   SoftUARTIntEnable(&g_sUART, SOFTUART_INT_TX);
+}
+
+#ifndef REV2
+void
+ZMUartCharPut(unsigned char c)
+{
+  SoftUARTCharPut(&g_sUART, c);
+}
+
+#else // REV2
+void ZMUartCharPut(unsigned char c)
+{
+#error "invalid UART unless I'm really lucky"
+  UARTCharPut(UART7_BASE, c); // CHANGE TO ACTUAL UART USED
+}
+#endif
+
+void ZynqMonTask(void *parameters)
+{
+  // Setup
+  InitSUART(); // Rev1
+  // will be done centrally in Rev 2
 
   uint8_t message[4] = {0x9c, 0x2c, 0x2b, 0x3e};
 
   bool enable = true;
+  // initialize to the current tick time
+  TickType_t xLastWakeTime = xTaskGetTickCount();
 
   // Loop forever
   for (;;) {
     uint32_t qmessage;
     // check for a new item in the queue but don't wait
-    if (xQueueReceive(xSoftUartQueue, &qmessage, 0)) {
+    if (xQueueReceive(xZynqMonQueue, &qmessage, 0)) {
       switch (qmessage) {
-        case SOFTUART_ENABLE_TRANSMIT:
+        case ZYNQMON_ENABLE_TRANSMIT:
           enable = true;
           break;
-        case SOFTUART_DISABLE_TRANSMIT:
+        case ZYNQMON_DISABLE_TRANSMIT:
           enable = false;
           break;
-#ifdef SUART_TEST_MODE
-        case SOFTUART_TEST_SINGLE:
+#ifdef ZYNQMON_TEST_MODE
+        case ZYNQMON_TEST_SINGLE:
           inTestMode = true;
           enable = true;
           testmode = 0;
           break;
-        case SOFTUART_TEST_INCREMENT:
+        case ZYNQMON_TEST_INCREMENT:
           inTestMode = true;
           enable = true;
           testmode = 1;
           break;
-        case SOFTUART_TEST_OFF:
+        case ZYNQMON_TEST_OFF:
           inTestMode = false;
           break;
-        case SOFTUART_TEST_SEND_ONE:
+        case ZYNQMON_TEST_SEND_ONE:
           inTestMode = true;
           enable = true;
           testmode = 0;
           break;
-        case SOFTUART_TEST_RAW:
+        case ZYNQMON_TEST_RAW:
           message[0] = 0x55;
           message[1] = 0xaa;
           message[2] = 0x55;
@@ -222,7 +248,7 @@ void ZynqMonTask(void *parameters)
           enable = true;
           testmode = 2;
           break;
-#endif // SUART_TEST_MODE
+#endif // ZYNQMON_TEST_MODE
       }
     }
     if (enable) {
@@ -230,15 +256,15 @@ void ZynqMonTask(void *parameters)
       MAP_IntEnable(INT_TIMER0A);
 
       if (inTestMode) {
-#ifdef SUART_TEST_MODE
+#ifdef ZYNQMON_TEST_MODE
         // non-incrementing, single word
         if (testmode == 0) {
           format_data(testaddress, testdata, message);
           for (int i = 0; i < 4; ++i) {
-            SoftUARTCharPut(&g_sUART, message[i]);
+            ZMUartCharPut( message[i]);
           }
           // one shot mode -- disable
-          if (qmessage == SOFTUART_TEST_SEND_ONE)
+          if (qmessage == ZYNQMON_TEST_SEND_ONE)
             enable = false;
         }
         // increment test mode, send
@@ -248,16 +274,16 @@ void ZynqMonTask(void *parameters)
             testaddress++;
             format_data(testaddress, testdata, message);
             for (int i = 0; i < 4; ++i) {
-              SoftUARTCharPut(&g_sUART, message[i]);
+              ZMUartCharPut( message[i]);
             }
           }
         }
         else if (testmode == 2) { // test mode, no formatting
           for (int i = 0; i < 4; ++i) {
-            SoftUARTCharPut(&g_sUART, message[i]);
+            ZMUartCharPut( message[i]);
           }
         }
-#endif       // SUART_TEST_MODE
+#endif       // ZYNQMON_TEST_MODE
       }      // end test mode
       else { // normal mode
         TickType_t now = pdTICKS_TO_MS(xLastWakeTime) / 1000;
@@ -279,7 +305,7 @@ void ZynqMonTask(void *parameters)
           format_data(j, temperature, message);
           // send data buffer
           for (int i = 0; i < 4; ++i) {
-            SoftUARTCharPut(&g_sUART, message[i]);
+            ZMUartCharPut( message[i]);
           }
         }
         typedef union {
@@ -314,7 +340,7 @@ void ZynqMonTask(void *parameters)
               int reg = offsets[j * 2 + l] + k;
               format_data(reg, u.us, message);
               for (int i = 0; i < 4; ++i) {
-                SoftUARTCharPut(&g_sUART, message[i]);
+                ZMUartCharPut( message[i]);
               }
             }
           }
@@ -326,7 +352,7 @@ void ZynqMonTask(void *parameters)
           u.f = getADCvalue(j);
           format_data(j + offsetADC, u.us, message);
           for (int i = 0; i < 4; ++i) {
-            SoftUARTCharPut(&g_sUART, message[i]);
+            ZMUartCharPut( message[i]);
           }
         }
         // MonitorTask -- FPGA values
@@ -353,7 +379,7 @@ void ZynqMonTask(void *parameters)
           }
           format_data(j + offsetFPGA, u.us, message);
           for (int i = 0; i < 4; ++i) {
-            SoftUARTCharPut(&g_sUART, message[i]);
+            ZMUartCharPut( message[i]);
           }
         }
         // git version
@@ -367,7 +393,7 @@ void ZynqMonTask(void *parameters)
           format_data(j + offsetGIT, *p, message);
           ++p;
           for (int i = 0; i < 4; ++i) {
-            SoftUARTCharPut(&g_sUART, message[i]);
+            ZMUartCharPut( message[i]);
           }
         }
         // uptime
@@ -376,12 +402,12 @@ void ZynqMonTask(void *parameters)
         uint16_t now_16 = now & 0xFFFFU;                 // lower 16 bits
         format_data(offsetUPTIME, now_16, message);
         for (int i = 0; i < 4; ++i) {
-          SoftUARTCharPut(&g_sUART, message[i]);
+          ZMUartCharPut( message[i]);
         }
         now_16 = (now >> 16) & 0xFFFFU; // upper 16 bits
         format_data(offsetUPTIME + 1, now_16, message);
         for (int i = 0; i < 4; ++i) {
-          SoftUARTCharPut(&g_sUART, message[i]);
+          ZMUartCharPut( message[i]);
         }
       } // if not test mode
 

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -243,7 +243,7 @@ int main(void)
   xTaskCreate(I2CSlaveTask, "I2CS0", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(EEPROMTask, "EPRM", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
   xTaskCreate(InitTask, "INIT", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(ZynqMonTask, "SUART", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(ZynqMonTask, "ZMON", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(GenericAlarmTask, "TALM", configMINIMAL_STACK_SIZE, &tempAlarmTask,
               tskIDLE_PRIORITY + 5, NULL);
 
@@ -270,8 +270,8 @@ int main(void)
   tempAlarmTask.xAlmQueue = xQueueCreate(10, sizeof(uint32_t)); // ALARM queue
   configASSERT(tempAlarmTask.xAlmQueue != NULL);
 
-  xSoftUartQueue = xQueueCreate(10, sizeof(uint32_t)); // Soft UART queue
-  configASSERT(xSoftUartQueue != NULL);
+  xZynqMonQueue = xQueueCreate(10, sizeof(uint32_t)); // Soft UART queue
+  configASSERT(xZynqMonQueue != NULL);
 
   // Set up the hardware ready to run the firmware. Don't do this earlier as
   // the interrupts call some FreeRTOS tasks that need to be set up first.

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -8,7 +8,11 @@
 #include "BoardCommands.h"
 
 // This command takes no arguments
+<<<<<<< HEAD
 BaseType_t restart_mcu(int argc, char **argv, char* m)
+=======
+static BaseType_t restart_mcu(int argc, char **argv, char m)
+>>>>>>> continue divding commands
 {
   int copied = 0;
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Restarting MCU\r\n");
@@ -17,7 +21,11 @@ BaseType_t restart_mcu(int argc, char **argv, char* m)
 }
 
 // Takes 3 arguments
+<<<<<<< HEAD
 BaseType_t set_board_id(int argc, char **argv, char* m)
+=======
+static BaseType_t set_board_id(int argc, char **argv, char m)
+>>>>>>> continue divding commands
 {
   int copied = 0;
 
@@ -49,7 +57,11 @@ BaseType_t set_board_id(int argc, char **argv, char* m)
 }
 
 // one-time use, has one function and takes 0 arguments
+<<<<<<< HEAD
 BaseType_t set_board_id_password(int argc, char **argv, char* m)
+=======
+static BaseType_t set_board_id_password(int argc, char **argv, char m)
+>>>>>>> continue divding commands
 {
   int copied = 0;
 
@@ -61,7 +73,11 @@ BaseType_t set_board_id_password(int argc, char **argv, char* m)
   return pdFALSE;
 }
 
+<<<<<<< HEAD
 BaseType_t board_id_info(int argc, char **argv, char* m)
+=======
+static BaseType_t board_id_info(int argc, char **argv, char m)
+>>>>>>> continue divding commands
 {
   int copied = 0;
   ;

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -1,0 +1,82 @@
+/*
+ * BoardCommands.c
+ *
+ *  Created on: Jan 18, 2021
+ *      Author: fatimayousuf
+ */
+
+#include "BoardCommands.h"
+
+// This command takes no arguments
+BaseType_t restart_mcu(int argc, char **argv, char* m)
+{
+  int copied = 0;
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Restarting MCU\r\n");
+  MAP_SysCtlReset(); // This function does not return
+  return pdFALSE;
+}
+
+// Takes 3 arguments
+BaseType_t set_board_id(int argc, char **argv, char* m)
+{
+  int copied = 0;
+
+  uint64_t pass, addr, data;
+  pass = strtoul(argv[1], NULL, 16);
+  addr = strtoul(argv[2], NULL, 16);
+  data = strtoul(argv[3], NULL, 16);
+  uint64_t block = EEPROMBlockFromAddr(addr);
+  if (block != 1) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please input address in Block 1\r\n");
+    return pdFALSE;
+  }
+
+  uint64_t unlock = EPRMMessage((uint64_t)EPRM_UNLOCK_BLOCK, block, pass);
+  xQueueSendToBack(xEPRMQueue_in, &unlock, portMAX_DELAY);
+
+  uint64_t message = EPRMMessage((uint64_t)EPRM_WRITE_SINGLE, addr, data);
+  xQueueSendToBack(xEPRMQueue_in, &message, portMAX_DELAY);
+
+  uint64_t lock = EPRMMessage((uint64_t)EPRM_LOCK_BLOCK, block << 32, 0);
+  xQueueSendToBack(xEPRMQueue_in, &lock, portMAX_DELAY);
+
+  if (pass != 0x12345678) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                       "Wrong password. Type eeprom_info to get password.");
+  } // data not printing correctly?
+
+  return pdFALSE;
+}
+
+// one-time use, has one function and takes 0 arguments
+BaseType_t set_board_id_password(int argc, char **argv, char* m)
+{
+  int copied = 0;
+
+  uint64_t message = EPRMMessage((uint64_t)EPRM_PASS_SET, 0, 0x12345678);
+  xQueueSendToBack(xEPRMQueue_in, &message, portMAX_DELAY);
+
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Block locked\r\n");
+
+  return pdFALSE;
+}
+
+BaseType_t board_id_info(int argc, char **argv, char* m)
+{
+  int copied = 0;
+  ;
+
+  uint32_t sn = read_eeprom_single(EEPROM_ID_SN_ADDR);
+  uint32_t ff = read_eeprom_single(EEPROM_ID_FF_ADDR);
+
+  uint32_t num = (uint32_t)sn >> 16;
+  uint32_t rev = ((uint32_t)sn) & 0xff;
+
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "ID:%08x\r\n", (uint32_t)sn);
+
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Board number: %x\r\n", num);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Revision: %x\r\n", rev);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Firefly config: %x\r\n", ff);
+
+  return pdFALSE;
+}

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -9,10 +9,14 @@
 
 // This command takes no arguments
 <<<<<<< HEAD
+<<<<<<< HEAD
 BaseType_t restart_mcu(int argc, char **argv, char* m)
 =======
 static BaseType_t restart_mcu(int argc, char **argv, char m)
 >>>>>>> continue divding commands
+=======
+BaseType_t restart_mcu(int argc, char **argv, char* m)
+>>>>>>> resolve some compilation errors
 {
   int copied = 0;
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Restarting MCU\r\n");
@@ -22,10 +26,14 @@ static BaseType_t restart_mcu(int argc, char **argv, char m)
 
 // Takes 3 arguments
 <<<<<<< HEAD
+<<<<<<< HEAD
 BaseType_t set_board_id(int argc, char **argv, char* m)
 =======
 static BaseType_t set_board_id(int argc, char **argv, char m)
 >>>>>>> continue divding commands
+=======
+BaseType_t set_board_id(int argc, char **argv, char* m)
+>>>>>>> resolve some compilation errors
 {
   int copied = 0;
 
@@ -58,10 +66,14 @@ static BaseType_t set_board_id(int argc, char **argv, char m)
 
 // one-time use, has one function and takes 0 arguments
 <<<<<<< HEAD
+<<<<<<< HEAD
 BaseType_t set_board_id_password(int argc, char **argv, char* m)
 =======
 static BaseType_t set_board_id_password(int argc, char **argv, char m)
 >>>>>>> continue divding commands
+=======
+BaseType_t set_board_id_password(int argc, char **argv, char* m)
+>>>>>>> resolve some compilation errors
 {
   int copied = 0;
 
@@ -74,10 +86,14 @@ static BaseType_t set_board_id_password(int argc, char **argv, char m)
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 BaseType_t board_id_info(int argc, char **argv, char* m)
 =======
 static BaseType_t board_id_info(int argc, char **argv, char m)
 >>>>>>> continue divding commands
+=======
+BaseType_t board_id_info(int argc, char **argv, char* m)
+>>>>>>> resolve some compilation errors
 {
   int copied = 0;
   ;

--- a/projects/cm_mcu/commands/BoardCommands.h
+++ b/projects/cm_mcu/commands/BoardCommands.h
@@ -5,14 +5,25 @@
  *      Author: fatimayousuf
  */
 
+<<<<<<< HEAD
 #include "parameters.h"
+=======
+#include <parameters.h>
+>>>>>>> continue divding commands
 
 #ifndef BOARD_COMMANDS_H_
 #define BOARD_COMMANDS_H_
 
+<<<<<<< HEAD
 BaseType_t restart_mcu(int argc, char **argv, char* m);
 BaseType_t set_board_id(int argc, char **argv, char* m);
 BaseType_t set_board_id_password(int argc, char **argv, char* m);
 BaseType_t board_id_info(int argc, char **argv, char* m);
+=======
+static BaseType_t restart_mcu(int argc, char **argv, char m);
+static BaseType_t set_board_id(int argc, char **argv, char m);
+static BaseType_t set_board_id_password(int argc, char **argv, char m);
+static BaseType_t board_id_info(int argc, char **argv, char m);
+>>>>>>> continue divding commands
 
 #endif

--- a/projects/cm_mcu/commands/BoardCommands.h
+++ b/projects/cm_mcu/commands/BoardCommands.h
@@ -1,0 +1,18 @@
+/*
+ * BoardCommands.h
+ *
+ *  Created on: Jan 18, 2021
+ *      Author: fatimayousuf
+ */
+
+#include "parameters.h"
+
+#ifndef BOARD_COMMANDS_H_
+#define BOARD_COMMANDS_H_
+
+BaseType_t restart_mcu(int argc, char **argv, char* m);
+BaseType_t set_board_id(int argc, char **argv, char* m);
+BaseType_t set_board_id_password(int argc, char **argv, char* m);
+BaseType_t board_id_info(int argc, char **argv, char* m);
+
+#endif

--- a/projects/cm_mcu/commands/BoardCommands.h
+++ b/projects/cm_mcu/commands/BoardCommands.h
@@ -6,24 +6,34 @@
  */
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 #include "parameters.h"
 =======
 #include <parameters.h>
 >>>>>>> continue divding commands
+=======
+#include "parameters.h"
+>>>>>>> resolve some compilation errors
 
 #ifndef BOARD_COMMANDS_H_
 #define BOARD_COMMANDS_H_
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> resolve some compilation errors
 BaseType_t restart_mcu(int argc, char **argv, char* m);
 BaseType_t set_board_id(int argc, char **argv, char* m);
 BaseType_t set_board_id_password(int argc, char **argv, char* m);
 BaseType_t board_id_info(int argc, char **argv, char* m);
+<<<<<<< HEAD
 =======
 static BaseType_t restart_mcu(int argc, char **argv, char m);
 static BaseType_t set_board_id(int argc, char **argv, char m);
 static BaseType_t set_board_id_password(int argc, char **argv, char m);
 static BaseType_t board_id_info(int argc, char **argv, char m);
 >>>>>>> continue divding commands
+=======
+>>>>>>> resolve some compilation errors
 
 #endif

--- a/projects/cm_mcu/commands/BufferCommands.c
+++ b/projects/cm_mcu/commands/BufferCommands.c
@@ -8,7 +8,7 @@
 #include <BufferCommands.h>
 
 // This command takes 1 arg, the data to be written to the buffer
-static BaseType_t errbuff_in(int argc, char **argv, char m)
+BaseType_t errbuff_in(int argc, char **argv, char* m)
 {
   int copied = 0;
 
@@ -21,7 +21,7 @@ static BaseType_t errbuff_in(int argc, char **argv, char m)
   return pdFALSE;
 }
 #define EBUFFOUT_MAX_ENTRIES 64
-static BaseType_t errbuff_out(int argc, char **argv, char m)
+BaseType_t errbuff_out(int argc, char **argv, char* m)
 {
   int copied = 0;
 
@@ -60,7 +60,7 @@ static BaseType_t errbuff_out(int argc, char **argv, char m)
 }
 
 // Takes no arguments
-static BaseType_t errbuff_info(int argc, char **argv, char m)
+BaseType_t errbuff_info(int argc, char **argv, char* m)
 {
   int copied = 0;
   uint32_t cap, minaddr, maxaddr, head;
@@ -86,7 +86,7 @@ static BaseType_t errbuff_info(int argc, char **argv, char m)
 }
 
 // Takes no arguments
-static BaseType_t errbuff_reset(int argc, char **argv, char m)
+BaseType_t errbuff_reset(int argc, char **argv, char* m)
 {
   errbuffer_reset();
   return pdFALSE;

--- a/projects/cm_mcu/commands/BufferCommands.c
+++ b/projects/cm_mcu/commands/BufferCommands.c
@@ -1,0 +1,93 @@
+/*
+ * BufferCommands.c
+ *
+ *  Created on: Jan 14, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <BufferCommands.h>
+
+// This command takes 1 arg, the data to be written to the buffer
+static BaseType_t errbuff_in(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  uint32_t data;
+  data = strtoul(argv[1], NULL, 16);
+  errbuffer_put(data, 0);
+  copied +=
+      snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM buffer: %x\r\n", data);
+
+  return pdFALSE;
+}
+#define EBUFFOUT_MAX_ENTRIES 64
+static BaseType_t errbuff_out(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  uint32_t num = strtoul(argv[1], NULL, 10);
+  if (num > EBUFFOUT_MAX_ENTRIES) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please enter a number 64 or less \r\n");
+    return pdFALSE;
+  }
+  uint32_t arr[EBUFFOUT_MAX_ENTRIES];
+  uint32_t(*arrptr)[EBUFFOUT_MAX_ENTRIES] = &arr;
+  errbuffer_get(num, arrptr);
+
+  static int i = 0;
+  if (i == 0) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Entries in EEPROM buffer:\r\n");
+  }
+  for (; i < num; ++i) {
+    uint32_t word = (*arrptr)[i];
+    uint16_t errcode = EBUF_ERRCODE(word);
+    // if this is a continuation and it's not the first entry we see
+    if (errcode == EBUF_CONTINUATION && i != 0) {
+      uint16_t errdata = EBUF_DATA(word);
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " 0x%02x", errdata);
+    }
+    else {
+      copied += errbuffer_get_messagestr(word, m + copied, SCRATCH_SIZE - copied);
+    }
+    if ((SCRATCH_SIZE - copied) < 30 && (i < num)) { // catch when buffer is almost full
+      ++i;
+      return pdTRUE;
+    }
+  }
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+  i = 0;
+  return pdFALSE;
+}
+
+// Takes no arguments
+static BaseType_t errbuff_info(int argc, char **argv, char m)
+{
+  int copied = 0;
+  uint32_t cap, minaddr, maxaddr, head;
+  uint16_t last, counter, n_continue;
+
+  cap = errbuffer_capacity();
+  minaddr = errbuffer_minaddr();
+  maxaddr = errbuffer_maxaddr();
+  head = errbuffer_head();
+  last = errbuffer_last();
+  counter = errbuffer_counter();
+  n_continue = errbuffer_continue();
+
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry:      0x%0x\r\n", last);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: %d\r\n", counter);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes:  %d\r\n", n_continue);
+
+  return pdFALSE;
+}
+
+// Takes no arguments
+static BaseType_t errbuff_reset(int argc, char **argv, char m)
+{
+  errbuffer_reset();
+  return pdFALSE;
+}

--- a/projects/cm_mcu/commands/BufferCommands.c
+++ b/projects/cm_mcu/commands/BufferCommands.c
@@ -5,18 +5,18 @@
  *      Author: fatimayousuf
  */
 
-#include <BufferCommands.h>
+#include "BufferCommands.h"
 
 // This command takes 1 arg, the data to be written to the buffer
 BaseType_t errbuff_in(int argc, char **argv, char* m)
 {
-  int copied = 0;
-
-  uint32_t data;
-  data = strtoul(argv[1], NULL, 16);
-  errbuffer_put(data, 0);
-  copied +=
-      snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM buffer: %x\r\n", data);
+//  int copied = 0;
+//
+//  uint32_t data;
+//  data = strtoul(argv[1], NULL, 16);
+//  errbuffer_put(data, 0);
+//  copied +=
+//      snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM buffer: %x\r\n", data);
 
   return pdFALSE;
 }
@@ -63,21 +63,21 @@ BaseType_t errbuff_out(int argc, char **argv, char* m)
 BaseType_t errbuff_info(int argc, char **argv, char* m)
 {
   int copied = 0;
-  uint32_t cap, minaddr, maxaddr, head;
+  //uint32_t cap, minaddr, maxaddr, head;
   uint16_t last, counter, n_continue;
 
-  cap = errbuffer_capacity();
-  minaddr = errbuffer_minaddr();
-  maxaddr = errbuffer_maxaddr();
-  head = errbuffer_head();
+//  cap = errbuffer_capacity();
+//  minaddr = errbuffer_minaddr();
+//  maxaddr = errbuffer_maxaddr();
+//  head = errbuffer_head();
   last = errbuffer_last();
   counter = errbuffer_counter();
   n_continue = errbuffer_continue();
-
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
+//
+//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
+//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
+//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
+//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry:      0x%0x\r\n", last);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: %d\r\n", counter);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes:  %d\r\n", n_continue);

--- a/projects/cm_mcu/commands/BufferCommands.c
+++ b/projects/cm_mcu/commands/BufferCommands.c
@@ -10,13 +10,13 @@
 // This command takes 1 arg, the data to be written to the buffer
 BaseType_t errbuff_in(int argc, char **argv, char* m)
 {
-//  int copied = 0;
-//
-//  uint32_t data;
-//  data = strtoul(argv[1], NULL, 16);
-//  errbuffer_put(data, 0);
-//  copied +=
-//      snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM buffer: %x\r\n", data);
+  int copied = 0;
+
+  uint32_t data;
+  data = strtoul(argv[1], NULL, 16);
+  errbuffer_put(data, 0);
+  copied +=
+      snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM buffer: %x\r\n", data);
 
   return pdFALSE;
 }
@@ -63,21 +63,21 @@ BaseType_t errbuff_out(int argc, char **argv, char* m)
 BaseType_t errbuff_info(int argc, char **argv, char* m)
 {
   int copied = 0;
-  //uint32_t cap, minaddr, maxaddr, head;
+  uint32_t cap, minaddr, maxaddr, head;
   uint16_t last, counter, n_continue;
 
-//  cap = errbuffer_capacity();
-//  minaddr = errbuffer_minaddr();
-//  maxaddr = errbuffer_maxaddr();
-//  head = errbuffer_head();
+  cap = errbuffer_capacity();
+  minaddr = errbuffer_minaddr();
+  maxaddr = errbuffer_maxaddr();
+  head = errbuffer_head();
   last = errbuffer_last();
   counter = errbuffer_counter();
   n_continue = errbuffer_continue();
-//
-//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
-//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
-//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
-//  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
+
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Capacity:        %d words\r\n", cap);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Min address:     0x%08x\r\n", minaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Max address:     0x%08x\r\n", maxaddr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Head address:    0x%08x\r\n", head);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Last entry:      0x%0x\r\n", last);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Message counter: %d\r\n", counter);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Continue codes:  %d\r\n", n_continue);

--- a/projects/cm_mcu/commands/BufferCommands.h
+++ b/projects/cm_mcu/commands/BufferCommands.h
@@ -7,9 +7,14 @@
 
 #include <parameters.h>
 
+#ifndef BUFFER_COMMANDS_H_
+#define BUFFER_COMMANDS_H_
+
 #define EBUFFOUT_MAX_ENTRIES 64
 
-static BaseType_t errbuff_in(int argc, char **argv);
-static BaseType_t errbuff_out(int argc, char **argv);
-static BaseType_t errbuff_info(int argc, char **argv);
-static BaseType_t errbuff_reset(int argc, char **argv);
+static BaseType_t errbuff_in(int argc, char **argv, char m);
+static BaseType_t errbuff_out(int argc, char **argv, char m);
+static BaseType_t errbuff_info(int argc, char **argv, char m);
+static BaseType_t errbuff_reset(int argc, char **argv, char m);
+
+#endif

--- a/projects/cm_mcu/commands/BufferCommands.h
+++ b/projects/cm_mcu/commands/BufferCommands.h
@@ -5,16 +5,16 @@
  *      Author: fatimayousuf
  */
 
-#include <parameters.h>
+#include "parameters.h"
 
 #ifndef BUFFER_COMMANDS_H_
 #define BUFFER_COMMANDS_H_
 
 #define EBUFFOUT_MAX_ENTRIES 64
 
-static BaseType_t errbuff_in(int argc, char **argv, char m);
-static BaseType_t errbuff_out(int argc, char **argv, char m);
-static BaseType_t errbuff_info(int argc, char **argv, char m);
-static BaseType_t errbuff_reset(int argc, char **argv, char m);
+BaseType_t errbuff_in(int argc, char **argv, char* m);
+BaseType_t errbuff_out(int argc, char **argv, char* m);
+BaseType_t errbuff_info(int argc, char **argv, char* m);
+BaseType_t errbuff_reset(int argc, char **argv, char* m);
 
 #endif

--- a/projects/cm_mcu/commands/BufferCommands.h
+++ b/projects/cm_mcu/commands/BufferCommands.h
@@ -1,0 +1,15 @@
+/*
+ * BufferCommands.h
+ *
+ *  Created on: Jan 13, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <parameters.h>
+
+#define EBUFFOUT_MAX_ENTRIES 64
+
+static BaseType_t errbuff_in(int argc, char **argv);
+static BaseType_t errbuff_out(int argc, char **argv);
+static BaseType_t errbuff_info(int argc, char **argv);
+static BaseType_t errbuff_reset(int argc, char **argv);

--- a/projects/cm_mcu/commands/EEPROMCommands.c
+++ b/projects/cm_mcu/commands/EEPROMCommands.c
@@ -1,0 +1,63 @@
+/*
+ * EEPROMCommands.c
+ *
+ *  Created on: Jan 14, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <EEPROMCommands.h>
+
+// This command takes 1 arg, the address
+static BaseType_t eeprom_read(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  uint32_t addr;
+  addr = strtol(argv[1], NULL, 16);
+  uint32_t block = EEPROMBlockFromAddr(addr);
+
+  uint64_t data = read_eeprom_multi(addr);
+  uint32_t data2 = (uint32_t)(data >> 32);
+  uint32_t data1 = (uint32_t)data;
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "Data read from EEPROM block %d: %08x %08x\r\n", block, data1, data2);
+
+  return pdFALSE;
+}
+
+// This command takes 2 args, the address and 4 bytes of data to be written
+static BaseType_t eeprom_write(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  uint32_t data, addr;
+  data = strtoul(argv[2], NULL, 16);
+  addr = strtoul(argv[1], NULL, 16);
+  uint32_t block = EEPROMBlockFromAddr(addr);
+  if ((block == 1) || ((EBUF_MINBLK <= block) && (block <= EBUF_MAXBLK))) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Please choose available block\r\n");
+    return pdFALSE;
+  }
+  write_eeprom(data, addr);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Data written to EEPROM block %d: %08x\r\n",
+                     block, data);
+
+  return pdFALSE;
+}
+
+// Takes 0 arguments
+static BaseType_t eeprom_info(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  copied +=
+      snprintf(m + copied, SCRATCH_SIZE - copied, "EEPROM has 96 blocks of 64 bytes each.\r\n");
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Block 0 \t 0x0000-0x0040 \t Free.\r\n");
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "Block 1 \t 0x0040-0x007c \t Apollo ID Information. Password: 0x12345678\r\n");
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "Blocks %u-%u \t 0x%04x-0x%04x \t Error buffer.\r\n", EBUF_MINBLK, EBUF_MAXBLK,
+                     EEPROMAddrFromBlock(EBUF_MINBLK), EEPROMAddrFromBlock(EBUF_MAXBLK + 1) - 4);
+
+  return pdFALSE;
+}

--- a/projects/cm_mcu/commands/EEPROMCommands.c
+++ b/projects/cm_mcu/commands/EEPROMCommands.c
@@ -8,7 +8,7 @@
 #include <EEPROMCommands.h>
 
 // This command takes 1 arg, the address
-static BaseType_t eeprom_read(int argc, char **argv, char m)
+BaseType_t eeprom_read(int argc, char **argv, char* m)
 {
   int copied = 0;
 
@@ -26,7 +26,7 @@ static BaseType_t eeprom_read(int argc, char **argv, char m)
 }
 
 // This command takes 2 args, the address and 4 bytes of data to be written
-static BaseType_t eeprom_write(int argc, char **argv, char m)
+BaseType_t eeprom_write(int argc, char **argv, char* m)
 {
   int copied = 0;
 
@@ -46,7 +46,7 @@ static BaseType_t eeprom_write(int argc, char **argv, char m)
 }
 
 // Takes 0 arguments
-static BaseType_t eeprom_info(int argc, char **argv, char m)
+BaseType_t eeprom_info(int argc, char **argv, char* m)
 {
   int copied = 0;
 

--- a/projects/cm_mcu/commands/EEPROMCommands.c
+++ b/projects/cm_mcu/commands/EEPROMCommands.c
@@ -5,7 +5,7 @@
  *      Author: fatimayousuf
  */
 
-#include <EEPROMCommands.h>
+#include "EEPROMCommands.h"
 
 // This command takes 1 arg, the address
 BaseType_t eeprom_read(int argc, char **argv, char* m)

--- a/projects/cm_mcu/commands/EEPROMCommands.h
+++ b/projects/cm_mcu/commands/EEPROMCommands.h
@@ -1,0 +1,12 @@
+/*
+ * EEPROMCommands.h
+ *
+ *  Created on: Jan 13, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <parameters.h>
+
+static BaseType_t eeprom_read(int argc, char **argv);
+static BaseType_t eeprom_write(int argc, char **argv);
+static BaseType_t eeprom_info(int argc, char **argv);

--- a/projects/cm_mcu/commands/EEPROMCommands.h
+++ b/projects/cm_mcu/commands/EEPROMCommands.h
@@ -5,13 +5,13 @@
  *      Author: fatimayousuf
  */
 
-#include <parameters.h>
+#include "parameters.h"
 
 #ifndef EEPROM_COMMANDS_H_
 #define EEPROM_COMMANDS_H_
 
-static BaseType_t eeprom_read(int argc, char **argv, char m);
-static BaseType_t eeprom_write(int argc, char **argv, char m);
-static BaseType_t eeprom_info(int argc, char **argv, char m);
+BaseType_t eeprom_read(int argc, char **argv, char* m);
+BaseType_t eeprom_write(int argc, char **argv, char* m);
+BaseType_t eeprom_info(int argc, char **argv, char* m);
 
 #endif

--- a/projects/cm_mcu/commands/EEPROMCommands.h
+++ b/projects/cm_mcu/commands/EEPROMCommands.h
@@ -7,6 +7,11 @@
 
 #include <parameters.h>
 
-static BaseType_t eeprom_read(int argc, char **argv);
-static BaseType_t eeprom_write(int argc, char **argv);
-static BaseType_t eeprom_info(int argc, char **argv);
+#ifndef EEPROM_COMMANDS_H_
+#define EEPROM_COMMANDS_H_
+
+static BaseType_t eeprom_read(int argc, char **argv, char m);
+static BaseType_t eeprom_write(int argc, char **argv, char m);
+static BaseType_t eeprom_info(int argc, char **argv, char m);
+
+#endif

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -5,7 +5,10 @@
  *      Author: fatimayousuf
  */
 
-#include <I2CCommands.h>
+#include "I2CCommands.h"
+
+static tSMBus *p_sMaster = &g_sMaster4;
+static tSMBusStatus *p_eStatus = &eStatus4;
 
 BaseType_t i2c_ctl_set_dev(int argc, char **argv, char* m)
 {

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -7,7 +7,7 @@
 
 #include <I2CCommands.h>
 
-static BaseType_t i2c_ctl_set_dev(int argc, char **argv, char m)
+BaseType_t i2c_ctl_set_dev(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   BaseType_t i = strtol(argv[1], NULL, 10); // device number
@@ -28,7 +28,7 @@ static BaseType_t i2c_ctl_set_dev(int argc, char **argv, char m)
   return pdFALSE;
 }
 
-static BaseType_t i2c_ctl_r(int argc, char **argv, char m)
+BaseType_t i2c_ctl_r(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   BaseType_t address, nbytes;
@@ -53,7 +53,7 @@ static BaseType_t i2c_ctl_r(int argc, char **argv, char m)
   return pdFALSE;
 }
 
-static BaseType_t i2c_ctl_reg_r(int argc, char **argv, char m)
+BaseType_t i2c_ctl_reg_r(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   BaseType_t address, reg_address, nbytes;
@@ -80,7 +80,7 @@ static BaseType_t i2c_ctl_reg_r(int argc, char **argv, char m)
   return pdFALSE;
 }
 
-static BaseType_t i2c_ctl_reg_w(int argc, char **argv)
+BaseType_t i2c_ctl_reg_w(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   // first byte is the register, others are the data
@@ -108,7 +108,7 @@ static BaseType_t i2c_ctl_reg_w(int argc, char **argv)
   return pdFALSE;
 }
 
-static BaseType_t i2c_ctl_w(int argc, char **argv, char m)
+BaseType_t i2c_ctl_w(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   BaseType_t address, nbytes, value;
@@ -133,7 +133,7 @@ static BaseType_t i2c_ctl_w(int argc, char **argv, char m)
   return pdFALSE;
 }
 
-static BaseType_t i2c_scan(int argc, char **argv, char m)
+BaseType_t i2c_scan(int argc, char **argv, char* m)
 {
   // takes no arguments
   int copied = 0;

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -1,0 +1,164 @@
+/*
+ * I2CCommands.c
+ *
+ *  Created on: Jan 14, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <I2CCommands.h>
+
+static BaseType_t i2c_ctl_set_dev(int argc, char **argv, char m)
+{
+  int s = SCRATCH_SIZE;
+  BaseType_t i = strtol(argv[1], NULL, 10); // device number
+
+  int status = apollo_i2c_ctl_set_dev(i);
+  if (status == 0) {
+    snprintf(m, s, "Setting i2c device to %d\r\n", i);
+  }
+  else if (status == -1) {
+    snprintf(m, s, "Invalid i2c device %d (%s), only 1,2,3, 4 and 6 supported\r\n", i, argv[1]);
+  }
+  else if (status == -2) {
+    snprintf(m, s, "%s: huh? line %d\r\n", argv[0], __LINE__);
+  }
+  else {
+    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
+  }
+  return pdFALSE;
+}
+
+static BaseType_t i2c_ctl_r(int argc, char **argv, char m)
+{
+  int s = SCRATCH_SIZE;
+  BaseType_t address, nbytes;
+  address = strtol(argv[1], NULL, 16);
+  nbytes = strtol(argv[2], NULL, 10);
+  uint8_t data[I2C_CTL_MAX_BYTES];
+
+  int status = apollo_i2c_ctl_r(address, nbytes, data);
+  if (status == 0) {
+    snprintf(m, s, "%s: add: 0x%02x: value 0x%02x %02x %02x %02x\r\n", argv[0], address, data[3],
+             data[2], data[1], data[0]);
+  }
+  else if (status == -1) {
+    snprintf(m, s, "%s: operation failed (1)\r\n", argv[0]);
+  }
+  else if (status == -2) {
+    snprintf(m, s, "%s: operation failed (2, value=%d)\r\n", argv[0], *p_eStatus);
+  }
+  else {
+    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
+  }
+  return pdFALSE;
+}
+
+static BaseType_t i2c_ctl_reg_r(int argc, char **argv, char m)
+{
+  int s = SCRATCH_SIZE;
+  BaseType_t address, reg_address, nbytes;
+  address = strtol(argv[1], NULL, 16);
+  reg_address = strtol(argv[2], NULL, 16);
+  nbytes = strtol(argv[3], NULL, 10);
+  uint8_t data[I2C_CTL_MAX_BYTES];
+  uint8_t txdata = reg_address;
+
+  int status = apollo_i2c_ctl_reg_r(address, txdata, nbytes, data);
+  if (status == 0) {
+    snprintf(m, s, "i2cr: add: 0x%02x, reg 0x%02x: value 0x%02x %02x %02x %02x\r\n", address,
+             reg_address, data[3], data[2], data[1], data[0]);
+  }
+  else if (status == -1) {
+    snprintf(m, s, "%s: operation failed (1)\r\n", argv[0]);
+  }
+  else if (status == -2) {
+    snprintf(m, s, "%s: operation failed (2, value=%d)\r\n", argv[0], *p_eStatus);
+  }
+  else {
+    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
+  }
+  return pdFALSE;
+}
+
+static BaseType_t i2c_ctl_reg_w(int argc, char **argv)
+{
+  int s = SCRATCH_SIZE;
+  // first byte is the register, others are the data
+  BaseType_t address, reg_address, nbytes, packed_data;
+  address = strtol(argv[1], NULL, 16);     // address
+  reg_address = strtol(argv[2], NULL, 16); // register
+  nbytes = strtol(argv[3], NULL, 16);      // number of bytes
+  packed_data = strtol(argv[4], NULL, 16); // data
+
+  int status = apollo_i2c_ctl_reg_w(address, reg_address, nbytes, packed_data);
+  if (status == 0) {
+    snprintf(m, s, "%s: Wrote to address 0x%x, register 0x%x, value 0x%08x (%d bytes)\r\n", argv[0],
+             address, reg_address, packed_data, nbytes - 1);
+  }
+  else if (status == -1) {
+    snprintf(m, s, "%s: operation failed (1)\r\n", argv[0]);
+  }
+  else if (status == -2) {
+    snprintf(m, s, "%s: operation failed (2)\r\n", argv[0]);
+  }
+  else {
+    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
+  }
+
+  return pdFALSE;
+}
+
+static BaseType_t i2c_ctl_w(int argc, char **argv, char m)
+{
+  int s = SCRATCH_SIZE;
+  BaseType_t address, nbytes, value;
+  address = strtol(argv[1], NULL, 16);
+  nbytes = strtol(argv[2], NULL, 16);
+  value = strtol(argv[3], NULL, 16);
+
+  int status = apollo_i2c_ctl_w(address, nbytes, value);
+  if (status == 0) {
+    snprintf(m, s, "i2cwr: Wrote to address 0x%x, value 0x%08x (%d bytes)\r\n", address, value,
+             nbytes);
+  }
+  else if (status == -1) {
+    snprintf(m, s, "%s: write failed (1)\r\n", argv[0]);
+  }
+  else if (status == -2) {
+    snprintf(m, s, "%s: write failed (2)\r\n", argv[0]);
+  }
+  else {
+    snprintf(m, s, "%s: invalid return value. line %d\r\n", argv[0], __LINE__);
+  }
+  return pdFALSE;
+}
+
+static BaseType_t i2c_scan(int argc, char **argv, char m)
+{
+  // takes no arguments
+  int copied = 0;
+  copied += snprintf(m, SCRATCH_SIZE - copied, "i2c bus scan\r\n");
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\r\n00:         ");
+  for (uint8_t i = 0x3; i < 0x78; ++i) {
+    uint8_t data;
+    if (i % 16 == 0)
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n%2x:", i);
+    tSMBusStatus r = SMBusMasterI2CRead(p_sMaster, i, &data, 1);
+    if (r != SMBUS_OK) {
+      Print("i2c_scan: Probe failed 1\r\n");
+    }
+    while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
+      vTaskDelay(pdMS_TO_TICKS(10)); // wait
+    }
+    if (*p_eStatus == SMBUS_OK)
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " %2x", i);
+    else
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " --");
+    configASSERT(copied < SCRATCH_SIZE);
+  }
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+  configASSERT(copied < SCRATCH_SIZE);
+
+  return pdFALSE;
+}

--- a/projects/cm_mcu/commands/I2CCommands.h
+++ b/projects/cm_mcu/commands/I2CCommands.h
@@ -7,9 +7,17 @@
 
 #include <parameters.h>
 
-static BaseType_t i2c_ctl_set_dev(int argc, char **argv);
-static BaseType_t i2c_ctl_r(int argc, char **argv);
-static BaseType_t i2c_ctl_reg_r(int argc, char **argv);
-static BaseType_t i2c_ctl_reg_w(int argc, char **argv);
-static BaseType_t i2c_ctl_w(int argc, char **argv);
-static BaseType_t i2c_scan(int argc, char **argv);
+#ifndef I2C_COMMANDS_H_
+#define I2C_COMMANDS_H_
+
+#define I2C_CTL_MAX_BYTES 4
+
+static BaseType_t i2c_ctl_set_dev(int argc, char **argv, char m);
+static BaseType_t i2c_ctl_r(int argc, char **argv, char m);
+static BaseType_t i2c_ctl_reg_r(int argc, char **argv, char m);
+static BaseType_t i2c_ctl_reg_w(int argc, char **argv, char m);
+static BaseType_t i2c_ctl_w(int argc, char **argv, char m);
+static BaseType_t i2c_scan(int argc, char **argv, char m);
+static BaseType_t i2c_scan(int argc, char **argv, char m);
+
+#endif

--- a/projects/cm_mcu/commands/I2CCommands.h
+++ b/projects/cm_mcu/commands/I2CCommands.h
@@ -1,0 +1,15 @@
+/*
+ * I2CCommands.h
+ *
+ *  Created on: Jan 13, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <parameters.h>
+
+static BaseType_t i2c_ctl_set_dev(int argc, char **argv);
+static BaseType_t i2c_ctl_r(int argc, char **argv);
+static BaseType_t i2c_ctl_reg_r(int argc, char **argv);
+static BaseType_t i2c_ctl_reg_w(int argc, char **argv);
+static BaseType_t i2c_ctl_w(int argc, char **argv);
+static BaseType_t i2c_scan(int argc, char **argv);

--- a/projects/cm_mcu/commands/I2CCommands.h
+++ b/projects/cm_mcu/commands/I2CCommands.h
@@ -5,19 +5,19 @@
  *      Author: fatimayousuf
  */
 
-#include <parameters.h>
+#include "parameters.h"
 
 #ifndef I2C_COMMANDS_H_
 #define I2C_COMMANDS_H_
 
 #define I2C_CTL_MAX_BYTES 4
 
-static BaseType_t i2c_ctl_set_dev(int argc, char **argv, char m);
-static BaseType_t i2c_ctl_r(int argc, char **argv, char m);
-static BaseType_t i2c_ctl_reg_r(int argc, char **argv, char m);
-static BaseType_t i2c_ctl_reg_w(int argc, char **argv, char m);
-static BaseType_t i2c_ctl_w(int argc, char **argv, char m);
-static BaseType_t i2c_scan(int argc, char **argv, char m);
-static BaseType_t i2c_scan(int argc, char **argv, char m);
+BaseType_t i2c_ctl_set_dev(int argc, char **argv, char* m);
+BaseType_t i2c_ctl_r(int argc, char **argv, char* m);
+BaseType_t i2c_ctl_reg_r(int argc, char **argv, char* m);
+BaseType_t i2c_ctl_reg_w(int argc, char **argv, char* m);
+BaseType_t i2c_ctl_w(int argc, char **argv, char* m);
+BaseType_t i2c_scan(int argc, char **argv, char* m);
+BaseType_t i2c_scan(int argc, char **argv, char* m);
 
 #endif

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -59,6 +59,7 @@ static BaseType_t sensor_summary(int argc, char **argv, char m)
 }
 
 // send power control commands
+extern struct gpio_pin_t oks[];
 static BaseType_t power_ctl(int argc, char **argv,  char m)
 {
   int s = SCRATCH_SIZE;

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1,0 +1,551 @@
+/*
+ * SensorControl.c
+ *
+ *  Created on: Jan 14, 2021
+ *      Author: fatimayousuf
+ */
+
+
+#include <SensorControl.h>
+
+// this command takes no arguments since there is only one command
+// right now.
+static BaseType_t sensor_summary(int argc, char **argv, char m)
+{
+  int copied = 0;
+  // collect all sensor information
+  // highest temperature for each
+  // Firefly
+  // FPGA
+  // DCDC
+  // TM4C
+  float tm4c_temp = getADCvalue(ADC_INFO_TEMP_ENTRY);
+  int tens, frac;
+  float_to_ints(tm4c_temp, &tens, &frac);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "MCU %02d.%02d\r\n", tens, frac);
+  // Fireflies. These are reported as ints but we are asked
+  // to report a float.
+  int8_t imax_temp = -99.0;
+  for (int i = 0; i < NFIREFLIES; ++i) {
+    int8_t v = getFFtemp(i);
+    if (v > imax_temp)
+      imax_temp = v;
+  }
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY %02d.0\r\n", imax_temp);
+  // FPGAs.
+  float max_fpga;
+  if (fpga_args.n_devices == 2)
+    max_fpga = MAX(fpga_args.pm_values[0], fpga_args.pm_values[1]);
+  else
+    max_fpga = fpga_args.pm_values[0];
+  float_to_ints(max_fpga, &tens, &frac);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA %02d.%02d\r\n", tens, frac);
+
+  // DCDC. The first command is READ_TEMPERATURE_1.
+  // I am assuming it stays that way!!!!!!!!
+  float max_temp = -99.0;
+  for (int ps = 0; ps < dcdc_args.n_devices; ++ps) {
+    for (int page = 0; page < dcdc_args.n_pages; ++page) {
+      float thistemp = dcdc_args.pm_values[ps * (dcdc_args.n_commands * dcdc_args.n_pages) +
+                                           page * dcdc_args.n_commands + 0];
+      if (thistemp > max_temp)
+        max_temp = thistemp;
+    }
+  }
+  float_to_ints(max_temp, &tens, &frac);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "REG %02d.%02d\r\n", tens, frac);
+
+  return pdFALSE;
+}
+
+// send power control commands
+static BaseType_t power_ctl(int argc, char **argv,  char m)
+{
+  int s = SCRATCH_SIZE;
+
+  uint32_t message;
+  if (strncmp(argv[1], "on", 2) == 0) {
+    message = PS_ON; // turn on power supply
+  }
+  else if (strncmp(argv[1], "off", 3) == 0) {
+    message = PS_OFF; // turn off power supply
+  }
+  else if (strncmp(argv[1], "clearfail", 9) == 0) {
+    message = PS_ANYFAIL_ALARM_CLEAR;
+  }
+  else if (strncmp(argv[1], "status", 5) == 0) { // report status to UART
+    int copied = 0;
+    bool ku_enable = (read_gpio_pin(TM4C_DIP_SW_1) == 1);
+    bool vu_enable = (read_gpio_pin(TM4C_DIP_SW_2) == 1);
+    static int i = 0;
+    if (i == 0) {
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                         "%s:\r\nVU_ENABLE:\t%d\r\n"
+                         "KU_ENABLE:\t%d\r\n",
+                         argv[0], vu_enable, ku_enable);
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "State machine state: %s\r\n",
+                         getPowerControlStateName(getPowerControlState()));
+    }
+    for (; i < N_PS_OKS; ++i) {
+      enum ps_state j = getPSStatus(i);
+      char *c;
+      switch (j) {
+        case PWR_UNKNOWN:
+          c = "PWR_UNKNOWN";
+          break;
+        case PWR_ON:
+          c = "PWR_ON";
+          break;
+        case PWR_OFF:
+          c = "PWR_OFF";
+          break;
+        case PWR_DISABLED:
+          c = "PWR_DISABLED";
+          break;
+        case PWR_FAILED:
+          c = "PWR_FAILED";
+          break;
+        default:
+          c = "UNKNOWN";
+          break;
+      }
+
+      copied +=
+          snprintf(m + copied, SCRATCH_SIZE - copied, "%15s: %s\r\n", pin_names[oks[i].name], c);
+      if ((SCRATCH_SIZE - copied) < 20 && (i < N_PS_OKS)) {
+        ++i;
+        return pdTRUE;
+      }
+    }
+    i = 0;
+    return pdFALSE;
+  }
+  else {
+    snprintf(m, s, "power_ctl: invalid argument %s received\r\n", argv[1]);
+    return pdFALSE;
+  }
+  // Send a message to the power supply task, if needed
+  xQueueSendToBack(xPwrQueue, &message, pdMS_TO_TICKS(10));
+  m[0] = '\0'; // no output from this command
+
+  return pdFALSE;
+}
+
+// takes 1-2 arguments
+static BaseType_t alarm_ctl(int argc, char **argv, char m)
+{
+  int s = SCRATCH_SIZE;
+  if (argc < 2) {
+    snprintf(m, s, "%s: need one or more arguments\r\n", argv[0]);
+    return pdFALSE;
+  }
+
+  uint32_t message;
+  if (strncmp(argv[1], "clear", 4) == 0) {
+    message = ALM_CLEAR_ALL; // clear all alarms
+    xQueueSendToBack(tempAlarmTask.xAlmQueue, &message, pdMS_TO_TICKS(10));
+    m[0] = '\0'; // no output from this command
+
+    return pdFALSE;
+  }
+  else if (strncmp(argv[1], "status", 5) == 0) { // report status to UART
+    int copied = 0;
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: ALARM status\r\n", argv[0]);
+    int32_t stat = getAlarmStatus();
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Raw: 0x%08x\r\n", stat);
+
+    float ff_val = getAlarmTemperature(FF);
+    int tens, frac;
+    float_to_ints(ff_val, &tens, &frac);
+    copied +=
+        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP FFLY: %s \t Threshold: %02d.%02d\r\n",
+                 (stat & ALM_STAT_FIREFLY_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
+
+    float fpga_val = getAlarmTemperature(FPGA);
+    float_to_ints(fpga_val, &tens, &frac);
+    copied +=
+        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP FPGA: %s \t Threshold: %02d.%02d\r\n",
+                 (stat & ALM_STAT_FPGA_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
+
+    float dcdc_val = getAlarmTemperature(DCDC);
+    float_to_ints(dcdc_val, &tens, &frac);
+    copied +=
+        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP DCDC: %s \t Threshold: %02d.%02d\r\n",
+                 (stat & ALM_STAT_DCDC_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
+
+    float tm4c_val = getAlarmTemperature(TM4C);
+    float_to_ints(tm4c_val, &tens, &frac);
+    copied +=
+        snprintf(m + copied, SCRATCH_SIZE - copied, "TEMP TM4C: %s \t Threshold: %02d.%02d\r\n",
+                 (stat & ALM_STAT_TM4C_OVERTEMP) ? "ALARM" : "GOOD", tens, frac);
+    configASSERT(copied < SCRATCH_SIZE);
+
+    return pdFALSE;
+  }
+  else if (strcmp(argv[1], "settemp") == 0) {
+    if (argc != 4) {
+      snprintf(m, s, "Invalid command\r\n");
+      return pdFALSE;
+    }
+    float newtemp = (float)strtol(argv[3], NULL, 10);
+    char *device = argv[2];
+    if (!strcmp(device, "ff")) {
+      setAlarmTemperature(FF, newtemp);
+      snprintf(m, s, "%s: set Firefly alarm temperature to %s\r\n", argv[0], argv[3]);
+      return pdFALSE;
+    }
+    if (!strcmp(device, "fpga")) {
+      setAlarmTemperature(FPGA, newtemp);
+      snprintf(m, s, "%s: set FPGA alarm temperature to %s\r\n", argv[0], argv[3]);
+      return pdFALSE;
+    }
+    if (!strcmp(device, "dcdc")) {
+      setAlarmTemperature(DCDC, newtemp);
+      snprintf(m, s, "%s: set DCDC alarm temperature to %s\r\n", argv[0], argv[3]);
+      return pdFALSE;
+    }
+    if (!strcmp(device, "tm4c")) {
+      setAlarmTemperature(TM4C, newtemp);
+      snprintf(m, s, "%s: set TM4C alarm temperature to %s\r\n", argv[0], argv[3]);
+      return pdFALSE;
+    }
+    else {
+      snprintf(m, s, "%s is not a valid device.\r\n", argv[2]);
+      return pdFALSE;
+    }
+  }
+  else {
+    snprintf(m, s, "%s: invalid argument %s received\r\n", argv[0], argv[1]);
+    return pdFALSE;
+  }
+  return pdFALSE;
+}
+
+// send LED commands
+static BaseType_t led_ctl(int argc, char **argv, char m)
+{
+
+  BaseType_t i1 = strtol(argv[1], NULL, 10);
+  configASSERT(i1 != 99);
+
+  uint32_t message = HUH; // default: message not understood
+  if (i1 == 0) {          // ToDo: make messages less clunky. break out color.
+    message = RED_LED_OFF;
+  }
+  else if (i1 == 1) {
+    message = RED_LED_ON;
+  }
+  else if (i1 == 2) {
+    message = RED_LED_TOGGLE;
+  }
+  else if (i1 == 3) {
+    message = RED_LED_TOGGLE3;
+  }
+  else if (i1 == 4) {
+    message = RED_LED_TOGGLE4;
+  }
+  // Send a message to the LED task
+  xQueueSendToBack(xLedQueue, &message, pdMS_TO_TICKS(10));
+  m[0] = '\0'; // no output from this command
+
+  return pdFALSE;
+}
+
+// this command takes no arguments
+static BaseType_t adc_ctl(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  static int whichadc = 0;
+  if (whichadc == 0) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "ADC outputs\r\n");
+  }
+  for (; whichadc < 21; ++whichadc) {
+    float val = getADCvalue(whichadc);
+    int tens, frac;
+    float_to_ints(val, &tens, &frac);
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%14s: %02d.%02d\r\n",
+                       getADCname(whichadc), tens, frac);
+    if ((SCRATCH_SIZE - copied) < 20 && (whichadc < 20)) {
+      ++whichadc;
+      return pdTRUE;
+    }
+  }
+  whichadc = 0;
+  return pdFALSE;
+}
+
+// this command takes up to two arguments
+static BaseType_t ff_ctl(int argc, char **argv, char m)
+{
+  // argument handling
+  int copied = 0;
+  static int whichff = 0;
+
+  if (whichff == 0) {
+    // check for stale data
+    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t last = pdTICKS_TO_MS(getFFupdateTick()) / 1000;
+    if ((now - last) > 60) {
+      int mins = (now - last) / 60;
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                         "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
+    }
+  }
+  // parse command based on how many arguments it has
+  if (argc == 1) { // default command: temps
+    uint32_t ff_config = read_eeprom_single(EEPROM_ID_FF_ADDR);
+    if (whichff == 0) {
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FF temperatures\r\n");
+    }
+    for (; whichff < NFIREFLIES; ++whichff) {
+      int8_t val = getFFtemp(whichff);
+      const char *name = getFFname(whichff);
+      if ((1 << whichff) & ff_config) // val > 0 )
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2d", name, val);
+      else // dummy value
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2s", name, "--");
+      bool isTx = (strstr(name, "Tx") != NULL);
+      if (isTx)
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+      else
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+      if ((SCRATCH_SIZE - copied) < 20) {
+        ++whichff;
+        return pdTRUE;
+      }
+    }
+    if (whichff % 2 == 1) {
+      m[copied++] = '\r';
+      m[copied++] = '\n';
+      m[copied] = '\0';
+    }
+    whichff = 0;
+  } // argc == 1
+  else {
+    int whichFF = 0;
+    // handle the channel number first
+    if (strncmp(argv[argc - 1], "all", 3) == 0) {
+      whichFF = NFIREFLIES;
+    }
+    else { // commands with arguments. The last argument is always which FF module.
+      whichFF = strtol(argv[argc - 1], NULL, 10);
+      if (whichFF >= NFIREFLIES || (whichFF == 0 && strncmp(argv[argc - 1], "0", 1) != 0)) {
+        snprintf(m + copied, SCRATCH_SIZE - copied, "%s: choose ff number less than %d\r\n",
+                 argv[0], NFIREFLIES);
+        return pdFALSE;
+      }
+    }
+    // now process various commands.
+    if (argc == 4) { // command + three arguments
+      bool receiveAnswer = false;
+      uint8_t code;
+      uint32_t data = (whichFF & FF_MESSAGE_CODE_REG_FF_MASK) << FF_MESSAGE_CODE_REG_FF_OFFSET;
+      ;
+      ;
+      if (strncmp(argv[1], "cdr", 3) == 0) {
+        code = FFLY_DISABLE_CDR; // default: disable
+        if (strncmp(argv[2], "on", 2) == 0) {
+          code = FFLY_ENABLE_CDR;
+        }
+      }
+      else if (strncmp(argv[1], "xmit", 4) == 0) {
+        code = FFLY_DISABLE_TRANSMITTER;
+        if (strncmp(argv[2], "on", 2) == 0) {
+          code = FFLY_ENABLE_TRANSMITTER;
+        }
+      }
+      else if (strncmp(argv[1], "rcvr", 4) == 0) {
+        code = FFLY_DISABLE;
+        if (strncmp(argv[2], "on", 2) == 0) {
+          code = FFLY_ENABLE;
+        }
+      }
+      // Add here
+      else if (strncmp(argv[1], "regr", 4) == 0) {
+        code = FFLY_READ_REGISTER;
+        receiveAnswer = true;
+        if (whichFF == NFIREFLIES) {
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: cannot read all registers\r\n",
+                             argv[0]);
+          return pdFALSE;
+        }
+        // register number
+        uint8_t regnum = strtol(argv[2], NULL, 16);
+        copied +=
+            snprintf(m + copied, SCRATCH_SIZE - copied, "%s: reading FF %s, register 0x%x\r\n",
+                     argv[0], getFFname(whichFF), regnum);
+        // pack channel and register into the data
+        data |= ((regnum & FF_MESSAGE_CODE_REG_REG_MASK) << FF_MESSAGE_CODE_REG_REG_OFFSET);
+      }
+      else {
+        snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s not recognized\r\n", argv[0],
+                 argv[1]);
+        return pdFALSE;
+      }
+      uint32_t message =
+          ((code & FF_MESSAGE_CODE_MASK) << FF_MESSAGE_CODE_OFFSET) | (data & FF_MESSAGE_DATA_MASK);
+      xQueueSendToBack(xFFlyQueueIn, &message, pdMS_TO_TICKS(10));
+      snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s %s sent.\r\n", argv[0], argv[1],
+               argv[2]);
+      if (receiveAnswer) {
+        BaseType_t f = xQueueReceive(xFFlyQueueOut, &message, pdMS_TO_TICKS(500));
+        if (f == pdTRUE)
+          snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Command returned 0x%x.\r\n", argv[0],
+                   message & 0xFFU);
+        else
+          snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Command failed.\r\n", argv[0]);
+      }
+    }                     // argc == 4
+    else if (argc == 5) { // command + five arguments
+      // register write. model:
+      // ff regw reg# val (0-23|all)
+      // register read/write commands
+      if (strncmp(argv[1], "regw", 4) == 0) {
+        uint8_t code = FFLY_WRITE_REGISTER;
+        // the two additional arguments
+        // register number
+        // value to be written
+        uint8_t regnum = strtol(argv[2], NULL, 16);
+        uint16_t value = strtol(argv[3], NULL, 16);
+        uint8_t channel = whichFF;
+        if (channel == NFIREFLIES) {
+          channel = 0; // silently fall back to first channel
+        }
+        // pack channel, register and value into the data
+        uint32_t data =
+            ((regnum & FF_MESSAGE_CODE_REG_REG_MASK) << FF_MESSAGE_CODE_REG_REG_OFFSET) |
+            ((value & FF_MESSAGE_CODE_REG_DAT_MASK) << FF_MESSAGE_CODE_REG_DAT_OFFSET) |
+            ((channel & FF_MESSAGE_CODE_REG_FF_MASK) << FF_MESSAGE_CODE_REG_FF_OFFSET);
+        uint32_t message = ((code & FF_MESSAGE_CODE_MASK) << FF_MESSAGE_CODE_OFFSET) |
+                           ((data & FF_MESSAGE_DATA_MASK) << FF_MESSAGE_DATA_OFFSET);
+        xQueueSendToBack(xFFlyQueueIn, &message, pdMS_TO_TICKS(10));
+        snprintf(m + copied, SCRATCH_SIZE - copied,
+                 "%s: write val 0x%x to register 0x%x, FF %d.\r\n", argv[0], value, regnum,
+                 channel);
+
+      } // end regw
+      else {
+        snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s not understood\r\n", argv[0],
+                 argv[1]);
+        return pdFALSE;
+      }
+    } // argc == 5
+    else {
+      snprintf(m + copied, SCRATCH_SIZE - copied, "%s: command %s not understood\r\n", argv[0],
+               argv[1]);
+      return pdFALSE;
+    }
+  }
+  return pdFALSE;
+}
+
+static BaseType_t ff_status(int argc, char **argv, char m)
+{
+  int copied = 0;
+
+  static int whichff = 0;
+  if (whichff == 0) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY STATUS:\r\n");
+  }
+  for (; whichff < 25; ++whichff) {
+    int8_t status = getFFstatus(whichff);
+    const char *name = getFFname(whichff);
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s %02d", name, status);
+
+    bool isTx = (strstr(name, "Tx") != NULL);
+    if (isTx)
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+    else
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+
+    if ((SCRATCH_SIZE - copied) < 20 && (whichff < 25)) {
+      ++whichff;
+      return pdTRUE;
+    }
+  }
+  whichff = 0;
+  return pdFALSE;
+}
+
+static BaseType_t fpga_ctl(int argc, char **argv, char m)
+{
+  if (argc == 2) {
+    if (strncmp(argv[1], "done", 4) == 0) { // print out value of done pins
+      int ku_done_ = read_gpio_pin(_K_FPGA_DONE);
+      int vu_done_ = read_gpio_pin(_V_FPGA_DONE);
+      snprintf(m, SCRATCH_SIZE, "KU_DONE* = %d\r\nVU_DONE* = %d\r\n", ku_done_, vu_done_);
+      return pdFALSE;
+    }
+    else {
+      snprintf(m, SCRATCH_SIZE, "%s: invalid command %s\r\n", argv[0], argv[1]);
+      return pdFALSE;
+    }
+  }
+  else if (argc != 1) {
+    // error, invalid
+    snprintf(m, SCRATCH_SIZE, "%s: invalid argument count %d\r\n", argv[0], argc);
+    return pdFALSE;
+  }
+  else {
+    int copied = 0;
+    static int whichfpga = 0;
+    int howmany = fpga_args.n_devices * fpga_args.n_pages;
+    if (whichfpga == 0) {
+      TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+      TickType_t last = pdTICKS_TO_MS(getFFupdateTick()) / 1000;
+      if ((now - last) > 60) {
+        int mins = (now - last) / 60;
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                           "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
+      }
+
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA monitors\r\n");
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s\r\n", fpga_args.commands[0].name);
+    }
+
+    for (; whichfpga < howmany; ++whichfpga) {
+      float val = fpga_args.pm_values[whichfpga];
+      int tens, frac;
+      float_to_ints(val, &tens, &frac);
+
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%5s: %02d.%02d",
+                         fpga_args.devices[whichfpga].name, tens, frac);
+      if (whichfpga % 2 == 1)
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+      else
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+      if ((SCRATCH_SIZE - copied) < 20) {
+        ++whichfpga;
+        return pdTRUE;
+      }
+    }
+    if (whichfpga % 2 == 1) {
+      m[copied++] = '\r';
+      m[copied++] = '\n';
+      m[copied] = '\0';
+    }
+    whichfpga = 0;
+    return pdFALSE;
+  }
+}
+
+static BaseType_t fpga_reset(int argc, char **argv, char m)
+{
+  int copied = 0;
+  const TickType_t delay = 1 / portTICK_PERIOD_MS; // 1 ms delay
+
+  if (strcmp(argv[1], "v") == 0) {
+    write_gpio_pin(V_FPGA_PROGRAM, 0x1);
+    vTaskDelay(delay);
+    write_gpio_pin(V_FPGA_PROGRAM, 0x0);
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "VU7P has been reset\r\n");
+  }
+  if (strcmp(argv[1], "k") == 0) {
+    write_gpio_pin(K_FPGA_PROGRAM, 0x1);
+    vTaskDelay(delay);
+    write_gpio_pin(K_FPGA_PROGRAM, 0x0);
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "KU15P has been reset\r\n");
+  }
+  return pdFALSE;
+}

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -10,7 +10,7 @@
 
 // this command takes no arguments since there is only one command
 // right now.
-static BaseType_t sensor_summary(int argc, char **argv, char m)
+BaseType_t sensor_summary(int argc, char **argv, char* m)
 {
   int copied = 0;
   // collect all sensor information
@@ -60,7 +60,7 @@ static BaseType_t sensor_summary(int argc, char **argv, char m)
 
 // send power control commands
 extern struct gpio_pin_t oks[];
-static BaseType_t power_ctl(int argc, char **argv,  char m)
+BaseType_t power_ctl(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
 
@@ -133,7 +133,7 @@ static BaseType_t power_ctl(int argc, char **argv,  char m)
 }
 
 // takes 1-2 arguments
-static BaseType_t alarm_ctl(int argc, char **argv, char m)
+BaseType_t alarm_ctl(int argc, char **argv, char* m)
 {
   int s = SCRATCH_SIZE;
   if (argc < 2) {
@@ -223,7 +223,7 @@ static BaseType_t alarm_ctl(int argc, char **argv, char m)
 }
 
 // send LED commands
-static BaseType_t led_ctl(int argc, char **argv, char m)
+BaseType_t led_ctl(int argc, char **argv, char* m)
 {
 
   BaseType_t i1 = strtol(argv[1], NULL, 10);
@@ -253,7 +253,7 @@ static BaseType_t led_ctl(int argc, char **argv, char m)
 }
 
 // this command takes no arguments
-static BaseType_t adc_ctl(int argc, char **argv, char m)
+BaseType_t adc_ctl(int argc, char **argv, char* m)
 {
   int copied = 0;
 
@@ -277,7 +277,7 @@ static BaseType_t adc_ctl(int argc, char **argv, char m)
 }
 
 // this command takes up to two arguments
-static BaseType_t ff_ctl(int argc, char **argv, char m)
+BaseType_t ff_ctl(int argc, char **argv, char* m)
 {
   // argument handling
   int copied = 0;
@@ -441,7 +441,7 @@ static BaseType_t ff_ctl(int argc, char **argv, char m)
   return pdFALSE;
 }
 
-static BaseType_t ff_status(int argc, char **argv, char m)
+BaseType_t ff_status(int argc, char **argv, char* m)
 {
   int copied = 0;
 
@@ -469,7 +469,7 @@ static BaseType_t ff_status(int argc, char **argv, char m)
   return pdFALSE;
 }
 
-static BaseType_t fpga_ctl(int argc, char **argv, char m)
+BaseType_t fpga_ctl(int argc, char **argv, char* m)
 {
   if (argc == 2) {
     if (strncmp(argv[1], "done", 4) == 0) { // print out value of done pins
@@ -531,7 +531,7 @@ static BaseType_t fpga_ctl(int argc, char **argv, char m)
   }
 }
 
-static BaseType_t fpga_reset(int argc, char **argv, char m)
+BaseType_t fpga_reset(int argc, char **argv, char* m)
 {
   int copied = 0;
   const TickType_t delay = 1 / portTICK_PERIOD_MS; // 1 ms delay

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -13,6 +13,7 @@
 static BaseType_t sensor_summary(int argc, char **argv, char m);
 
 // Power
+static BaseType_t psmon_ctl(int argc, char **argv, char m);
 static BaseType_t power_ctl(int argc, char **argv, char m);
 
 // Alarms

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -7,30 +7,29 @@
 
 #include <parameters.h>
 
-static BaseType_t sensor_summary(int argc, char **argv);
+#ifndef SENSOR_CONTROL_H_
+#define SENSOR_CONTROL_H_
+
+static BaseType_t sensor_summary(int argc, char **argv, char m);
 
 // Power
-static BaseType_t power_ctl(int argc, char **argv);
+static BaseType_t power_ctl(int argc, char **argv, char m);
 
 // Alarms
-static BaseType_t alarm_ctl(int argc, char **argv);
+static BaseType_t alarm_ctl(int argc, char **argv, char m);
 
 // LED
-static BaseType_t led_ctl(int argc, char **argv);
+static BaseType_t led_ctl(int argc, char **argv, char m);
 
 // ADC
-static BaseType_t adc_ctl(int argc, char **argv);
-
-// Bootloader
-static BaseType_t bl_ctl(int argc, char **argv);
-
-// Clock
-static BaseType_t clock_ctl(int argc, char **argv);
+static BaseType_t adc_ctl(int argc, char **argv, char m);
 
 // Fireflies
-static BaseType_t ff_ctl(int argc, char **argv);
+static BaseType_t ff_ctl(int argc, char **argv, char m);
 static BaseType_t ff_status(int argc, char **argv);
 
 // FPGA
-static BaseType_t fpga_ctl(int argc, char **argv);
-static BaseType_t fpga_reset(int argc, char **argv);
+static BaseType_t fpga_ctl(int argc, char **argv, char m);
+static BaseType_t fpga_reset(int argc, char **argv, char m);
+
+#endif

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -5,32 +5,32 @@
  *      Author: fatimayousuf
  */
 
-#include <parameters.h>
+#include "parameters.h"
 
 #ifndef SENSOR_CONTROL_H_
 #define SENSOR_CONTROL_H_
 
-static BaseType_t sensor_summary(int argc, char **argv, char m);
+BaseType_t sensor_summary(int argc, char **argv, char* m);
 
 // Power
-static BaseType_t psmon_ctl(int argc, char **argv, char m);
-static BaseType_t power_ctl(int argc, char **argv, char m);
+BaseType_t psmon_ctl(int argc, char **argv, char* m);
+BaseType_t power_ctl(int argc, char **argv, char* m);
 
 // Alarms
-static BaseType_t alarm_ctl(int argc, char **argv, char m);
+BaseType_t alarm_ctl(int argc, char **argv, char* m);
 
 // LED
-static BaseType_t led_ctl(int argc, char **argv, char m);
+BaseType_t led_ctl(int argc, char **argv, char* m);
 
 // ADC
-static BaseType_t adc_ctl(int argc, char **argv, char m);
+BaseType_t adc_ctl(int argc, char **argv, char* m);
 
 // Fireflies
-static BaseType_t ff_ctl(int argc, char **argv, char m);
-static BaseType_t ff_status(int argc, char **argv);
+BaseType_t ff_ctl(int argc, char **argv, char* m);
+BaseType_t ff_status(int argc, char **argv, char* m);
 
 // FPGA
-static BaseType_t fpga_ctl(int argc, char **argv, char m);
-static BaseType_t fpga_reset(int argc, char **argv, char m);
+BaseType_t fpga_ctl(int argc, char **argv, char* m);
+BaseType_t fpga_reset(int argc, char **argv, char* m);
 
 #endif

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -1,0 +1,36 @@
+/*
+ * SensorControl.h
+ *
+ *  Created on: Jan 13, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <parameters.h>
+
+static BaseType_t sensor_summary(int argc, char **argv);
+
+// Power
+static BaseType_t power_ctl(int argc, char **argv);
+
+// Alarms
+static BaseType_t alarm_ctl(int argc, char **argv);
+
+// LED
+static BaseType_t led_ctl(int argc, char **argv);
+
+// ADC
+static BaseType_t adc_ctl(int argc, char **argv);
+
+// Bootloader
+static BaseType_t bl_ctl(int argc, char **argv);
+
+// Clock
+static BaseType_t clock_ctl(int argc, char **argv);
+
+// Fireflies
+static BaseType_t ff_ctl(int argc, char **argv);
+static BaseType_t ff_status(int argc, char **argv);
+
+// FPGA
+static BaseType_t fpga_ctl(int argc, char **argv);
+static BaseType_t fpga_reset(int argc, char **argv);

--- a/projects/cm_mcu/commands/parameters.h
+++ b/projects/cm_mcu/commands/parameters.h
@@ -16,9 +16,51 @@
 #include "driverlib/sysctl.h"
 #include "driverlib/eeprom.h"
 
+// local includes
+#include "common/i2c_reg.h"
+#include "common/uart.h"
+#include "common/power_ctl.h"
+#include "common/pinsel.h"
+#include "common/smbus.h"
+#include "common/utils.h"
+#include "common/microrl.h"
+
+// FreeRTOS includes
+#include "FreeRTOSConfig.h"
+#include "FreeRTOS.h"
+#include "stream_buffer.h"
+#include "queue.h"
+
+// strlen, strtol, and strncpy
+#include <string.h>
+#include <stdlib.h>
+
+// TivaWare includes
+#include "driverlib/uart.h"
+
+#include "MonitorTask.h"
+#include "CommandLineTask.h"
+#include "I2CCommunication.h"
+#include "Tasks.h"
+#include "AlarmUtilities.h"
+
+#include "clocksynth.h"
+
 int snprintf(char *buf, unsigned int count, const char *format, ...);
 
 #define MAX_INPUT_LENGTH  50
 #define MAX_OUTPUT_LENGTH 512
+#define SCRATCH_SIZE 512
 
-
+extern tSMBus g_sMaster1;
+extern tSMBusStatus eStatus1;
+extern tSMBus g_sMaster2;
+extern tSMBusStatus eStatus2;
+extern tSMBus g_sMaster3;
+extern tSMBusStatus eStatus3;
+extern tSMBus g_sMaster4;
+extern tSMBusStatus eStatus4;
+extern tSMBus g_sMaster6;
+extern tSMBusStatus eStatus6;
+static tSMBus *p_sMaster = &g_sMaster4;
+static tSMBusStatus *p_eStatus = &eStatus4;

--- a/projects/cm_mcu/commands/parameters.h
+++ b/projects/cm_mcu/commands/parameters.h
@@ -52,15 +52,15 @@ int snprintf(char *buf, unsigned int count, const char *format, ...);
 #define MAX_OUTPUT_LENGTH 512
 #define SCRATCH_SIZE 512
 
-extern tSMBus g_sMaster1;
-extern tSMBusStatus eStatus1;
-extern tSMBus g_sMaster2;
-extern tSMBusStatus eStatus2;
-extern tSMBus g_sMaster3;
-extern tSMBusStatus eStatus3;
-extern tSMBus g_sMaster4;
-extern tSMBusStatus eStatus4;
-extern tSMBus g_sMaster6;
-extern tSMBusStatus eStatus6;
-static tSMBus *p_sMaster = &g_sMaster4;
-static tSMBusStatus *p_eStatus = &eStatus4;
+//extern tSMBus g_sMaster1;
+//extern tSMBusStatus eStatus1;
+//extern tSMBus g_sMaster2;
+//extern tSMBusStatus eStatus2;
+//extern tSMBus g_sMaster3;
+//extern tSMBusStatus eStatus3;
+//extern tSMBus g_sMaster4;
+//extern tSMBusStatus eStatus4;
+//extern tSMBus g_sMaster6;
+//extern tSMBusStatus eStatus6;
+//tSMBus *p_sMaster = &g_sMaster4;
+//tSMBusStatus *p_eStatus = &eStatus4;

--- a/projects/cm_mcu/commands/parameters.h
+++ b/projects/cm_mcu/commands/parameters.h
@@ -46,21 +46,32 @@
 
 #include "clocksynth.h"
 
+#ifdef DEBUG_CON
+// prototype of mutex'd print
+#define DPRINT(x) Print(x)
+#else // DEBUG_CON
+#define DPRINT(x)
+#endif // DEBUG_CON
+
+void Print(const char *str);
+
+// local sprintf prototype
 int snprintf(char *buf, unsigned int count, const char *format, ...);
 
 #define MAX_INPUT_LENGTH  50
 #define MAX_OUTPUT_LENGTH 512
 #define SCRATCH_SIZE 512
 
-//extern tSMBus g_sMaster1;
-//extern tSMBusStatus eStatus1;
-//extern tSMBus g_sMaster2;
-//extern tSMBusStatus eStatus2;
-//extern tSMBus g_sMaster3;
-//extern tSMBusStatus eStatus3;
-//extern tSMBus g_sMaster4;
-//extern tSMBusStatus eStatus4;
-//extern tSMBus g_sMaster6;
-//extern tSMBusStatus eStatus6;
-//tSMBus *p_sMaster = &g_sMaster4;
-//tSMBusStatus *p_eStatus = &eStatus4;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat" // because of our mini-sprintf
+
+extern tSMBus g_sMaster1;
+extern tSMBusStatus eStatus1;
+extern tSMBus g_sMaster2;
+extern tSMBusStatus eStatus2;
+extern tSMBus g_sMaster3;
+extern tSMBusStatus eStatus3;
+extern tSMBus g_sMaster4;
+extern tSMBusStatus eStatus4;
+extern tSMBus g_sMaster6;
+extern tSMBusStatus eStatus6;

--- a/projects/cm_mcu/commands/parameters.h
+++ b/projects/cm_mcu/commands/parameters.h
@@ -1,0 +1,24 @@
+/*
+ * parameters.h
+ *
+ *  Created on: Jan 13, 2021
+ *      Author: fatimayousuf
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "inc/hw_types.h"
+#include "inc/hw_memmap.h"
+#include "inc/hw_nvic.h"
+#include "driverlib/rom.h"
+#include "driverlib/rom_map.h"
+#include "driverlib/systick.h"
+#include "driverlib/sysctl.h"
+#include "driverlib/eeprom.h"
+
+int snprintf(char *buf, unsigned int count, const char *format, ...);
+
+#define MAX_INPUT_LENGTH  50
+#define MAX_OUTPUT_LENGTH 512
+
+


### PR DESCRIPTION
Resolves #84 

- Broke out all the commands from the command line task into separate files in the commands folder. This was to make the code for the command line task more readable and simple
- The parameters file holds some common includes and constraints for the command line task (i.e how many characters can be printed out, max input length, etc).