### PR TITLE
Hotfix for issues running on Rev1

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -587,7 +587,9 @@ static struct command_t commands[] = {
     {"alm", alarm_ctl, "args: (clear|status|settemp #)\r\nGet or clear status of alarm task.\r\n",
      -1},
     {"bootloader", bl_ctl, "Call the boot loader\r\n", 0},
+#ifdef REV2
     {"clkmon", clkmon_ctl, "Displays a table showing the clock chips' statuses given the clock chip id option\r\n", 1},
+#endif // REV2
     {"clock", clock_ctl,
      "args: (1|2)\r\nReset (1) or program the clock synthesizer to 156.25 MHz (2).\r\n", 1},
     {"eeprom_info", eeprom_info, "Prints information about the EEPROM.\r\n", 0},

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -31,7 +31,6 @@ void InitTask(void *parameters)
   ROM_SysCtlResetCauseClear(r);
   errbuffer_put(EBUF_RESTART, restart_reason);
   log_info(LOG_SERVICE, "REC register=0x%08x\r\n", restart_reason);
-  init_registers_ff(); // initalize I/O expander for fireflies -- with FF monitoring via I2C in other threads, it grabs semaphore inside
 
 // wait for 3.3V power to come up. Wait indefinitely.
 // in Rev1 the clocks cannot be accessed before the 3.3 V is on.
@@ -40,6 +39,7 @@ void InitTask(void *parameters)
     vTaskDelay(pdMS_TO_TICKS(1000));
   }
 #endif                  // REV1
