### PR TITLE
Fix hardcode in InitTask from issue #148 

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -107,7 +107,11 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
   }
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s is programming clock %s. \r\n", argv[0], clk_ids[i]);
   int status = -1;           // shut up clang compiler warning
+  // grab the semaphore to ensure unique access to I2C controller
+  while (xSemaphoreTake(clock_args.xSem, (TickType_t)10) == pdFALSE)
+    ;
   status = init_load_clk(i); // status is 0 if all registers can be written to a clock chip. otherwise, it implies that some write registers fail in a certain list.
+  xSemaphoreGive(clock_args.xSem);
   if (status == 0) {
     snprintf(m + copied, SCRATCH_SIZE - copied,
              "clock synthesizer with id %s successfully programmed. \r\n", clk_ids[i]);

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -106,7 +106,7 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
     return pdFALSE;
   }
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s is programming clock %s. \r\n", argv[0], clk_ids[i]);
-  int status = -1;           // shut up clang compiler warning
+  int status = -1; // shut up clang compiler warning
   // grab the semaphore to ensure unique access to I2C controller
   while (xSemaphoreTake(clock_args.xSem, (TickType_t)10) == pdFALSE)
     ;

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -43,9 +43,13 @@ void InitTask(void *parameters)
   init_registers_clk(); // initalize I/O expander for clocks
   log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");
 #ifdef REV2
+  // grab the semaphore to ensure unique access to I2C controller
+  while (xSemaphoreTake(clock_args.xSem, (TickType_t)10) == pdFALSE)
+    ;
   for (int i = 0; i < 5; ++i) {
     init_load_clk(i); // load each clock config from EEPROM
   }
+  xSemaphoreGive(clock_args.xSem);
   log_info(LOG_SERVICE, "Clocks configured\r\n");
   getFFpart(); // the order of where to check FF part matters -- it won't be able to read anything if check sooner
 #endif         // REV2

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -44,8 +44,6 @@ void InitTask(void *parameters)
   log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");
 #ifdef REV2
   for (int i = 0; i < 5; ++i) {
-    if (i == 1 || i == 4)
-      continue;
     init_load_clk(i); // load each clock config from EEPROM
   }
   log_info(LOG_SERVICE, "Clocks configured\r\n");

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -1318,7 +1318,7 @@ int init_load_clk(int clk_n)
 
   if (PreambleList_row == 0xff) {
     log_warn(LOG_SERVICE, "Quit.. garbage EEPROM of %s PreL\r\n", clk_ids[clk_n]);
-    return status_r+1; // fail reading and exit
+    return status_r + 1; // fail reading and exit
   }
 
   uint32_t RegisterList_row; // the size of register list in a clock config file store at the end of the last eeprom page of a clock
@@ -1331,7 +1331,7 @@ int init_load_clk(int clk_n)
 
   if (RegisterList_row == 0xffff) {
     log_warn(LOG_SERVICE, "Quit.. garbage EEPROM of %s RegL\r\n", clk_ids[clk_n]);
-    return status_r+1; // fail reading and exit
+    return status_r + 1; // fail reading and exit
   }
 
   uint32_t PostambleList_row; // the size of postamble list in a clock config file store at the end of the last eeprom page of a clock
@@ -1344,7 +1344,7 @@ int init_load_clk(int clk_n)
 
   if (PostambleList_row == 0xff) {
     log_warn(LOG_SERVICE, "Quit.. garbage EEPROM of %s PostL\r\n", clk_ids[clk_n]);
-    return status_r+1; // fail reading and exit
+    return status_r + 1; // fail reading and exit
   }
 
   log_debug(LOG_SERVICE, "Start programming clock %s\r\n", clk_ids[clk_n]);


### PR DESCRIPTION
Testing the CLI `loadclock` 0-4 on CM202 (FPGA-less board) after removing this hardcode and adjust semaphore scopes, and the following results look as expected:

```
% loadclock 0                                                                                                       
loadclock is programming clock r0a.                                                                                 
clock synthesizer with id r0a successfully programmed.                                                              
% loadclock 1                                                                                                       
loadclock is programming clock r0b.                                                                                 
clock synthesizer with id r0b successfully programmed.                                                              
% loadclock 2                                                                                                       
loadclock is programming clock r1a.                                                                                 
clock synthesizer with id r1a successfully programmed.                                                              
% loadclock 3                                                                                                       
loadclock is programming clock r1b.                                                                                 
clock synthesizer with id r1b successfully programmed.                                                              
% loadclock 4                                                                                                       
2044373 SRV WRN LocalTasks.c:1320:Quit.. garbage EEPROM of r1c PreL                                                 
loadclock is programming clock r1c.                                                                                 
loadclock operation failed                                                                                          
% version                                                                                                           
Version commit date 2022-10-11 15:51:41 -0400   (HEAD, origin/fix_clk_hardcode, fix_clk_hardcode) v0.99.1-19-gefaf58a-dirty                                                                                                             DEBUG build                                                                                                          
built at 12:31:49, Oct 12 2022.                                                                                    
% 
```