### PR TITLE
Clang build

### DIFF
--- a/driverlib/cpu.c
+++ b/driverlib/cpu.c
@@ -47,7 +47,7 @@
 // on entry.
 //
 //*****************************************************************************
-#if defined(codered) || defined(gcc) || defined(sourcerygxx)
+#if defined(codered) || defined(gcc) || defined(sourcerygxx) 
 uint32_t __attribute__((naked))
 CPUcpsid(void)
 {
@@ -68,6 +68,19 @@ CPUcpsid(void)
     // naked attribute).
     //
     return(ui32Ret);
+}
+#endif
+#if defined(clang)
+uint32_t __attribute__((naked)) CPUcpsid(void)
+{
+
+  //
+  // Read PRIMASK and disable interrupts.
+  //
+  __asm("    mrs     r0, PRIMASK\n"
+        "    cpsid   i\n"
+        "    bx      lr\n");
+// TODO: does this return the right value?
 }
 #endif
 #if defined(ewarm)
@@ -207,7 +220,7 @@ CPUprimask(void)
 // on entry.
 //
 //*****************************************************************************
-#if defined(codered) || defined(gcc) || defined(sourcerygxx)
+#if defined(codered) || defined(gcc) || defined(sourcerygxx) 
 uint32_t __attribute__((naked))
 CPUcpsie(void)
 {
@@ -228,6 +241,18 @@ CPUcpsie(void)
     // naked attribute).
     //
     return(ui32Ret);
+}
+#endif
+#if defined(clang)
+uint32_t __attribute__((naked)) CPUcpsie(void)
+{
+
+  //
+  // Read PRIMASK and enable interrupts.
+  //
+  __asm("    mrs     r0, PRIMASK\n"
+        "    cpsie   i\n"
+        "    bx      lr\n");
 }
 #endif
 #if defined(ewarm)
@@ -288,7 +313,7 @@ CPUcpsie(void)
 // Wrapper function for the WFI instruction.
 //
 //*****************************************************************************
-#if defined(codered) || defined(gcc) || defined(sourcerygxx)
+#if defined(codered) || defined(gcc) || defined(sourcerygxx) || defined(clang)
 void __attribute__((naked))
 CPUwfi(void)
 {
@@ -336,7 +361,7 @@ CPUwfi(void)
 // Wrapper function for writing the BASEPRI register.
 //
 //*****************************************************************************
-#if defined(codered) || defined(gcc) || defined(sourcerygxx)
+#if defined(codered) || defined(gcc) || defined(sourcerygxx) || defined(clang)
 void __attribute__((naked))
 CPUbasepriSet(uint32_t ui32NewBasepri)
 {
@@ -404,6 +429,16 @@ CPUbasepriGet(void)
     // naked attribute).
     //
     return(ui32Ret);
+}
+#endif
+#if defined(clang)
+uint32_t __attribute__((naked)) CPUbasepriGet(void)
+{
+  //
+  // Read BASEPRI
+  //
+  __asm("    mrs     r0, BASEPRI\n"
+        "    bx      lr\n");
 }
 #endif
 #if defined(ewarm)

--- a/driverlib/sysctl.c
+++ b/driverlib/sysctl.c
@@ -1834,7 +1834,7 @@ SysCtlDelay(uint32_t ui32Count)
           "    bx      lr");
 }
 #endif
-#if defined(codered) || defined(gcc) || defined(sourcerygxx)
+#if defined(codered) || defined(gcc) || defined(sourcerygxx) || defined(clang)
 void __attribute__((naked))
 SysCtlDelay(uint32_t ui32Count)
 {

--- a/makedefs
+++ b/makedefs
@@ -205,39 +205,49 @@ SIZE=llvm-size
 CPU=--target=armv7m-none-eabi -mcpu=cortex-m4
 FPU=-mfpu=fpv4-sp-d16 -mfloat-abi=hard #-mfp16-format=ieee
 
-CFLAGS=             \
-       ${CPU}              \
-       ${FPU}              \
-       -ffunction-sections \
-       -fdata-sections     \
-       -MD                 \
-       -std=c11            \
-       -DPART_${PART}      \
-       --sysroot=/usr/local/arm-none-eabi \
-       -Wall -pedantic \
+## THESE BELOW GET CALLED FROM GCC
+##
+GCC=arm-none-eabi-gcc
+# tell CLANG where the appropriate header files are 
+SYSROOT=${shell ${GCC} --print-sysroot}
+
+CFLAGS=                     \
+       ${CPU}               \
+       ${FPU}               \
+       -ffunction-sections  \
+       -fdata-sections      \
+       -MD                  \
+       -std=c11             \
+       -DPART_${PART}       \
+       --sysroot=${SYSROOT} \
+       -Wall                \
+	   -pedantic            \
        -c
 
 ifdef DEBUG
 CFLAGS+=-g -D DEBUG -O0
 else
-CFLAGS+=-Os 
+CFLAGS+=-Oz 
 endif
 
 ## THESE BELOW GET CALLED FROM GCC
+##
+GCC=arm-none-eabi-gcc
+GCC_CFLAGS=
 #
 # Get the location of libgcc.a from the GCC front-end.
 #
-LIBGCC=${shell ${CC} ${CFLAGS} -print-libgcc-file-name}
+LIBGCC=${shell ${GCC} ${GCC_CFLAGS} -print-libgcc-file-name}
 
 #
 # Get the location of libc.a from the GCC front-end.
 #
-LIBC=${shell ${CC} ${CFLAGS} -print-file-name=libc.a}
+LIBC=${shell ${GCC} ${GCC_CFLAGS} -print-file-name=libc.a}
 
 #
 # Get the location of libm.a from the GCC front-end.
 #
-LIBM=${shell ${CC} ${CFLAGS} -print-file-name=libm.a}
+LIBM=${shell ${GCC} ${GCC_CFLAGS} -print-file-name=libm.a}
 
 
 #
@@ -331,7 +341,7 @@ ${COMPILER}${SUFFIX}/%.axf:
 	          ${LDFLAGSgcc_${notdir ${@:.axf=}}}                          \
 	          ${LDFLAGS} -o ${@} $(filter %.o %.a, ${^})                  \
 	          '${LIBM}' '${LIBC}' '${LIBGCC}';                            \
-	     echo ${SIZE} ${@} ;                                                 \
+	     echo ${SIZE} ${@} ;                                              \
 	 fi;                                                                  \
 	${LD} -T $${ldname}                                                   \
 	      --entry ${ENTRY_${notdir ${@:.axf=}}}                           \

--- a/makedefs
+++ b/makedefs
@@ -205,6 +205,13 @@ SIZE=llvm-size
 CPU=--target=armv7m-none-eabi -mcpu=cortex-m4
 FPU=-mfpu=fpv4-sp-d16 -mfloat-abi=hard #-mfp16-format=ieee
 
+#
+# The flags passed to the assembler.
+#
+AFLAGS=-mthumb \
+       ${CPU}  \
+       ${FPU}  \
+       -MD
 ## THESE BELOW GET CALLED FROM GCC
 ##
 GCC=arm-none-eabi-gcc

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -1,6 +1,6 @@
 
 
-DIRS=boot_loader blinky uart_echo cm_mcu #i2c-sensors 
+DIRS=boot_loader cm_mcu #i2c-sensors 
 
 DIRSCLEAN=$(addsuffix .clean,$(DIRS))
 

--- a/projects/boot_loader/bl_link.ld
+++ b/projects/boot_loader/bl_link.ld
@@ -48,4 +48,12 @@ SECTIONS
         *(COMMON)
         _ebss = .;
     }