+  init_registers_ff();  // initalize I/O expander for fireflies -- with FF monitoring via I2C in other threads, it grabs semaphore inside
   init_registers_clk(); // initalize I/O expander for clocks
   log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");
 #ifdef REV2

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -102,13 +102,23 @@ struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES] = {
 #endif
 
 // FFDAQ arguments for monitoring i2c task of 4-channel firefly ports connected to FPGA1
-
+#ifdef REV1
+struct dev_moni2c_addr_t ffldaq_f1_moni2c_addrs[NFIREFLIES_DAQ_F1] = {
+    {"K04 4 XCVR GTY", FF_I2CMUX_2_ADDR, 0, 0x50}, //
+    {"K05 4 XCVR GTY", FF_I2CMUX_2_ADDR, 1, 0x50}, //
+    {"K06 4 XCVR GTY", FF_I2CMUX_2_ADDR, 2, 0x50}, //
+};
+#elif defined(REV2)
 struct dev_moni2c_addr_t ffldaq_f1_moni2c_addrs[NFIREFLIES_DAQ_F1] = {
     {"F1_4 4 XCVR", FF_I2CMUX_1_ADDR, 2, 0x50}, //
     {"F1_5 4 XCVR", FF_I2CMUX_2_ADDR, 0, 0x50}, //
     {"F1_6 4 XCVR", FF_I2CMUX_2_ADDR, 1, 0x50}, //
     {"F1_7 4 XCVR", FF_I2CMUX_2_ADDR, 2, 0x50}, //
 };
+#else
+#error "Define either Rev1 or Rev2"
+#endif
+
 struct sm_command_t sm_command_ffldaq_f1[] = {
     {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
     {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
@@ -116,6 +126,7 @@ struct sm_command_t sm_command_ffldaq_f1[] = {
     {1, 0x00, 0x05, 1, "FF_CDR_LOL_ALARM", 0xff, "", PM_STATUS},
 
 };
+
 uint16_t ffldaq_f1_values[NSUPPLIES_FFLDAQ_F1 * NCOMMANDS_FFLDAQ_F1];
 
 struct MonitorI2CTaskArgs_t ffldaq_f1_args = {
@@ -154,6 +165,18 @@ struct sm_command_t sm_command_fflot_f1[] = {
 
 };
 
+#ifdef REV1
+struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1] = {
+    {"K01  12 Tx GTH", FF_I2CMUX_1_ADDR, 0, 0x50}, //
+    {"K01  12 Rx GTH", FF_I2CMUX_1_ADDR, 1, 0x54}, //
+    {"K02  12 Tx GTH", FF_I2CMUX_1_ADDR, 2, 0x50}, //
+    {"K02  12 Rx GTH", FF_I2CMUX_1_ADDR, 3, 0x54}, //
+    {"K03  12 Tx GTH", FF_I2CMUX_1_ADDR, 4, 0x50}, //
+    {"K03  12 Rx GTH", FF_I2CMUX_1_ADDR, 5, 0x54}, //
+    {"K07  12 Tx GTY", FF_I2CMUX_2_ADDR, 3, 0x50}, //
+    {"K07  12 Rx GTY", FF_I2CMUX_2_ADDR, 4, 0x54}, //
+};
+#elif defined(REV2)
 struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1] = {
     {"F1_1  12 Tx",
      FF_I2CMUX_1_ADDR, 0, 0x50},                //
@@ -163,6 +186,9 @@ struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1] = {
     {"F1_3  12 Tx", FF_I2CMUX_2_ADDR, 3, 0x50}, //
     {"F1_3  12 Rx", FF_I2CMUX_2_ADDR, 4, 0x54}, //
 };
+#else
+#error "Define either Rev1 or Rev2"
+#endif
 
 uint16_t ffl12_f1_values[NSUPPLIES_FFL12_F1 * NCOMMANDS_FFL12_F1];
 
@@ -183,13 +209,29 @@ struct MonitorI2CTaskArgs_t ffl12_f1_args = {
 };
 
 // FFDAQV arguments for monitoring i2c task of 4-channel firefly ports connected to FPGA2
-
+#ifdef REV1
+struct dev_moni2c_addr_t ffldaq_f2_moni2c_addrs[NFIREFLIES_DAQ_F2] = {
+    {"V01 4 XCVR GTY", FF_I2CMUX_1_ADDR, 0, 0x50}, //
+    {"V02 4 XCVR GTY", FF_I2CMUX_1_ADDR, 1, 0x50}, //
+    {"V03 4 XCVR GTY", FF_I2CMUX_1_ADDR, 2, 0x50}, //
+    {"V04 4 XCVR GTY", FF_I2CMUX_1_ADDR, 3, 0x50}, //
+    {"V05 4 XCVR GTY", FF_I2CMUX_1_ADDR, 4, 0x50}, //
+    {"V06 4 XCVR GTY", FF_I2CMUX_1_ADDR, 5, 0x50}, //
+    {"V07 4 XCVR GTY", FF_I2CMUX_2_ADDR, 0, 0x50}, //
+    {"V08 4 XCVR GTY", FF_I2CMUX_2_ADDR, 1, 0x50}, //
+    {"V09 4 XCVR GTY", FF_I2CMUX_2_ADDR, 2, 0x50}, //
+    {"V10 4 XCVR GTY", FF_I2CMUX_2_ADDR, 3, 0x50}, //
+};
+#elif defined(REV2)
 struct dev_moni2c_addr_t ffldaq_f2_moni2c_addrs[NFIREFLIES_DAQ_F2] = {
     {"F2_4 4 XCVR", FF_I2CMUX_1_ADDR, 2, 0x50}, //
     {"F2_5 4 XCVR", FF_I2CMUX_2_ADDR, 0, 0x50}, //
     {"F2_6 4 XCVR", FF_I2CMUX_2_ADDR, 1, 0x50}, //
     {"F2_7 4 XCVR", FF_I2CMUX_2_ADDR, 2, 0x50}, //
 };
+#else
+#error "Define either Rev1 or Rev2"
+#endif
 
 struct sm_command_t sm_command_ffldaq_f2[] = {
     {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
@@ -236,6 +278,15 @@ struct sm_command_t sm_command_fflot_f2[] = {
 
 };
 
+
+#ifdef REV1
+struct dev_moni2c_addr_t ffl12_f2_moni2c_addrs[NFIREFLIES_IT_F2] = {
+    {"V11  12 Tx GTY", FF_I2CMUX_1_ADDR, 6, 0x50}, //
+    {"V11  12 Rx GTY", FF_I2CMUX_1_ADDR, 7, 0x54}, //
+    {"V12  12 Tx GTY", FF_I2CMUX_2_ADDR, 4, 0x50}, //
+    {"V12  12 Rx GTY", FF_I2CMUX_2_ADDR, 5, 0x54}, //
+};
+#elif defined(REV2)
 struct dev_moni2c_addr_t ffl12_f2_moni2c_addrs[NFIREFLIES_IT_F2] = {
     {"F2_1  12 Tx", FF_I2CMUX_1_ADDR, 0, 0x50}, //
     {"F2_1  12 Rx", FF_I2CMUX_1_ADDR, 1, 0x54}, //
@@ -244,6 +295,9 @@ struct dev_moni2c_addr_t ffl12_f2_moni2c_addrs[NFIREFLIES_IT_F2] = {
     {"F2_3  12 Tx", FF_I2CMUX_2_ADDR, 3, 0x50}, //
     {"F2_3  12 Rx", FF_I2CMUX_2_ADDR, 4, 0x54}, //
 };
+#else
+#error "Define either Rev1 or Rev2"
+#endif
 
 uint16_t ffl12_f2_values[NSUPPLIES_FFL12_F2 * NCOMMANDS_FFL12_F2];
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -136,8 +136,8 @@ struct dev_moni2c_addr_t ffldaq_f1_moni2c_addrs[NFIREFLIES_DAQ_F1] = {
 #endif
 
 struct sm_command_t sm_command_ffldaq_f1[] = {
-    {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
-    {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
+    {1, 0x00, 0x02, 2, "FF_STATUS_REG", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {1, 0x00, 0x03, 1, "FF_LOS_ALARM", 0xff, "", PM_STATUS},
     {1, 0x00, 0x05, 1, "FF_CDR_LOL_ALARM", 0xff, "", PM_STATUS},
 
@@ -165,8 +165,8 @@ struct MonitorI2CTaskArgs_t ffldaq_f1_args = {
 
 // register maps for IT-DTC Fireflies 12-ch part -- future will be CERN-B but currently is 14Gbps ECUO
 struct sm_command_t sm_command_fflit_f1[] = {
-    {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
-    {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
+    {1, 0x00, 0x02, 2, "FF_STATUS_REG", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
@@ -174,8 +174,8 @@ struct sm_command_t sm_command_fflit_f1[] = {
 // register maps for OT-DTC Fireflies 12-ch part -- 25Gbps ECUO (no connected devices to test as of 08.04.22)
 // **commands below have not been tested yet**
 struct sm_command_t sm_command_fflot_f1[] = {
-    {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
-    {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
+    {1, 0x00, 0x02, 2, "FF_STATUS_REG", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
@@ -250,8 +250,8 @@ struct dev_moni2c_addr_t ffldaq_f2_moni2c_addrs[NFIREFLIES_DAQ_F2] = {
 #endif
 
 struct sm_command_t sm_command_ffldaq_f2[] = {
-    {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
-    {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
+    {1, 0x00, 0x02, 2, "FF_STATUS_REG", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {1, 0x00, 0x03, 1, "FF_LOS_ALARM", 0xff, "", PM_STATUS},
     {1, 0x00, 0x05, 1, "FF_CDR_LOL_ALARM", 0xff, "", PM_STATUS},
 
@@ -278,8 +278,8 @@ struct MonitorI2CTaskArgs_t ffldaq_f2_args = {
 
 // register maps for IT-DTC Fireflies 12-ch part -- future will be CERN-B but currently is 14Gbps ECUO
 struct sm_command_t sm_command_fflit_f2[] = {
-    {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
-    {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
+    {1, 0x00, 0x02, 2, "FF_STATUS_REG", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
@@ -287,8 +287,8 @@ struct sm_command_t sm_command_fflit_f2[] = {
 // register maps for OT-DTC Fireflies 12-ch part -- 25Gbps ECUO (no connected devices to test as of 08.04.22)
 // **commands below have not been tested yet**
 struct sm_command_t sm_command_fflot_f2[] = {
-    {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
-    {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
+    {1, 0x00, 0x02, 2, "FF_STATUS_REG", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -167,8 +167,8 @@ struct MonitorI2CTaskArgs_t ffldaq_f1_args = {
 struct sm_command_t sm_command_fflit_f1[] = {
     {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
     {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
-    {2, 0x00, 0x07, 2, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
-    {2, 0x00, 0x14, 2, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
 };
 // register maps for OT-DTC Fireflies 12-ch part -- 25Gbps ECUO (no connected devices to test as of 08.04.22)
@@ -176,8 +176,8 @@ struct sm_command_t sm_command_fflit_f1[] = {
 struct sm_command_t sm_command_fflot_f1[] = {
     {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
     {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
-    {2, 0x00, 0x07, 2, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
-    {2, 0x00, 0x14, 2, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
 };
 
@@ -280,8 +280,8 @@ struct MonitorI2CTaskArgs_t ffldaq_f2_args = {
 struct sm_command_t sm_command_fflit_f2[] = {
     {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
     {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
-    {2, 0x00, 0x07, 2, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
-    {2, 0x00, 0x14, 2, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
 };
 // register maps for OT-DTC Fireflies 12-ch part -- 25Gbps ECUO (no connected devices to test as of 08.04.22)
@@ -289,8 +289,8 @@ struct sm_command_t sm_command_fflit_f2[] = {
 struct sm_command_t sm_command_fflot_f2[] = {
     {1, 0x00, 0x02, 1, "FF_STATUS_REG", 0xff, "", PM_STATUS},
     {1, 0x00, 0x16, 1, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
-    {2, 0x00, 0x07, 2, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
-    {2, 0x00, 0x14, 2, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
 
 };
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -963,6 +963,8 @@ void init_registers_ff()
 
   // =====================================================
   // CMv1 Schematic 4.06 I2C VU7P OPTICS
+  while (xSemaphoreTake(ffldaq_f2_args.xSem, (TickType_t)10) == pdFALSE)
+    ;
 
   // 5a) U103 inputs vs. outputs (I2C address 0x20 on I2C channel #3)
   // All signals are inputs.
@@ -995,6 +997,10 @@ void init_registers_ff()
   apollo_i2c_ctl_w(3, 0x72, 1, 0x04);
   apollo_i2c_ctl_reg_w(3, 0x22, 1, 0x06, 1, 0xff); // 11111111 [P07..P00]
   apollo_i2c_ctl_reg_w(3, 0x22, 1, 0x07, 1, 0xf0); // 11110000 [P17..P10]
+  xSemaphoreGive(ffldaq_f2_args.xSem);
+
+  while (xSemaphoreTake(ffldaq_f1_args.xSem, (TickType_t)10) == pdFALSE)
+    ;
 
   // 7b) U6 default output values (I2C address 0x22 on I2C channel #3)
   // The outputs on P10 and P11 should default to "1".

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -68,6 +68,15 @@ struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES] = {
     {"V12  12 Tx GTY", FF_I2CMUX_2_ADDR, 4, 0x50}, //
     {"V12  12 Rx GTY", FF_I2CMUX_2_ADDR, 5, 0x54}, //
 };
+
+struct arg_moni2c_ff_t ff_moni2c_arg[NFIREFLY_ARG] = {
+    {"FFL12", &ffl12_f1_args, 0, 0, 6}, //
+    {"FFLDAQ", &ffldaq_f1_args, 6, 0, 3}, //
+    {"FFL12", &ffl12_f1_args, 9, 6, 2}, //
+    {"FFLDAQ", &ffldaq_f2_args, 11, 0, 10}, //
+    {"FFL12", &ffl12_f2_args, 21, 0, 4}, //
+};
+
 #elif defined(REV2)
 // -------------------------------------------------
 //
@@ -96,6 +105,13 @@ struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES] = {
     {"F2_6 4 XCVR", FF_I2CMUX_2_ADDR, 1, 0x50}, //
     {"F2_7 4 XCVR", FF_I2CMUX_2_ADDR, 2, 0x50}, //
 
+};
+
+struct arg_moni2c_ff_t ff_moni2c_arg[NFIREFLY_ARG] = {
+    {"FFL12", &ffl12_f1_args, 0, 0, 6}, //
+    {"FFLDAQ", &ffldaq_f1_args, 6, 0, 4}, //
+    {"FFL12", &ffl12_f2_args, 10, 0, 6}, //
+    {"FFLDAQ", &ffldaq_f2_args, 16, 0, 4}, //
 };
 #else
 #error "Define either Rev1 or Rev2"
@@ -190,7 +206,9 @@ struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1] = {
 #error "Define either Rev1 or Rev2"
 #endif
 
+
 uint16_t ffl12_f1_values[NSUPPLIES_FFL12_F1 * NCOMMANDS_FFL12_F1];
+
 
 struct MonitorI2CTaskArgs_t ffl12_f1_args = {
     .name = "FF12",
@@ -491,6 +509,7 @@ void getFFpart()
 
   // checking the FF 12-ch part connected to FPGA1 (need to check from Rx devices (i.e devices[odd]))
   uint8_t data1;
+
   data1 = 0x1U << ffl12_f1_args.devices[3].mux_bit;
   log_debug(LOG_MONI2C, "Mux set to 0x%02x\r\n", data1);
   int rmux = apollo_i2c_ctl_w(ffl12_f1_args.i2c_dev, ffl12_f1_args.devices[3].mux_addr, 1, data1);

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -278,7 +278,6 @@ struct sm_command_t sm_command_fflot_f2[] = {
 
 };
 
-
 #ifdef REV1
 struct dev_moni2c_addr_t ffl12_f2_moni2c_addrs[NFIREFLIES_IT_F2] = {
     {"V11  12 Tx GTY", FF_I2CMUX_1_ADDR, 6, 0x50}, //

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -70,11 +70,11 @@ struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES] = {
 };
 
 struct arg_moni2c_ff_t ff_moni2c_arg[NFIREFLY_ARG] = {
-    {"FFL12", &ffl12_f1_args, 0, 0, 6}, //
-    {"FFLDAQ", &ffldaq_f1_args, 6, 0, 3}, //
-    {"FFL12", &ffl12_f1_args, 9, 6, 2}, //
+    {"FFL12", &ffl12_f1_args, 0, 0, 6},     //
+    {"FFLDAQ", &ffldaq_f1_args, 6, 0, 3},   //
+    {"FFL12", &ffl12_f1_args, 9, 6, 2},     //
     {"FFLDAQ", &ffldaq_f2_args, 11, 0, 10}, //
-    {"FFL12", &ffl12_f2_args, 21, 0, 4}, //
+    {"FFL12", &ffl12_f2_args, 21, 0, 4},    //
 };
 
 #elif defined(REV2)
@@ -108,9 +108,9 @@ struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES] = {
 };
 
 struct arg_moni2c_ff_t ff_moni2c_arg[NFIREFLY_ARG] = {
-    {"FFL12", &ffl12_f1_args, 0, 0, 6}, //
-    {"FFLDAQ", &ffldaq_f1_args, 6, 0, 4}, //
-    {"FFL12", &ffl12_f2_args, 10, 0, 6}, //
+    {"FFL12", &ffl12_f1_args, 0, 0, 6},    //
+    {"FFLDAQ", &ffldaq_f1_args, 6, 0, 4},  //
+    {"FFL12", &ffl12_f2_args, 10, 0, 6},   //
     {"FFLDAQ", &ffldaq_f2_args, 16, 0, 4}, //
 };
 #else
@@ -206,9 +206,7 @@ struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1] = {
 #error "Define either Rev1 or Rev2"
 #endif
 
-
 uint16_t ffl12_f1_values[NSUPPLIES_FFL12_F1 * NCOMMANDS_FFL12_F1];
-
 
 struct MonitorI2CTaskArgs_t ffl12_f1_args = {
     .name = "FF12",

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -37,14 +37,6 @@
 
 void Print(const char *str);
 
-// break out of loop, releasing semaphore if we have it
-
-#define release_break()         \
-  {                             \
-    xSemaphoreGive(args->xSem); \
-    break;                      \
-  }
-
 // read-only accessor functions for Firefly names and values.
 
 bool getFFch_low(uint8_t val, int channel)
@@ -139,7 +131,7 @@ void MonitorI2CTask(void *parameters)
       int res = apollo_i2c_ctl_w(args->i2c_dev, args->devices[ps].mux_addr, 1, data);
       if (res != 0) {
         log_warn(LOG_MONI2C, "Mux write error %s, break (instance=%s,ps=%d)\r\n", SMBUS_get_error(res), args->name, ps);
-        release_break();
+        break;
       }
 
       // Read I2C registers/commands
@@ -163,7 +155,7 @@ void MonitorI2CTask(void *parameters)
           log_warn(LOG_MONI2C, "%s read Error %s, break (ps=%d)\r\n",
                    args->commands[c].name, SMBUS_get_error(res), ps);
           args->sm_values[index] = 0xffff;
-          release_break();
+          break;
         }
         else {
           args->sm_values[index] = (uint16_t)masked_output;

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -78,9 +78,9 @@ void MonitorI2CTask(void *parameters)
   // wait for the power to come up
   vTaskDelayUntil(&(args->updateTick), pdMS_TO_TICKS(2500));
 
-  int IsCLK = (strstr(args->name, "CLK") != NULL);   // the instance is of CLK-device type
-  int IsFF12 = (strstr(args->name, "FF12") != NULL); // the instance is of FF 12-ch part type
-  int IsFFDAQ =  (strstr(args->name, "FFDAQ") != NULL);  //the instance is of FF 4-ch part type (DAQ links) -- not being used currently
+  int IsCLK = (strstr(args->name, "CLK") != NULL);     // the instance is of CLK-device type
+  int IsFF12 = (strstr(args->name, "FF12") != NULL);   // the instance is of FF 12-ch part type
+  int IsFFDAQ = (strstr(args->name, "FFDAQ") != NULL); // the instance is of FF 4-ch part type (DAQ links) -- not being used currently
 
   // reset the wake time to account for the time spent in any work in i2c tasks
 
@@ -97,25 +97,25 @@ void MonitorI2CTask(void *parameters)
     // -------------------------------
     for (int ps = 0; ps < args->n_devices; ++ps) {
 
-      if (!IsCLK) { // Fireflies need to be checked if the links are connected or not
-        if (args->i2c_dev == I2C_DEVICE_F1){ // FPGA #1
+      if (!IsCLK) {                           // Fireflies need to be checked if the links are connected or not
+        if (args->i2c_dev == I2C_DEVICE_F1) { // FPGA #1
 #ifdef REV1
           int NFIREFLIES_IT_F1_P1 = NFIREFLIES_IT_F1 - 2;
-          if (!isEnabledFF((IsFFDAQ*(ps + NFIREFLIES_IT_F1_P1)) + (IsFF12*(ps < NFIREFLIES_IT_F1 - 3)*(ps)) + (IsFF12*(ps > NFIREFLIES_IT_F1 - 3)*(ps + NFIREFLIES_DAQ_F1)))) // skip the FF if it's not enabled via the FF config
+          if (!isEnabledFF((IsFFDAQ * (ps + NFIREFLIES_IT_F1_P1)) + (IsFF12 * (ps < NFIREFLIES_IT_F1 - 3) * (ps)) + (IsFF12 * (ps > NFIREFLIES_IT_F1 - 3) * (ps + NFIREFLIES_DAQ_F1)))) // skip the FF if it's not enabled via the FF config
             continue;
 #elif defined(REV2)
-          if (!isEnabledFF((IsFFDAQ*(ps + NFIREFLIES_IT_F1)) + (IsFF12*(ps)))) // skip the FF if it's not enabled via the FF config
+          if (!isEnabledFF((IsFFDAQ * (ps + NFIREFLIES_IT_F1)) + (IsFF12 * (ps)))) // skip the FF if it's not enabled via the FF config
             continue;
 #else
 #error "Define either Rev1 or Rev2"
 #endif
         }
-        if (args->i2c_dev == I2C_DEVICE_F2){ // FPGA #2
+        if (args->i2c_dev == I2C_DEVICE_F2) { // FPGA #2
 #ifdef REV1
-          if (!isEnabledFF(NFIREFLIES_F1 + (IsFFDAQ*(ps)) + (IsFF12*(ps + NFIREFLIES_DAQ_F2)))) // skip the FF if it's not enabled via the FF config
+          if (!isEnabledFF(NFIREFLIES_F1 + (IsFFDAQ * (ps)) + (IsFF12 * (ps + NFIREFLIES_DAQ_F2)))) // skip the FF if it's not enabled via the FF config
             continue;
 #elif defined(REV2)
-          if (!isEnabledFF(NFIREFLIES_F1 + (IsFFDAQ*(ps + NFIREFLIES_IT_F2)) + (IsFF12*(ps)))) // skip the FF if it's not enabled via the FF config
+          if (!isEnabledFF(NFIREFLIES_F1 + (IsFFDAQ * (ps + NFIREFLIES_IT_F2)) + (IsFF12 * (ps)))) // skip the FF if it's not enabled via the FF config
             continue;
 #else
 #error "Define either Rev1 or Rev2"

--- a/projects/cm_mcu/MonitorI2CTask.h
+++ b/projects/cm_mcu/MonitorI2CTask.h
@@ -42,6 +42,7 @@ struct MonitorI2CTaskArgs_t {
   UBaseType_t stack_size;              // stack size of task
 };
 
+
 #ifndef REV2
 #define NSUPPLIES_FFLDAQ_F1 (3)
 #else // REV2
@@ -73,6 +74,7 @@ struct MonitorI2CTaskArgs_t {
 #endif                       // REV 2
 #define NCOMMANDS_FFL12_F2 4 // number of commands
 #define NPAGES_FFL12_F2    1 // number of pages on the 12-channel firefly ports
+
 
 extern struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1];
 extern struct dev_moni2c_addr_t ffldaq_f1_moni2c_addrs[NFIREFLIES_DAQ_F1];

--- a/projects/cm_mcu/MonitorI2CTask.h
+++ b/projects/cm_mcu/MonitorI2CTask.h
@@ -42,7 +42,6 @@ struct MonitorI2CTaskArgs_t {
   UBaseType_t stack_size;              // stack size of task
 };
 
-
 #ifndef REV2
 #define NSUPPLIES_FFLDAQ_F1 (3)
 #else // REV2
@@ -74,7 +73,6 @@ struct MonitorI2CTaskArgs_t {
 #endif                       // REV 2
 #define NCOMMANDS_FFL12_F2 4 // number of commands
 #define NPAGES_FFL12_F2    1 // number of pages on the 12-channel firefly ports
-
 
 extern struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1];
 extern struct dev_moni2c_addr_t ffldaq_f1_moni2c_addrs[NFIREFLIES_DAQ_F1];

--- a/projects/cm_mcu/MonitorI2CTask.h
+++ b/projects/cm_mcu/MonitorI2CTask.h
@@ -42,19 +42,36 @@ struct MonitorI2CTaskArgs_t {
   UBaseType_t stack_size;              // stack size of task
 };
 
+#ifndef REV2
+#define NSUPPLIES_FFLDAQ_F1 (3)
+#else // REV2
 #define NSUPPLIES_FFLDAQ_F1 (4)
+#endif // REV 2
 #define NCOMMANDS_FFLDAQ_F1 4 // number of commands
 #define NPAGES_FFLDAQ_F1    1 // number of pages on the 4-channel firefly ports
 
+
+#ifndef REV2
+#define NSUPPLIES_FFL12_F1 (8)
+#else // REV1
 #define NSUPPLIES_FFL12_F1 (6)
+#endif // REV 2
 #define NCOMMANDS_FFL12_F1 4 // number of commands
 #define NPAGES_FFL12_F1    1 // number of pages on the 12-channel firefly ports
 
+#ifndef REV2
+#define NSUPPLIES_FFLDAQ_F2 (10)
+#else // REV1
 #define NSUPPLIES_FFLDAQ_F2 (4)
+#endif // REV 2
 #define NCOMMANDS_FFLDAQ_F2 4 // number of commands
 #define NPAGES_FFLDAQ_F2    1 // number of pages on the 4-channel firefly ports
 
+#ifndef REV2
+#define NSUPPLIES_FFL12_F2 (4)
+#else // REV1
 #define NSUPPLIES_FFL12_F2 (6)
+#endif // REV 2
 #define NCOMMANDS_FFL12_F2 4 // number of commands
 #define NPAGES_FFL12_F2    1 // number of pages on the 12-channel firefly ports
 

--- a/projects/cm_mcu/MonitorI2CTask.h
+++ b/projects/cm_mcu/MonitorI2CTask.h
@@ -46,16 +46,15 @@ struct MonitorI2CTaskArgs_t {
 #define NSUPPLIES_FFLDAQ_F1 (3)
 #else // REV2
 #define NSUPPLIES_FFLDAQ_F1 (4)
-#endif // REV 2
+#endif                        // REV 2
 #define NCOMMANDS_FFLDAQ_F1 4 // number of commands
 #define NPAGES_FFLDAQ_F1    1 // number of pages on the 4-channel firefly ports
-
 
 #ifndef REV2
 #define NSUPPLIES_FFL12_F1 (8)
 #else // REV1
 #define NSUPPLIES_FFL12_F1 (6)
-#endif // REV 2
+#endif                       // REV 2
 #define NCOMMANDS_FFL12_F1 4 // number of commands
 #define NPAGES_FFL12_F1    1 // number of pages on the 12-channel firefly ports
 
@@ -63,7 +62,7 @@ struct MonitorI2CTaskArgs_t {
 #define NSUPPLIES_FFLDAQ_F2 (10)
 #else // REV1
 #define NSUPPLIES_FFLDAQ_F2 (4)
-#endif // REV 2
+#endif                        // REV 2
 #define NCOMMANDS_FFLDAQ_F2 4 // number of commands
 #define NPAGES_FFLDAQ_F2    1 // number of pages on the 4-channel firefly ports
 
@@ -71,7 +70,7 @@ struct MonitorI2CTaskArgs_t {
 #define NSUPPLIES_FFL12_F2 (4)
 #else // REV1
 #define NSUPPLIES_FFL12_F2 (6)
-#endif // REV 2
+#endif                       // REV 2
 #define NCOMMANDS_FFL12_F2 4 // number of commands
 #define NPAGES_FFL12_F2    1 // number of pages on the 12-channel firefly ports
 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -109,15 +109,19 @@ void MonitorI2CTask(void *parameters);
 #ifndef REV2
 #define NFIREFLIES_F1 11
 #define NFIREFLIES_F2 14
+#define NFIREFLIES_IT_F1  8
+#define NFIREFLIES_DAQ_F1 3
+#define NFIREFLIES_IT_F2  4
+#define NFIREFLIES_DAQ_F2 10
 #else // REV2
 // REV 2
 #define NFIREFLIES_F1 10
 #define NFIREFLIES_F2 10
-#endif // REV 2
 #define NFIREFLIES_IT_F1  6
 #define NFIREFLIES_DAQ_F1 4
 #define NFIREFLIES_IT_F2  6
 #define NFIREFLIES_DAQ_F2 4
+#endif // REV 2
 #define CLK_PAGE_COMMAND  1
 #define NFIREFLIES        (NFIREFLIES_F1 + NFIREFLIES_F2)
 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -107,23 +107,23 @@ void MonitorI2CTask(void *parameters);
 
 // REV1
 #ifndef REV2
-#define NFIREFLIES_F1 11
-#define NFIREFLIES_F2 14
+#define NFIREFLIES_F1     11
+#define NFIREFLIES_F2     14
 #define NFIREFLIES_IT_F1  8
 #define NFIREFLIES_DAQ_F1 3
 #define NFIREFLIES_IT_F2  4
 #define NFIREFLIES_DAQ_F2 10
 #else // REV2
 // REV 2
-#define NFIREFLIES_F1 10
-#define NFIREFLIES_F2 10
+#define NFIREFLIES_F1     10
+#define NFIREFLIES_F2     10
 #define NFIREFLIES_IT_F1  6
 #define NFIREFLIES_DAQ_F1 4
 #define NFIREFLIES_IT_F2  6
 #define NFIREFLIES_DAQ_F2 4
 #endif // REV 2
-#define CLK_PAGE_COMMAND  1
-#define NFIREFLIES        (NFIREFLIES_F1 + NFIREFLIES_F2)
+#define CLK_PAGE_COMMAND 1
+#define NFIREFLIES       (NFIREFLIES_F1 + NFIREFLIES_F2)
 
 #define VENDOR_START_BIT_FFDAQ 168
 #define VENDOR_STOP_BIT_FFDAQ  184

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -105,8 +105,10 @@ void MonitorI2CTask(void *parameters);
 #define FF_I2CMUX_2_ADDR 0x71
 #define I2C_DEVICE_CLK   2
 
+
 // REV1
 #ifndef REV2
+#define NFIREFLY_ARG      5
 #define NFIREFLIES_F1     11
 #define NFIREFLIES_F2     14
 #define NFIREFLIES_IT_F1  8
@@ -115,6 +117,7 @@ void MonitorI2CTask(void *parameters);
 #define NFIREFLIES_DAQ_F2 10
 #else // REV2
 // REV 2
+#define NFIREFLY_ARG      4
 #define NFIREFLIES_F1     10
 #define NFIREFLIES_F2     10
 #define NFIREFLIES_IT_F1  6
@@ -145,7 +148,16 @@ struct dev_moni2c_addr_t {
   uint8_t dev_addr; // I2C address of device.
 };
 
+struct arg_moni2c_ff_t {
+  char *ff_part; // ff part
+  struct MonitorI2CTaskArgs_t *arg; // ff arg
+  uint8_t int_idx; // start idx of this arg in ff_moni2c_addrs
+  uint8_t dev_int_idx;  // start idx of the device in its arg
+  uint8_t num_dev; // number of devices in this ff arg.
+};
+
 extern struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES];
+extern struct arg_moni2c_ff_t ff_moni2c_arg[NFIREFLY_ARG];
 
 bool getFFch_low(uint8_t val, int channel);
 bool getFFch_high(uint8_t val, int channel);

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -105,7 +105,6 @@ void MonitorI2CTask(void *parameters);
 #define FF_I2CMUX_2_ADDR 0x71
 #define I2C_DEVICE_CLK   2
 
-
 // REV1
 #ifndef REV2
 #define NFIREFLY_ARG      5
@@ -149,11 +148,11 @@ struct dev_moni2c_addr_t {
 };
 
 struct arg_moni2c_ff_t {
-  char *ff_part; // ff part
+  char *ff_part;                    // ff part
   struct MonitorI2CTaskArgs_t *arg; // ff arg
-  uint8_t int_idx; // start idx of this arg in ff_moni2c_addrs
-  uint8_t dev_int_idx;  // start idx of the device in its arg
-  uint8_t num_dev; // number of devices in this ff arg.
+  uint8_t int_idx;                  // start idx of this arg in ff_moni2c_addrs
+  uint8_t dev_int_idx;              // start idx of the device in its arg
+  uint8_t num_dev;                  // number of devices in this ff arg.
 };
 
 extern struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES];

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -322,7 +322,7 @@ void zm_set_psmon(struct zynqmon_data_t data[], int start)
   for (int j = 0; j < dcdc_args.n_devices; ++j) {      // loop over supplies
     for (int l = 0; l < dcdc_args.n_pages; ++l) {      // loop over register pages
       for (int k = 0; k < dcdc_args.n_commands; ++k) { // loop over FIRST SIX commands
-        if (k > 6) {
+        if (k > 5) {
           break; // only consider first six commands
         }
         int index =

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -322,7 +322,7 @@ void zm_set_psmon(struct zynqmon_data_t data[], int start)
   for (int j = 0; j < dcdc_args.n_devices; ++j) {      // loop over supplies
     for (int l = 0; l < dcdc_args.n_pages; ++l) {      // loop over register pages
       for (int k = 0; k < dcdc_args.n_commands; ++k) { // loop over FIRST SIX commands
-        if (k >= 6) {
+        if (k > 6) {
           break; // only consider first six commands
         }
         int index =

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -301,7 +301,7 @@ int main(void)
   xTaskCreate(LedTask, "LED", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 2, NULL);
   xTaskCreate(vCommandLineTask, "CLIZY", 512, &cli_uart, tskIDLE_PRIORITY + 4, NULL);
 #ifdef REV1
-  xTaskCreate(vCommandLineTask, "CLIFP", 512, &cli_uart4, tskIDLE_PRIORITY + 1, NULL);
+  xTaskCreate(vCommandLineTask, "CLIFP", 512, &cli_uart4, tskIDLE_PRIORITY + 4, NULL);
 #endif // REV1
   xTaskCreate(ADCMonitorTask, "ADC", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
 

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -312,10 +312,12 @@ int main(void)
               NULL);
   xTaskCreate(MonitorI2CTask, "FFDAQV", 2 * configMINIMAL_STACK_SIZE, &ffldaq_f2_args, tskIDLE_PRIORITY + 4,
               NULL);
+#ifdef REV2
   xTaskCreate(MonitorI2CTask, "CLKSI", 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(MonitorI2CTask, "CLKR0A", 2 * configMINIMAL_STACK_SIZE, &clockr0a_args, tskIDLE_PRIORITY + 4,
               NULL);
+#endif // REV2
   xTaskCreate(MonitorTask, "PSMON", 2 * configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(MonitorTask, "XIMON", 2 * configMINIMAL_STACK_SIZE, &fpga_args, tskIDLE_PRIORITY + 4,

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -304,6 +304,7 @@ int main(void)
   xTaskCreate(vCommandLineTask, "CLIFP", 512, &cli_uart4, tskIDLE_PRIORITY + 1, NULL);
 #endif // REV1
   xTaskCreate(ADCMonitorTask, "ADC", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
+
   xTaskCreate(MonitorI2CTask, "FF12", 2 * configMINIMAL_STACK_SIZE, &ffl12_f1_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(MonitorI2CTask, "FFDAQ", 2 * configMINIMAL_STACK_SIZE, &ffldaq_f1_args, tskIDLE_PRIORITY + 4,
@@ -311,7 +312,8 @@ int main(void)
   xTaskCreate(MonitorI2CTask, "FF12V", 2 * configMINIMAL_STACK_SIZE, &ffl12_f2_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(MonitorI2CTask, "FFDAQV", 2 * configMINIMAL_STACK_SIZE, &ffldaq_f2_args, tskIDLE_PRIORITY + 4,
-              NULL);
+             NULL);
+
 #ifdef REV2
   xTaskCreate(MonitorI2CTask, "CLKSI", 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,
               NULL);

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -312,7 +312,7 @@ int main(void)
   xTaskCreate(MonitorI2CTask, "FF12V", 2 * configMINIMAL_STACK_SIZE, &ffl12_f2_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(MonitorI2CTask, "FFDAQV", 2 * configMINIMAL_STACK_SIZE, &ffldaq_f2_args, tskIDLE_PRIORITY + 4,
-             NULL);
+              NULL);
 
 #ifdef REV2
   xTaskCreate(MonitorI2CTask, "CLKSI", 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -84,7 +84,7 @@ BaseType_t board_id_info(int argc, char **argv, char *m)
 
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "ID:%08lx\r\n", (uint32_t)sn);
 
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Board number: %ld\r\n", num);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Board number: %lu\r\n", num);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Revision: %lx\r\n", rev);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Firefly config: %lx\r\n", ff);
   // copied += // this is here to remind you to update `copied` if you add more lines

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -84,7 +84,7 @@ BaseType_t board_id_info(int argc, char **argv, char *m)
 
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "ID:%08lx\r\n", (uint32_t)sn);
 
-  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Board number: %lx\r\n", num);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Board number: %ld\r\n", num);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Revision: %lx\r\n", rev);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "Firefly config: %lx\r\n", ff);
   // copied += // this is here to remind you to update `copied` if you add more lines

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -595,34 +595,34 @@ BaseType_t ff_status(int argc, char **argv, char *m)
     if (isEnabledFF(whichff)) {
       int i1 = 0; // 0 for status
 #ifdef REV1
-        if (0 <= whichff && whichff < NFIREFLIES_IT_F1 - 2) {
-          int index = whichff * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
-          uint8_t val = ffl12_f1_args.sm_values[index];
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
-        }
+      if (0 <= whichff && whichff < NFIREFLIES_IT_F1 - 2) {
+        int index = whichff * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
+        uint8_t val = ffl12_f1_args.sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+      }
 
-        else if (NFIREFLIES_IT_F1 - 2 <= whichff && whichff < NFIREFLIES_IT_F1 - 2 + NFIREFLIES_DAQ_F1) {
-          int index = (whichff - NFIREFLIES_IT_F1) * (ffldaq_f1_args.n_commands * ffldaq_f1_args.n_pages) + i1;
-          uint8_t val = ffldaq_f1_args.sm_values[index];
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
-        }
+      else if (NFIREFLIES_IT_F1 - 2 <= whichff && whichff < NFIREFLIES_IT_F1 - 2 + NFIREFLIES_DAQ_F1) {
+        int index = (whichff - NFIREFLIES_IT_F1) * (ffldaq_f1_args.n_commands * ffldaq_f1_args.n_pages) + i1;
+        uint8_t val = ffldaq_f1_args.sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+      }
 
-        else if (NFIREFLIES_IT_F1 - 2 + NFIREFLIES_DAQ_F1 <= whichff && whichff < NFIREFLIES_F1) {
-          int index = (whichff - NFIREFLIES_IT_F1 + 2 - NFIREFLIES_DAQ_F1) * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
-          uint8_t val = ffl12_f1_args.sm_values[index];
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
-        }
+      else if (NFIREFLIES_IT_F1 - 2 + NFIREFLIES_DAQ_F1 <= whichff && whichff < NFIREFLIES_F1) {
+        int index = (whichff - NFIREFLIES_IT_F1 + 2 - NFIREFLIES_DAQ_F1) * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
+        uint8_t val = ffl12_f1_args.sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+      }
 
-        else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_DAQ_F2) {
-          int index = (whichff - NFIREFLIES_F1) * (ffldaq_f2_args.n_commands * ffldaq_f2_args.n_pages) + i1;
-          uint8_t val = ffldaq_f2_args.sm_values[index];
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
-        }
-        else {
-          int index = (whichff - NFIREFLIES_F1 - NFIREFLIES_DAQ_F2) * (ffl12_f2_args.n_commands * ffl12_f2_args.n_pages) + i1;
-          uint8_t val = ffl12_f2_args.sm_values[index];
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
-        }
+      else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_DAQ_F2) {
+        int index = (whichff - NFIREFLIES_F1) * (ffldaq_f2_args.n_commands * ffldaq_f2_args.n_pages) + i1;
+        uint8_t val = ffldaq_f2_args.sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+      }
+      else {
+        int index = (whichff - NFIREFLIES_F1 - NFIREFLIES_DAQ_F2) * (ffl12_f2_args.n_commands * ffl12_f2_args.n_pages) + i1;
+        uint8_t val = ffl12_f2_args.sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+      }
 #elif defined(REV2)
       if (0 <= whichff && whichff < NFIREFLIES_IT_F1) {
         int index = whichff * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
@@ -745,7 +745,6 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
           int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
         }
-
       }
       else {
         int index = (whichff - NFIREFLIES_F1 - NFIREFLIES_DAQ_F2) * (ffl12_f2_args.n_commands * ffl12_f2_args.n_pages) + i1;
@@ -856,6 +855,70 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
     else {
       int i1 = 3; // 3 for cdr_lol_alarm
       uint8_t i2cdata[2];
+#ifdef REV1
+      if (0 <= whichff && whichff < NFIREFLIES_IT_F1 - 2) {
+        int index = whichff * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ffl12_f1_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
+        }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+        for (size_t i = 8; i < 12; i++) {
+          int alarm = getFFch_high(i2cdata[1], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+      }
+      else if (NFIREFLIES_IT_F1 - 2 <= whichff && whichff < NFIREFLIES_IT_F1 - 2 + NFIREFLIES_DAQ_F1) {
+        int index = (whichff - NFIREFLIES_IT_F1) * (ffldaq_f1_args.n_commands * ffldaq_f1_args.n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ffldaq_f1_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
+        }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+      }
+      else if (NFIREFLIES_IT_F1 - 2 + NFIREFLIES_DAQ_F1 <= whichff && whichff < NFIREFLIES_F1) {
+        int index = (whichff - NFIREFLIES_IT_F1 + 2 - NFIREFLIES_DAQ_F1) * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ffl12_f1_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
+        }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+        for (size_t i = 8; i < 12; i++) {
+          int alarm = getFFch_high(i2cdata[1], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+      }
+      else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_IT_F2) {
+        int index = (whichff - NFIREFLIES_F1) * (ffldaq_f2_args.n_commands * ffldaq_f2_args.n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ffldaq_f2_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
+        }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+      }
+      else {
+        int index = (whichff - NFIREFLIES_F1 - NFIREFLIES_DAQ_F2) * (ffl12_f2_args.n_commands * ffl12_f2_args.n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ffl12_f2_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
+        }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+        for (size_t i = 8; i < 12; i++) {
+          int alarm = getFFch_high(i2cdata[1], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+      }
+#elif defined(REV2)
       if (0 <= whichff && whichff < NFIREFLIES_IT_F1) {
         int index = whichff * (ffl12_f1_args.n_commands * ffl12_f1_args.n_pages) + i1;
         for (int i = 0; i < 2; ++i) {
@@ -905,6 +968,9 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
         }
       }
+#else
+#error "Define either Rev1 or Rev2"
+#endif
     }
     bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
     if (isTx)

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -224,7 +224,7 @@ static int write_arbitrary_ff_register(uint16_t regnumber, uint8_t value, int nu
   for (; i < imax; ++i) {
 
     if (num_ff == i)
-          break;
+      break;
   }
 
   if (!isEnabledFF(i)) { // skip the FF if it's not enabled via the FF config

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -223,21 +223,23 @@ static int write_arbitrary_ff_register(uint16_t regnumber, uint8_t value, int nu
   int i2c_dev;
   for (; i < imax; ++i) {
 
-    if (!isEnabledFF(i)) { // skip the FF if it's not enabled via the FF config
-      log_warn(LOG_SERVICE, "Skip writing to disabled FF %d\r\n", i);
-      continue;
-    }
-    if (i < NFIREFLIES_F1) {
-      i2c_dev = I2C_DEVICE_F1;
-    }
-    else {
-      i2c_dev = I2C_DEVICE_F2;
-    }
-    int ret1 = write_ff_register(ff_moni2c_addrs[i].name, regnumber, value, 1, i2c_dev);
-    if (ret1) {
-      log_warn(LOG_SERVICE, "%s: error %s\r\n", __func__, SMBUS_get_error(ret1));
-      ret += ret1;
-    }
+    if (num_ff == i)
+          break;
+  }
+
+  if (!isEnabledFF(i)) { // skip the FF if it's not enabled via the FF config
+    log_warn(LOG_SERVICE, "Skip writing to disabled FF %d\r\n", i);
+  }
+  if (i < NFIREFLIES_F1) {
+    i2c_dev = I2C_DEVICE_F1;
+  }
+  else {
+    i2c_dev = I2C_DEVICE_F2;
+  }
+  int ret1 = write_ff_register(ff_moni2c_addrs[i].name, regnumber, value, 1, i2c_dev);
+  if (ret1) {
+    log_warn(LOG_SERVICE, "%s: error %s\r\n", __func__, SMBUS_get_error(ret1));
+    ret += ret1;
   }
   return ret;
 }

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -687,7 +687,6 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
         return pdTRUE;
       }
     }
-
   }
   if (whichff % 2 == 1) {
     m[copied++] = '\r';
@@ -741,7 +740,7 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
           int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
         }
-        if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL){
+        if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL) {
           for (size_t i = 8; i < 12; i++) {
             int alarm = getFFch_high(i2cdata[1], i) ? 1 : 0;
             copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
@@ -758,8 +757,6 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
         return pdTRUE;
       }
     }
-
-
   }
   if (whichff % 2 == 1) {
     m[copied++] = '\r';

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -654,66 +654,40 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
 
   for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
-    if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL) {
-      for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
-        int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
-        if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
+
+    for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
+      int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
+      if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
+      }
+      else {
+        int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
         }
-        else {
-          int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-          for (int i = 0; i < 2; ++i) {
-            i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
-          }
-          for (size_t i = 0; i < 8; i++) {
-            int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
-            copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
-          }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+        if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL) {
           for (size_t i = 8; i < 12; i++) {
             int alarm = getFFch_high(i2cdata[1], i) ? 1 : 0;
             copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
           }
         }
-        bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
-        if (isTx)
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-        else
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-        if ((SCRATCH_SIZE - copied) < 20) {
-          ++whichff;
-          return pdTRUE;
-        }
+      }
+      bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
+      if (isTx)
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+      else
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+      if ((SCRATCH_SIZE - copied) < 20) {
+        ++whichff;
+        return pdTRUE;
       }
     }
-    else {
-      for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
-        int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
-        if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
-        }
-        else {
-          int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-          for (int i = 0; i < 2; ++i) {
-            i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
-          }
-          for (size_t i = 0; i < 8; i++) {
-            int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
-            copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
-          }
-        }
-        bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
-        if (isTx)
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-        else
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-        if ((SCRATCH_SIZE - copied) < 20) {
-          ++whichff;
-          return pdTRUE;
-        }
-      }
-    }
+
   }
   if (whichff % 2 == 1) {
     m[copied++] = '\r';
@@ -751,66 +725,41 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
 
   for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
-    if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL) {
-      for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
-        int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
-        if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
+
+    for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
+      int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
+      if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
+      }
+      else {
+        int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
+        for (int i = 0; i < 2; ++i) {
+          i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
         }
-        else {
-          int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-          for (int i = 0; i < 2; ++i) {
-            i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
-          }
-          for (size_t i = 0; i < 8; i++) {
-            int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
-            copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
-          }
+        for (size_t i = 0; i < 8; i++) {
+          int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
+          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
+        }
+        if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL){
           for (size_t i = 8; i < 12; i++) {
             int alarm = getFFch_high(i2cdata[1], i) ? 1 : 0;
             copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
           }
         }
-        bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
-        if (isTx)
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-        else
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-        if ((SCRATCH_SIZE - copied) < 20) {
-          ++whichff;
-          return pdTRUE;
-        }
+      }
+      bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
+      if (isTx)
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+      else
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+      if ((SCRATCH_SIZE - copied) < 20) {
+        ++whichff;
+        return pdTRUE;
       }
     }
-    else {
-      for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
-        int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
-        if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
-        }
-        else {
-          int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-          for (int i = 0; i < 2; ++i) {
-            i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
-          }
-          for (size_t i = 0; i < 8; i++) {
-            int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
-            copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
-          }
-        }
-        bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
-        if (isTx)
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-        else
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-        if ((SCRATCH_SIZE - copied) < 20) {
-          ++whichff;
-          return pdTRUE;
-        }
-      }
-    }
+
+
   }
   if (whichff % 2 == 1) {
     m[copied++] = '\r';

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -720,7 +720,7 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY CDR LOL ALARM:\r\n");
   }
 
-  int i1 = 3; // 2 for cdr_lol_alarm
+  int i1 = 3; // 3 for cdr_lol_alarm
   uint8_t i2cdata[2];
 
   for (; n < NFIREFLY_ARG; ++n) {

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -600,8 +600,8 @@ BaseType_t ff_status(int argc, char **argv, char *m)
       int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
       if (isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
         int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-        uint8_t val = ffldaq_f1_args.sm_values[index];
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+        uint8_t val = ff_arg->sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: 0x%02x", ff_moni2c_addrs[whichff].name, val);
       }
       else // dummy value
         copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2s", ff_moni2c_addrs[whichff].name, "--");
@@ -663,9 +663,8 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
       }
       else {
         int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-        for (int i = 0; i < 2; ++i) {
-          i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
-        }
+        i2cdata[0] = (ff_arg->sm_values[index]) & 0xFFU;
+        i2cdata[1] = (ff_arg->sm_values[index] >> 8) & 0xFFU;
         for (size_t i = 0; i < 8; i++) {
           int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
@@ -733,9 +732,8 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
       }
       else {
         int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-        for (int i = 0; i < 2; ++i) {
-          i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
-        }
+        i2cdata[0] = (ff_arg->sm_values[index]) & 0xFFU;
+        i2cdata[1] = (ff_arg->sm_values[index] >> 8) & 0xFFU;
         for (size_t i = 0; i < 8; i++) {
           int alarm = getFFch_low(i2cdata[0], i) ? 1 : 0;
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
@@ -798,8 +796,8 @@ BaseType_t ff_temp(int argc, char **argv, char *m)
       int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
       if (isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
         int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-        uint8_t val = ffldaq_f1_args.sm_values[index];
-        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
+        uint8_t val = ff_arg->sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2d", ff_moni2c_addrs[whichff].name, val);
       }
       else // dummy value
         copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2s", ff_moni2c_addrs[whichff].name, "--");

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -587,14 +587,14 @@ BaseType_t ff_status(int argc, char **argv, char *m)
       TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
+                         "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
     }
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FF STATUS:\r\n");
   }
 
   int i1 = 0; // 0 for status
 
-  for (; n < NFIREFLY_ARG; ++n){
+  for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
     for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
       int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
@@ -627,7 +627,6 @@ BaseType_t ff_status(int argc, char **argv, char *m)
   n = 0;
 
   return pdFALSE;
-
 }
 
 BaseType_t ff_los_alarm(int argc, char **argv, char *m)
@@ -653,16 +652,16 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
   int i1 = 2; // 2 for los_alarm
   uint8_t i2cdata[2];
 
-  for (; n < NFIREFLY_ARG; ++n){
+  for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
-    if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL){
+    if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL) {
       for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
         int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
         copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
         if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
         }
-        else{
+        else {
           int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
           for (int i = 0; i < 2; ++i) {
             i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
@@ -687,14 +686,14 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
         }
       }
     }
-    else{
+    else {
       for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
         int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
         copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
         if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
         }
-        else{
+        else {
           int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
           for (int i = 0; i < 2; ++i) {
             i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
@@ -742,7 +741,7 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
       TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
+                         "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
     }
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY CDR LOL ALARM:\r\n");
   }
@@ -750,16 +749,16 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
   int i1 = 3; // 2 for cdr_lol_alarm
   uint8_t i2cdata[2];
 
-  for (; n < NFIREFLY_ARG; ++n){
+  for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
-    if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL){
+    if (strstr(ff_moni2c_arg[n].ff_part, "FFL12") != NULL) {
       for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
         int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
         copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
         if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
         }
-        else{
+        else {
           int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
           for (int i = 0; i < 2; ++i) {
             i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
@@ -784,14 +783,14 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
         }
       }
     }
-    else{
+    else {
       for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
         int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
         copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s ", ff_moni2c_addrs[whichff].name);
         if (!isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "------------");
         }
-        else{
+        else {
           int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
           for (int i = 0; i < 2; ++i) {
             i2cdata[1 - i] = (ff_arg->sm_values[index] >> (1 - i) * 8) & 0xFFU;
@@ -840,35 +839,35 @@ BaseType_t ff_temp(int argc, char **argv, char *m)
       TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
-          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
+                         "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
     }
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FF Temperature:\r\n");
   }
 
   int i1 = 1; // 1 for temperature
 
-  for (; n < NFIREFLY_ARG; ++n){
+  for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
-      for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
-        int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
-        if (isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
-          int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
-          uint8_t val = ffldaq_f1_args.sm_values[index];
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
-        }
-        else // dummy value
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2s", ff_moni2c_addrs[whichff].name, "--");
-
-        bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
-        if (isTx)
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
-        else
-          copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
-        if ((SCRATCH_SIZE - copied) < 20) {
-          ++whichff;
-          return pdTRUE;
-        }
+    for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {
+      int dev = whichff - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
+      if (isEnabledFF(ff_moni2c_arg[n].int_idx + dev)) {
+        int index = dev * (ff_arg->n_commands * ff_arg->n_pages) + i1;
+        uint8_t val = ffldaq_f1_args.sm_values[index];
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %02d", ff_moni2c_addrs[whichff].name, val);
       }
+      else // dummy value
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: %2s", ff_moni2c_addrs[whichff].name, "--");
+
+      bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
+      if (isTx)
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+      else
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+      if ((SCRATCH_SIZE - copied) < 20) {
+        ++whichff;
+        return pdTRUE;
+      }
+    }
   }
 
   if (whichff % 2 == 1) {
@@ -880,9 +879,7 @@ BaseType_t ff_temp(int argc, char **argv, char *m)
   n = 0;
 
   return pdFALSE;
-
 }
-
 
 // this command takes up to two arguments
 BaseType_t ff_ctl(int argc, char **argv, char *m)

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -736,7 +736,7 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
         }
       }
-      else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_IT_F2) {
+      else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_DAQ_F2) {
         int index = (whichff - NFIREFLIES_F1) * (ffldaq_f2_args.n_commands * ffldaq_f2_args.n_pages) + i1;
         for (int i = 0; i < 2; ++i) {
           i2cdata[1 - i] = (ffldaq_f2_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
@@ -819,10 +819,15 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
     else
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
 
-    if ((SCRATCH_SIZE - copied) < 20 && (whichff < 25)) {
+    if ((SCRATCH_SIZE - copied) < 20) {
       ++whichff;
       return pdTRUE;
     }
+  }
+  if (whichff % 2 == 1) {
+    m[copied++] = '\r';
+    m[copied++] = '\n';
+    m[copied] = '\0';
   }
   whichff = 0;
   return pdFALSE;
@@ -894,7 +899,7 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%d", alarm);
         }
       }
-      else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_IT_F2) {
+      else if (NFIREFLIES_F1 <= whichff && whichff < NFIREFLIES_F1 + NFIREFLIES_DAQ_F2) {
         int index = (whichff - NFIREFLIES_F1) * (ffldaq_f2_args.n_commands * ffldaq_f2_args.n_pages) + i1;
         for (int i = 0; i < 2; ++i) {
           i2cdata[1 - i] = (ffldaq_f2_args.sm_values[index] >> (1 - i) * 8) & 0xFFU;
@@ -978,10 +983,15 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
     else
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
 
-    if ((SCRATCH_SIZE - copied) < 20 && (whichff < 25)) {
+    if ((SCRATCH_SIZE - copied) < 20) {
       ++whichff;
       return pdTRUE;
     }
+  }
+  if (whichff % 2 == 1) {
+    m[copied++] = '\r';
+    m[copied++] = '\n';
+    m[copied] = '\0';
   }
   whichff = 0;
   return pdFALSE;


### PR DESCRIPTION
* only do clock monitoring on Rev2 for now
* only init FF I/O expanders after power is up, and fix up semaphores here
* also fix a Rev2 bug on ZynqMonitorTask