+    /* Stuff that isn't needed for an embedded system */
+    /DISCARD/ :
+    {
+        *(.init*)
+        *(.fini*)
+        *(.ARM.exidx)
+    }
+
 }

--- a/projects/boot_loader/bl_main.c
+++ b/projects/boot_loader/bl_main.c
@@ -159,7 +159,7 @@ uint8_t *g_pui8DataBuffer;
 #include <intrinsics.h>
 #define SwapWord(x)             __REV(x)
 #endif
-#if defined(codered) || defined(gcc) || defined(sourcerygxx)
+#if defined(codered) || defined(gcc) || defined(sourcerygxx) || defined(clang)
 #define SwapWord(x) __extension__                                             \
     ({                                                                    \
   register uint32_t __ret, __inp = x;                              \

--- a/projects/boot_loader/bl_startup_clang.S
+++ b/projects/boot_loader/bl_startup_clang.S
@@ -1,0 +1,663 @@
+//*****************************************************************************
+//
+// bl_startup_gcc.S - Startup code for GNU.
+//
+// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+// Texas Instruments (TI) is supplying this software for use solely and
+// exclusively on TI's microcontroller products. The software is owned by
+// TI and/or its suppliers, and is protected under applicable copyright
+// laws. You may not combine this software with "viral" open-source
+// software in order to form a larger program.
+// 
+// THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
+// NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
+// NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
+// CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
+// DAMAGES, FOR ANY REASON WHATSOEVER.
+// 
+// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Include the assember definitions used to make this code compiler
+// independent.
+//
+//*****************************************************************************
+#include "inc/hw_nvic.h"
+#include "inc/hw_sysctl.h"
+#include "bl_config.h"
+
+//*****************************************************************************
+//
+// Put the assembler into the correct configuration.
+//
+//*****************************************************************************
+    .syntax unified
+    .thumb
+
+//*****************************************************************************
+//
+// The stack gets placed into the zero-init section.
+//
+//*****************************************************************************
+    .bss
+
+//*****************************************************************************
+//
+// Allocate storage for the stack.
+//
+//*****************************************************************************
+g_pulStack:
+    .space  STACK_SIZE * 4
+
+//*****************************************************************************
+//
+// This portion of the file goes into the text section.
+//
+//*****************************************************************************
+    .section .isr_vector
+
+//*****************************************************************************
+//
+// The minimal vector table for a Cortex-M3 processor.
+//
+//*****************************************************************************
+Vectors:
+    .word   g_pulStack + (STACK_SIZE * 4)   // Offset 00: Initial stack pointer
+    .word   ResetISR - 0x20000000           // Offset 04: Reset handler
+    .word   NmiSR - 0x20000000              // Offset 08: NMI handler
+    .word   FaultISR - 0x20000000           // Offset 0C: Hard fault handler
+    .word   IntDefaultHandler               // Offset 10: MPU fault handler
+    .word   IntDefaultHandler               // Offset 14: Bus fault handler
+    .word   IntDefaultHandler               // Offset 18: Usage fault handler
+    .word   0                               // Offset 1C: Reserved
+    .word   0                               // Offset 20: Reserved
+    .word   0                               // Offset 24: Reserved
+    .word   0                               // Offset 28: Reserved
+    .word   UpdateHandler - 0x20000000      // Offset 2C: SVCall handler
+    .word   IntDefaultHandler               // Offset 30: Debug monitor handler
+    .word   0                               // Offset 34: Reserved
+    .word   IntDefaultHandler               // Offset 38: PendSV handler
+#if defined(ENET_ENABLE_UPDATE)
+    .extern SysTickIntHandler
+    .word   SysTickIntHandler               // Offset 3C: SysTick handler
+#else
+    .word   IntDefaultHandler               // Offset 3C: SysTick handler
+#endif
+#if defined(UART_ENABLE_UPDATE) && defined(UART_AUTOBAUD)
+    .extern GPIOIntHandler
+    .word   GPIOIntHandler                  // Offset 40: GPIO port A handler
+#else
+    .word   IntDefaultHandler               // Offset 40: GPIO port A handler
+#endif
+#if (defined(USB_ENABLE_UPDATE) ||                                            \
+     (APP_START_ADDRESS != VTABLE_START_ADDRESS))
+    .word   IntDefaultHandler               // Offset 44: GPIO Port B
+    .word   IntDefaultHandler               // Offset 48: GPIO Port C
+    .word   IntDefaultHandler               // Offset 4C: GPIO Port D
+    .word   IntDefaultHandler               // Offset 50: GPIO Port E
+    .word   IntDefaultHandler               // Offset 54: UART0 Rx and Tx
+    .word   IntDefaultHandler               // Offset 58: UART1 Rx and Tx
+    .word   IntDefaultHandler               // Offset 5C: SSI0 Rx and Tx
+    .word   IntDefaultHandler               // Offset 60: I2C0 Master and Slave
+    .word   IntDefaultHandler               // Offset 64: PWM Fault
+    .word   IntDefaultHandler               // Offset 68: PWM Generator 0
+    .word   IntDefaultHandler               // Offset 6C: PWM Generator 1
+    .word   IntDefaultHandler               // Offset 70: PWM Generator 2
+    .word   IntDefaultHandler               // Offset 74: Quadrature Encoder 0
+    .word   IntDefaultHandler               // Offset 78: ADC Sequence 0
+    .word   IntDefaultHandler               // Offset 7C: ADC Sequence 1
+    .word   IntDefaultHandler               // Offset 80: ADC Sequence 2
+    .word   IntDefaultHandler               // Offset 84: ADC Sequence 3
+    .word   IntDefaultHandler               // Offset 88: Watchdog timer
+    .word   IntDefaultHandler               // Offset 8C: Timer 0 subtimer A
+    .word   IntDefaultHandler               // Offset 90: Timer 0 subtimer B
+    .word   IntDefaultHandler               // Offset 94: Timer 1 subtimer A
+    .word   IntDefaultHandler               // Offset 98: Timer 1 subtimer B
+    .word   IntDefaultHandler               // Offset 9C: Timer 2 subtimer A
+    .word   IntDefaultHandler               // Offset A0: Timer 2 subtimer B
+    .word   IntDefaultHandler               // Offset A4: Analog Comparator 0
+    .word   IntDefaultHandler               // Offset A8: Analog Comparator 1
+    .word   IntDefaultHandler               // Offset AC: Analog Comparator 2
+    .word   IntDefaultHandler               // Offset B0: System Control
+    .word   IntDefaultHandler               // Offset B4: FLASH Control
+#endif
+#if (defined(USB_ENABLE_UPDATE) || (APP_START_ADDRESS != VTABLE_START_ADDRESS))
+    .word   IntDefaultHandler               // Offset B8: GPIO Port F
+    .word   IntDefaultHandler               // Offset BC: GPIO Port G
+    .word   IntDefaultHandler               // Offset C0: GPIO Port H
+    .word   IntDefaultHandler               // Offset C4: UART2 Rx and Tx
+    .word   IntDefaultHandler               // Offset C8: SSI1 Rx and Tx
+    .word   IntDefaultHandler               // Offset CC: Timer 3 subtimer A
+    .word   IntDefaultHandler               // Offset D0: Timer 3 subtimer B
+    .word   IntDefaultHandler               // Offset D4: I2C1 Master and Slave
+#if (defined(TARGET_IS_TM4C129_RA0) || defined(TARGET_IS_TM4C129_RA1) ||      \
+     defined(TARGET_IS_TM4C129_RA2))
+    .word   IntDefaultHandler               // Offset D8: CAN0
+    .word   IntDefaultHandler               // Offset DC: CAN1
+    .word   IntDefaultHandler               // Offset E0: Ethernet
+    .word   IntDefaultHandler               // Offset E4: Hibernation module
+#if defined(USB_ENABLE_UPDATE)
+    .extern USB0DeviceIntHandler
+    .word   USB0DeviceIntHandler            // Offset E8: USB 0 Controller
+#else
+    .word   IntDefaultHandler               // Offset E8: USB 0 Controller
+#endif
+    .word   IntDefaultHandler               // Offset EC: PWM Generator 3
+    .word   IntDefaultHandler               // Offset F0: uDMA 0 Software
+#else
+    .word   IntDefaultHandler               // Offset D8: Quadrature Encoder 1
+    .word   IntDefaultHandler               // Offset DC: CAN0
+    .word   IntDefaultHandler               // Offset E0: CAN1
+    .word   IntDefaultHandler               // Offset E4: CAN2
+    .word   IntDefaultHandler               // Offset E8: Ethernet
+    .word   IntDefaultHandler               // Offset EC: Hibernation module
+#if defined(USB_ENABLE_UPDATE)
+    .extern USB0DeviceIntHandler
+    .word   USB0DeviceIntHandler            // Offset F0: USB 0 Controller
+#else
+    .word   IntDefaultHandler               // Offset F0: USB 0 Controller
+#endif
+#endif
+#endif
+
+//*****************************************************************************
+//
+// This portion of the file goes into the text section.
+//
+//*****************************************************************************
+    .text
+
+//*****************************************************************************
+//
+// Initialize the processor by copying the boot loader from flash to SRAM, zero
+// filling the .bss section, and moving the vector table to the beginning of
+// SRAM.  The return address is modified to point to the SRAM copy of the boot
+// loader instead of the flash copy, resulting in a branch to the copy now in
+// SRAM.
+//
+//*****************************************************************************
+    .thumb_func
+ProcessorInit:
+    //
+    // Copy the code image from flash to SRAM.
+    //
+    movs    r0, #0x0000
+    movs    r1, #0x0000
+    movt    r1, #0x2000
+    .extern _bss
+    ldr     r2, =_bss
+copy_loop:
+        ldr     r3, [r0], #4
+        str     r3, [r1], #4
+        cmp     r1, r2
+        blt     copy_loop
+
+    //
+    // Zero fill the .bss section.
+    //
+    movs    r0, #0x0000
+    .extern _ebss
+    ldr     r2, =_ebss
+zero_loop:
+        str     r0, [r1], #4
+        cmp     r1, r2
+        blt     zero_loop
+
+    //
+    // Set the vector table pointer to the beginning of SRAM.
+    //
+    movw    r0, #(NVIC_VTABLE & 0xffff)
+    movt    r0, #(NVIC_VTABLE >> 16)
+    movs    r1, #0x0000
+    movt    r1, #0x2000
+    str     r1, [r0]
+
+    //
+    // Set the return address to the code just copied into SRAM.
+    //
+    orr     lr, lr, #0x20000000
+
+    //
+    // Return to the caller.
+    //
+    bx      lr
+
+//*****************************************************************************
+//
+// The reset handler, which gets called when the processor starts.
+//
+//*****************************************************************************
+    .globl  ResetISR
+    .thumb_func
+ResetISR:
+    //
+    // Enable the floating-point unit.  This must be done here in case any
+    // later C functions use floating point.  Note that some toolchains will
+    // use the FPU registers for general workspace even if no explicit floating
+    // point data types are in use.
+    //
+    movw    r0, #0xED88
+    movt    r0, #0xE000
+    ldr     r1, [r0]
+    orr     r1, r1, #0x00F00000
+    str     r1, [r0]
+
+    //
+    // Initialize the processor.
+    //
+    bl      ProcessorInit
+
+    //
+    // Call the user-supplied low level hardware initialization function
+    // if provided.
+    //
+#ifdef BL_HW_INIT_FN_HOOK
+    .extern BL_HW_INIT_FN_HOOK
+    bl      BL_HW_INIT_FN_HOOK
+#endif
+
+    //
+    // See if an update should be performed.
+    //
+    .extern CheckForceUpdate
+    bl      CheckForceUpdate
+    cbz     r0, CallApplication
+
+    //
+    // Configure the microcontroller.
+    //
+    .thumb_func
+EnterBootLoader:
+#ifdef ENET_ENABLE_UPDATE
+    .extern ConfigureEnet
+    bl      ConfigureEnet
+#elif defined(CAN_ENABLE_UPDATE)
+    .extern ConfigureCAN
+    bl      ConfigureCAN
+#elif defined(USB_ENABLE_UPDATE)
+    .extern ConfigureUSB
+    bl      ConfigureUSB
+//#else
+// Not used in Apollo as of v0.20
+//   .extern ConfigureDevice
+//    bl      ConfigureDevice
+#endif
+
+    //
+    // Call the user-supplied initialization function if provided.
+    //
+#ifdef BL_INIT_FN_HOOK
+    .extern BL_INIT_FN_HOOK
+    bl      BL_INIT_FN_HOOK
+#endif
+
+    //
+    // Branch to the update handler.
+    //
+#ifdef ENET_ENABLE_UPDATE
+    .extern UpdateBOOTP
+    b       UpdateBOOTP
+#elif defined(CAN_ENABLE_UPDATE)
+    .extern UpdaterCAN
+    b       UpdaterCAN
+#elif defined(USB_ENABLE_UPDATE)
+    .extern UpdaterUSB
+    b       UpdaterUSB
+#else
+    .extern Updater
+    b       Updater
+#endif
+
+    //
+    // This is a second symbol to allow starting the application from the boot
+    // loader the linker may not like the perceived jump.
+    //
+    .globl  StartApplication
+    .thumb_func
+StartApplication:
+    //
+    // Call the application via the reset handler in its vector table.  Load
+    // the address of the application vector table.
+    //
+    .thumb_func
+CallApplication:
+    //
+    // Copy the application's vector table to the target address if necessary.
+    // Note that incorrect boot loader configuration could cause this to
+    // corrupt the code!  Setting VTABLE_START_ADDRESS to 0x20000000 (the start
+    // of SRAM) is safe since this will use the same memory that the boot
+    // loader already uses for its vector table.  Great care will have to be
+    // taken if other addresses are to be used.
+    //
+#if (APP_START_ADDRESS != VTABLE_START_ADDRESS)
+    movw    r0, #(VTABLE_START_ADDRESS & 0xffff)
+#if (VTABLE_START_ADDRESS > 0xffff)
+    movt    r0, #(VTABLE_START_ADDRESS >> 16)
+#endif
+    movw    r1, #(APP_START_ADDRESS & 0xffff)
+#if (APP_START_ADDRESS > 0xffff)
+    movt    r1, #(APP_START_ADDRESS >> 16)
+#endif
+
+    //
+    // Calculate the end address of the vector table assuming that it has the
+    // maximum possible number of vectors.  We don't know how many the app has
+    // populated so this is the safest approach though it may copy some non
+    // vector data if the app table is smaller than the maximum.
+    //
+    movw    r2, #(70 * 4)
+    adds    r2, r2, r0
+VectorCopyLoop:
+        ldr     r3, [r1], #4
+        str     r3, [r0], #4
+        cmp     r0, r2
+        blt     VectorCopyLoop
+#endif
+
+    //
+    // Set the application's vector table start address.  Typically this is the
+    // application start address but in some cases an application may relocate
+    // this so we can't assume that these two addresses are equal.
+    //
+    movw    r0, #(VTABLE_START_ADDRESS & 0xffff)
+#if (VTABLE_START_ADDRESS > 0xffff)
+    movt    r0, #(VTABLE_START_ADDRESS >> 16)
+#endif
+    movw    r1, #(NVIC_VTABLE & 0xffff)
+    movt    r1, #(NVIC_VTABLE >> 16)
+    str     r0, [r1]
+
+    //
+    // Load the stack pointer from the application's vector table.
+    //
+#if (APP_START_ADDRESS != VTABLE_START_ADDRESS)
+    movw    r0, #(APP_START_ADDRESS & 0xffff)
+#if (APP_START_ADDRESS > 0xffff)
+    movt    r0, #(APP_START_ADDRESS >> 16)
+#endif
+#endif
+    ldr     sp, [r0]
+
+    //
+    // Load the initial PC from the application's vector table and branch to
+    // the application's entry point.
+    //
+    ldr     r0, [r0, #4]
+    bx      r0
+
+//*****************************************************************************
+//
+// The update handler, which gets called when the application would like to
+// start an update.
+//
+//*****************************************************************************
+    .thumb_func
+UpdateHandler:
+    //
+    // Initialize the processor.
+    //
+    bl      ProcessorInit
+
+    //
+    // Load the stack pointer from the vector table.
+    //
+    movs    r0, #0x0000
+    ldr     sp, [r0]
+
+    //
+    // Call the user-supplied low level hardware initialization function
+    // if provided.
+    //
+#ifdef BL_HW_INIT_FN_HOOK
+    bl      BL_HW_INIT_FN_HOOK
+#endif
+
+    //
+    // Call the user-supplied re-initialization function if provided.
+    //
+#ifdef BL_REINIT_FN_HOOK
+    .extern BL_REINIT_FN_HOOK
+    bl      BL_REINIT_FN_HOOK
+#endif
+
+    //
+    // Branch to the update handler.
+    //
+#ifdef ENET_ENABLE_UPDATE
+    b       UpdateBOOTP
+#elif defined(CAN_ENABLE_UPDATE)
+    .extern AppUpdaterCAN
+    b       AppUpdaterCAN
+#elif defined(USB_ENABLE_UPDATE)
+    .extern AppUpdaterUSB
+    b       AppUpdaterUSB
+#else
+    b       Updater
+#endif
+
+//*****************************************************************************
+//
+// The NMI handler.
+//
+//*****************************************************************************
+    .thumb_func
+NmiSR:
+#ifdef ENABLE_MOSCFAIL_HANDLER
+    //
+    // Grab the fault frame from the stack (the stack will be cleared by the
+    // processor initialization that follows).
+    //
+    ldm     sp, {r4-r11}
+    mov     r12, lr
+
+    //
+    // Initialize the processor.
+    //
+    bl      ProcessorInit
+
+    //
+    // Restore the stack frame.
+    //
+    mov     lr, r12
+    stm     sp, {r4-r11}
+
+    //
+    // Save the link register.
+    //
+    mov     r9, lr
+
+    //
+    // Call the user-supplied low level hardware initialization function
+    // if provided.
+    //
+#ifdef BL_HW_INIT_FN_HOOK
+    bl      BL_HW_INIT_FN_HOOK
+#endif
+
+    //
+    // See if an update should be performed.
+    //
+    bl      CheckForceUpdate
+    cbz     r0, EnterApplication
+
+        //
+        // Clear the MOSCFAIL bit in RESC.
+        //
+        movw    r0, #(SYSCTL_RESC & 0xffff)
+        movt    r0, #(SYSCTL_RESC >> 16)
+        ldr     r1, [r0]
+        bic     r1, r1, #SYSCTL_RESC_MOSCFAIL
+        str     r1, [r0]
+
+        //
+        // Fix up the PC on the stack so that the boot pin check is bypassed
+        // (since it has already been performed).
+        //
+        ldr     r0, =EnterBootLoader
+        bic     r0, #0x00000001
+        str     r0, [sp, #0x18]
+
+        //
+        // Return from the NMI handler.  This will then start execution of the
+        // boot loader.
+        //
+        bx      r9
+
+    //
+    // Restore the link register.
+    //
+    .thumb_func
+EnterApplication:
+    mov     lr, r9
+
+    //
+    // Copy the application's vector table to the target address if necessary.
+    // Note that incorrect boot loader configuration could cause this to
+    // corrupt the code!  Setting VTABLE_START_ADDRESS to 0x20000000 (the start
+    // of SRAM) is safe since this will use the same memory that the boot
+    // loader already uses for its vector table.  Great care will have to be
+    // taken if other addresses are to be used.
+    //
+#if (APP_START_ADDRESS != VTABLE_START_ADDRESS)
+    movw    r0, #(VTABLE_START_ADDRESS & 0xffff)
+#if (VTABLE_START_ADDRESS > 0xffff)
+    movt    r0, #(VTABLE_START_ADDRESS >> 16)
+#endif
+    movw    r1, #(APP_START_ADDRESS & 0xffff)
+#if (APP_START_ADDRESS > 0xffff)
+    movt    r1, #(APP_START_ADDRESS >> 16)
+#endif
+
+    //
+    // Calculate the end address of the vector table assuming that it has the
+    // maximum possible number of vectors.  We don't know how many the app has
+    // populated so this is the safest approach though it may copy some non
+    // vector data if the app table is smaller than the maximum.
+    //
+    movw    r2, #(70 * 4)
+    adds    r2, r2, r0
+VectorCopyLoop2:
+        ldr     r3, [r1], #4
+        str     r3, [r0], #4
+        cmp     r0, r2
+        blt     VectorCopyLoop2
+#endif
+
+    //
+    // Set the application's vector table start address.  Typically this is the
+    // application start address but in some cases an application may relocate
+    // this so we can't assume that these two addresses are equal.
+    //
+    movw    r0, #(VTABLE_START_ADDRESS & 0xffff)
+#if (VTABLE_START_ADDRESS > 0xffff)
+    movt    r0, #(VTABLE_START_ADDRESS >> 16)
+#endif
+    movw    r1, #(NVIC_VTABLE & 0xffff)
+    movt    r1, #(NVIC_VTABLE >> 16)
+    str     r0, [r1]
+
+    //
+    // Remove the NMI stack frame from the boot loader's stack.
+    //
+    ldmia   sp, {r4-r11}
+
+    //
+    // Get the application's stack pointer.
+    //
+#if (APP_START_ADDRESS != VTABLE_START_ADDRESS)
+    movw    r0, #(APP_START_ADDRESS & 0xffff)
+#if (APP_START_ADDRESS > 0xffff)
+    movt    r0, #(APP_START_ADDRESS >> 16)
+#endif
+#endif
+    ldr     sp, [r0, #0x00]
+
+    //
+    // Fix up the NMI stack frame's return address to be the reset handler of
+    // the application.
+    //
+    ldr     r10, [r0, #0x04]
+    bic     r10, #0x00000001
+
+    //
+    // Store the NMI stack frame onto the application's stack.
+    //
+    stmdb   sp!, {r4-r11}
+
+    //
+    // Branch to the application's NMI handler.
+    //
+    ldr     r0, [r0, #0x08]
+    bx      r0
+#else
+    //
+    // Loop forever since there is nothing that we can do about a NMI.
+    //
+    b       .
+#endif
+
+//*****************************************************************************
+//
+// The hard fault handler.
+//
+//*****************************************************************************
+    .thumb_func
+FaultISR:
+    //
+    // Loop forever since there is nothing that we can do about a hard fault.
+    //
+    b       .
+
+//*****************************************************************************
+//
+// The default interrupt handler.
+//
+//*****************************************************************************
+    .thumb_func
+IntDefaultHandler:
+    //
+    // Loop forever since there is nothing that we can do about an unexpected
+    // interrupt.
+    //
+    b       .
+
+//*****************************************************************************
+//
+// Provides a small delay.  The loop below takes 3 cycles/loop.
+//
+//*****************************************************************************
+    .globl  Delay
+    .thumb_func
+Delay:
+    subs    r0, #1
+    bne     Delay
+    bx      lr
+
+//*****************************************************************************
+// Updated loop: turn on RED LED before going into an infinite loop
+// address of GPIO pin data register for the RED LED 
+// we use address bits a[9:2] to mask which bits are written (here only bit position 1)
+// see TM4C1290NCPDT data sheet section 10.3.1.2 "Data Register Operation" 
+//*****************************************************************************
+#define RED_LED_GPIO_WHICH_BIT 0x2 // (0x1<<1) // pin 1 
+#define GPIO_PORTP_DATA_BITS_R 0x40065000
+#define RED_LED_GPIO_DATA_BITS (GPIO_PORTP_DATA_BITS_R | (RED_LED_GPIO_WHICH_BIT<<2))
+    .thumb_func
+IntDefHandler2:
+    ldr r4, =RED_LED_GPIO_DATA_BITS // register address 
+    ldr r5, =RED_LED_GPIO_WHICH_BIT // which bit to turn on 
+    str r5, [r4] // toggle bit on
+    b       . // loop forever 
+
+//*****************************************************************************
+//
+// This is the end of the file.
+//
+//*****************************************************************************
+    .end

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -29,6 +29,12 @@ endif
 CFLAGS+=-Wno-pointer-compare ## for configASSERT macro
 #CFLAGS+=-fstack-protector 
 
+ifeq (${COMPILER}, clang)
+## for clang complaining about FreeRTOS code
+## this is not the right way to solve this
+#CFLAGS+=-Wno-int-in-bool-context
+endif
+
 #
 # Where to find source files that do not live in this directory.
 #

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -32,7 +32,7 @@ CFLAGS+=-Wno-pointer-compare ## for configASSERT macro
 ifeq (${COMPILER}, clang)
 ## for clang complaining about FreeRTOS code
 ## this is not the right way to solve this
-#CFLAGS+=-Wno-int-in-bool-context
+CFLAGS+=-Wno-int-in-bool-context
 endif
 
 #

--- a/projects/cm_mcu/cm_mcu.ld
+++ b/projects/cm_mcu/cm_mcu.ld
@@ -55,4 +55,12 @@ SECTIONS
         *(COMMON)
         _ebss = .;
     } > SRAM
+    /* Stuff that isn't needed for an embedded system */
+    /DISCARD/ :
+    {
+        *(.init*)
+        *(.fini*)
+        *(.ARM.exidx)
+    }
+
 }

--- a/projects/cm_mcu/startup_clang.c
+++ b/projects/cm_mcu/startup_clang.c
@@ -1,0 +1,393 @@
+/**
+ * startup.c : TM4C startup code for use with the GNU Build System
+ * (Will likely work with other Tiva/Stellaris boards as well)
+ *
+ * With credit to:
+ *     Lukasz Janyst (bit.ly/2pxKw8x)
+ *     TI's TivaWare
+ *     The uctools Project (bit.ly/2oIRO9y)
+ *
+ * Author:   Rahul Butani
+ * Modified: March 4th, 2019
+ */
+// from here:
+// https://github.com/rrbutani/tm4c-llvm-toolchain
+
+// Dependencies:
+#include <stdint.h>
+
+#include "inc/hw_types.h"
+#include "inc/hw_nvic.h"
+
+#include "FreeRTOSConfig.h"
+#include "InterruptHandlers.h"
+
+
+        // Prototypes/Declarations:
+void ResetISR(void);
+static void IntDefaultHandler(void);
+
+//*****************************************************************************
+//
+// Reserve space for the system stack.
+//
+//*****************************************************************************
+static uint32_t pui32Stack[SYSTEM_STACK_SIZE];
+
+const uint32_t *getSystemStack()
+{
+  return pui32Stack;
+}
+
+//
+// Macros: 
+
+// Macro to create a weakly aliased placeholder interrupt that points to the
+// default interrupt handler.
+// This allows us to define proper strongly defined interrupt handlers
+// anywhere in the project and have them override the default interrupt
+// handler (taken care of by the linker) without us having to edit this file.
+#define DEFINE_HANDLER(NAME)                                                                       \
+  void NAME##_handler() __attribute__((used, weak, alias("__default_int_handler")))
+
+// Macro to generate function name of an aliased placeholder interrupt.
+// (Generating these allows us to avoid hardcoding the function names)
+#define HANDLER(NAME) NAME##_handler
+
+// Define weakly aliased interrupt handlers:
+
+// Reset is a special case:
+void ResetISR() __attribute__((used, weak));
+
+DEFINE_HANDLER(NmiSR);
+DEFINE_HANDLER(HardFault);
+DEFINE_HANDLER(mman);
+DEFINE_HANDLER(bus_fault);
+DEFINE_HANDLER(usage_fault);
+DEFINE_HANDLER(vPortSVCHandler);
+DEFINE_HANDLER(debug_monitor);
+DEFINE_HANDLER(xPortPendSVHandler);
+DEFINE_HANDLER(xPortSysTickHandler);
+
+DEFINE_HANDLER(gpio_porta);
+DEFINE_HANDLER(gpio_portb);
+DEFINE_HANDLER(gpio_portc);
+DEFINE_HANDLER(gpio_portd);
+DEFINE_HANDLER(gpio_porte);
+DEFINE_HANDLER(uart0);
+DEFINE_HANDLER(UART1IntHandler);
+DEFINE_HANDLER(ssi0);
+DEFINE_HANDLER(I2CSlave0Interrupt);
+DEFINE_HANDLER(pwm0_fault);
+DEFINE_HANDLER(pwm0_gen0);
+DEFINE_HANDLER(pwm0_gen1);
+DEFINE_HANDLER(pwm0_gen2);
+DEFINE_HANDLER(qei0);
+DEFINE_HANDLER(adc0_seq0);
+DEFINE_HANDLER(ADCSeq1Interrupt);
+DEFINE_HANDLER(adc0_seq2);
+DEFINE_HANDLER(adc0_seq3);
+DEFINE_HANDLER(watchdog);
+DEFINE_HANDLER(timer0a_32);
+DEFINE_HANDLER(timer0b_32);
+DEFINE_HANDLER(timer1a_32);
+DEFINE_HANDLER(timer1b_32);
+DEFINE_HANDLER(timer2a_32);
+DEFINE_HANDLER(timer2b_32);
+DEFINE_HANDLER(analog_comp0);
+DEFINE_HANDLER(analog_comp1);
+DEFINE_HANDLER(sysctl);
+DEFINE_HANDLER(flashctl);
+DEFINE_HANDLER(gpio_portf);
+DEFINE_HANDLER(uart2);
+DEFINE_HANDLER(ssi1);
+DEFINE_HANDLER(timer3a_32);
+DEFINE_HANDLER(timer3b_32);
+DEFINE_HANDLER(i2c1);
+DEFINE_HANDLER(qei1);
+DEFINE_HANDLER(can0);
+DEFINE_HANDLER(can1);
+DEFINE_HANDLER(hibernation);
+DEFINE_HANDLER(usb);
+DEFINE_HANDLER(pwm0_gen3);
+DEFINE_HANDLER(udma_soft);
+DEFINE_HANDLER(udma_error);
+DEFINE_HANDLER(adc1_seq0);
+DEFINE_HANDLER(adc1_seq1);
+DEFINE_HANDLER(adc1_seq2);
+DEFINE_HANDLER(adc1_seq3);
+DEFINE_HANDLER(ssi2);
+DEFINE_HANDLER(ssi3);
+DEFINE_HANDLER(uart3);
+DEFINE_HANDLER(uart4);
+DEFINE_HANDLER(uart5);
+DEFINE_HANDLER(uart6);
+DEFINE_HANDLER(uart7);
+DEFINE_HANDLER(i2c2);
+DEFINE_HANDLER(i2c3);
+DEFINE_HANDLER(timer4a_32);
+DEFINE_HANDLER(timer4b_32);
+DEFINE_HANDLER(timer5a_32);
+DEFINE_HANDLER(timer5b_32);
+DEFINE_HANDLER(timer0a_64);
+DEFINE_HANDLER(timer0b_64);
+DEFINE_HANDLER(timer1a_64);
+DEFINE_HANDLER(timer1b_64);
+DEFINE_HANDLER(timer2a_64);
+DEFINE_HANDLER(timer2b_64);
+DEFINE_HANDLER(timer3a_64);
+DEFINE_HANDLER(timer3b_64);
+DEFINE_HANDLER(timer4a_64);
+DEFINE_HANDLER(timer4b_64);
+DEFINE_HANDLER(timer5a_64);
+DEFINE_HANDLER(timer5b_64);
+DEFINE_HANDLER(sysexcept);
+DEFINE_HANDLER(pwm1_gen0);
+DEFINE_HANDLER(pwm1_gen1);
+DEFINE_HANDLER(pwm1_gen2);
+DEFINE_HANDLER(pwm1_gen3);
+DEFINE_HANDLER(pwm1_fault);
+
+// The Nested Vectored Interrupt Controller (NVIC) Table:
+// Mark with .nvic_table (as in the linker script) so it'll be placed correctly
+void (*nvic_table[])(void) __attribute__((used, section(".isr_vector"))) = {
+    ResetISR,               // The reset handler
+    HANDLER(NmiSR),         // The NMI handler
+    HardFault_handler,      // The hard fault handler -- was FaultISR
+    IntDefaultHandler,      // The MPU fault handler
+    IntDefaultHandler,      // The bus fault handler
+    IntDefaultHandler,      // The usage fault handler
+    0,                      // Reserved
+    0,                      // Reserved
+    0,                      // Reserved
+    0,                      // Reserved
+    vPortSVCHandler,        // SVCall handler
+    IntDefaultHandler,      // Debug monitor handler
+    0,                      // Reserved
+    xPortPendSVHandler,     // The PendSV handler
+    xPortSysTickHandler,    // The SysTick handler
+    IntDefaultHandler,      // GPIO Port A
+    IntDefaultHandler,      // GPIO Port B
+    IntDefaultHandler,      // GPIO Port C
+    IntDefaultHandler,      // GPIO Port D
+    IntDefaultHandler,      // GPIO Port E
+    IntDefaultHandler,      // UART0 Rx and Tx
+    UART1IntHandler,        // UART1 Rx and Tx -- ZYNQ UART
+    IntDefaultHandler,      // SSI0 Rx and Tx
+    I2CSlave0Interrupt,     // I2C0 Master and Slave
+    IntDefaultHandler,      // PWM Fault
+    IntDefaultHandler,      // PWM Generator 0
+    IntDefaultHandler,      // PWM Generator 1
+    IntDefaultHandler,      // PWM Generator 2
+    IntDefaultHandler,      // Quadrature Encoder 0
+    IntDefaultHandler,      // ADC Sequence 0
+    ADCSeq1Interrupt,       // ADC Sequence 1
+    IntDefaultHandler,      // ADC Sequence 2
+    IntDefaultHandler,      // ADC Sequence 3
+    IntDefaultHandler,      // Watchdog timer
+    Timer0AIntHandler,      // Timer 0 subtimer A
+    IntDefaultHandler,      // Timer 0 subtimer B
+    IntDefaultHandler,      // Timer 1 subtimer A
+    IntDefaultHandler,      // Timer 1 subtimer B
+    IntDefaultHandler,      // Timer 2 subtimer A
+    IntDefaultHandler,      // Timer 2 subtimer B
+    IntDefaultHandler,      // Analog Comparator 0
+    IntDefaultHandler,      // Analog Comparator 1
+    IntDefaultHandler,      // Analog Comparator 2
+    IntDefaultHandler,      // System Control (PLL, OSC, BO)
+    IntDefaultHandler,      // FLASH Control
+    IntDefaultHandler,      // GPIO Port F
+    IntDefaultHandler,      // GPIO Port G
+    IntDefaultHandler,      // GPIO Port H
+    IntDefaultHandler,      // UART2 Rx and Tx
+    IntDefaultHandler,      // SSI1 Rx and Tx
+    IntDefaultHandler,      // Timer 3 subtimer A
+    IntDefaultHandler,      // Timer 3 subtimer B
+    SMBusMasterIntHandler1, // I2C1 Master and Slave
+    IntDefaultHandler,      // CAN0
+    IntDefaultHandler,      // CAN1
+    IntDefaultHandler,      // Ethernet
+    IntDefaultHandler,      // Hibernate
+    IntDefaultHandler,      // USB0
+    IntDefaultHandler,      // PWM Generator 3
+    IntDefaultHandler,      // uDMA Software Transfer
+    IntDefaultHandler,      // uDMA Error
+    ADCSeq0Interrupt,       // ADC1 Sequence 0
+    IntDefaultHandler,      // ADC1 Sequence 1
+    IntDefaultHandler,      // ADC1 Sequence 2
+    IntDefaultHandler,      // ADC1 Sequence 3
+    IntDefaultHandler,      // External Bus Interface 0
+    IntDefaultHandler,      // GPIO Port J
+    IntDefaultHandler,      // GPIO Port K
+    IntDefaultHandler,      // GPIO Port L
+    IntDefaultHandler,      // SSI2 Rx and Tx
+    IntDefaultHandler,      // SSI3 Rx and Tx
+    IntDefaultHandler,      // UART3 Rx and Tx
+    UART4IntHandler,        // UART4 Rx and Tx -- FRONT PANEL
+    IntDefaultHandler,      // UART5 Rx and Tx
+    IntDefaultHandler,      // UART6 Rx and Tx
+    IntDefaultHandler,      // UART7 Rx and Tx
+    SMBusMasterIntHandler2, // I2C2 Master and Slave
+    SMBusMasterIntHandler3, // I2C3 Master and Slave
+    IntDefaultHandler,      // Timer 4 subtimer A
+    IntDefaultHandler,      // Timer 4 subtimer B
+    IntDefaultHandler,      // Timer 5 subtimer A
+    IntDefaultHandler,      // Timer 5 subtimer B
+    IntDefaultHandler,      // FPU
+    0,                      // Reserved
+    0,                      // Reserved
+    SMBusMasterIntHandler4, // I2C4 Master and Slave
+    IntDefaultHandler,      // I2C5 Master and Slave
+    IntDefaultHandler,      // GPIO Port M
+    IntDefaultHandler,      // GPIO Port N
+    0,                      // Reserved
+    IntDefaultHandler,      // Tamper
+    IntDefaultHandler,      // GPIO Port P (Summary or P0)
+    IntDefaultHandler,      // GPIO Port P1
+    IntDefaultHandler,      // GPIO Port P2
+    IntDefaultHandler,      // GPIO Port P3
+    IntDefaultHandler,      // GPIO Port P4
+    IntDefaultHandler,      // GPIO Port P5
+    IntDefaultHandler,      // GPIO Port P6
+    IntDefaultHandler,      // GPIO Port P7
+    IntDefaultHandler,      // GPIO Port Q (Summary or Q0)
+    IntDefaultHandler,      // GPIO Port Q1
+    IntDefaultHandler,      // GPIO Port Q2
+    IntDefaultHandler,      // GPIO Port Q3
+    IntDefaultHandler,      // GPIO Port Q4
+    IntDefaultHandler,      // GPIO Port Q5
+    IntDefaultHandler,      // GPIO Port Q6
+    IntDefaultHandler,      // GPIO Port Q7
+    IntDefaultHandler,      // GPIO Port R
+    IntDefaultHandler,      // GPIO Port S
+    IntDefaultHandler,      // SHA/MD5 0
+    IntDefaultHandler,      // AES 0
+    IntDefaultHandler,      // DES3DES 0
+    IntDefaultHandler,      // LCD Controller 0
+    IntDefaultHandler,      // Timer 6 subtimer A
+    IntDefaultHandler,      // Timer 6 subtimer B
+    IntDefaultHandler,      // Timer 7 subtimer A
+    IntDefaultHandler,      // Timer 7 subtimer B
+    SMBusMasterIntHandler6, // I2C6 Master and Slave
+    IntDefaultHandler,      // I2C7 Master and Slave
+    IntDefaultHandler,      // HIM Scan Matrix Keyboard 0
+    IntDefaultHandler,      // One Wire 0
+    IntDefaultHandler,      // HIM PS/2 0
+    IntDefaultHandler,      // HIM LED Sequencer 0
+    IntDefaultHandler,      // HIM Consumer IR 0
+    IntDefaultHandler,      // I2C8 Master and Slave
+    IntDefaultHandler,      // I2C9 Master and Slave
+    IntDefaultHandler       // GPIO Port T
+};
+
+// External Links:
+
+// // Link to linker symbols (memory boundaries)
+// // text : __text_start_vma :: __text_end_vma
+// // data : __data_start_vma :: __data_end_vma
+// // bss  : __bss_start_vma  ::   _bss_end_vma
+// // (see tm4c.ld for more details)
+// extern unsigned long __text_start_vma;
+// extern unsigned long __text_end_vma;
+// extern unsigned long __data_start_vma;
+// extern unsigned long __data_end_vma;
+// extern unsigned long __bss_start_vma;
+// extern unsigned long __bss_end_vma;
+
+//*****************************************************************************
+//
+// The following are constructs created by the linker, indicating where the
+// the "data" and "bss" segments reside in memory.  The initializers for the
+// for the "data" segment resides immediately following the "text" segment.
+//
+//*****************************************************************************
+extern uint32_t _ldata;
+extern uint32_t _data;
+extern uint32_t _edata;
+extern uint32_t _bss;
+extern uint32_t _ebss;
+
+// Link to project's entry point
+extern int main();
+
+// Interrupt Handlers:
+
+// Declare a dummy interrupt handler that does nothing (essentially gets
+// trapped in a loop). This works as the default interrupt handler as it
+// retains the system state and stops execution when it is called; this
+// interrupt handler will only ever be called if an unexpected interrupt
+// (i.e. one that does not have a strongly defined interrupt handler) is
+// triggered.
+void __default_int_handler(void)
+{
+  while (1)
+    ;
+}
+
+// A default reset handler. Configured in the same manner as the default
+// handler above (ResetISR() is weakly aliased to this function) so
+// that (if needed) this function can be overriden in a project using this
+// file (shouldn't be necessary though).
+void __default_rst_handler(void) {
+  uint32_t *pui32Src, *pui32Dest;
+
+  //
+  // Copy the data segment initializers from flash to SRAM.
+  //
+  pui32Src = &_ldata;
+  for (pui32Dest = &_data; pui32Dest < &_edata;) {
+    *pui32Dest++ = *pui32Src++;
+  }
+  //
+  // Zero fill the bss segment.
+  //
+  __asm("    ldr     r0, =_bss\n"
+        "    ldr     r1, =_ebss\n"
+        "    mov     r2, #0\n"
+        "    .thumb_func\n"
+        "zero_loop:\n"
+        "        cmp     r0, r1\n"
+        "        it      lt\n"
+        "        strlt   r2, [r0], #4\n"
+        "        blt     zero_loop");
+  // Put a canary on the system stack
+  pui32Dest = pui32Stack;
+  for (; pui32Dest < (pui32Stack + sizeof(pui32Stack) / sizeof(uint32_t));) {
+    *pui32Dest++ = 0xDEADBEEFUL;
+  }
+
+  //
+  // Enable the floating-point unit.  This must be done here to handle the
+  // case where main() uses floating-point and the function prologue saves
+  // floating-point registers (which will fault if floating-point is not
+  // enabled).  Any configuration of the floating-point unit using DriverLib
+  // APIs must be done here prior to the floating-point unit being enabled.
+  //
+  ROM_FPULazyStackingEnable();
+  // Note that this does not use DriverLib since it might not be included in
+  // this project.
+  //
+  HWREG(NVIC_CPAC) = ((HWREG(NVIC_CPAC) & ~(NVIC_CPAC_CP10_M | NVIC_CPAC_CP11_M)) |
+                      NVIC_CPAC_CP10_FULL | NVIC_CPAC_CP11_FULL);
+
+  //
+  // Call the application's entry point.
+  //
+  main();
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives an unexpected
+// interrupt.  This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+static void IntDefaultHandler(void)
+{
+  //
+  // Go into an infinite loop.
+  //
+  while (1) {
+  }
+}


### PR DESCRIPTION
update the code base to allow a clang build to complete. 

**Note that the resulting binary has not been tested**

the main purpose of this compiler path is to allow building with clang and its better static code analysis tools and warnings compared to gcc. 