### PR TITLE
require a check on 3.3V power supply for loadclock 

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -111,8 +111,8 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
   bool isFullyPowered = false; // assume not fully powered
   enum power_system_state power_state = getPowerControlState();
   if (power_state != POWER_ON) { // if the power state is not fully on
-    if (!isFullyPowered) {        // was previously on
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied," 3V3 died. skip loadclock\r\n");
+    if (!isFullyPowered) {       // was previously on
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " 3V3 died. skip loadclock\r\n");
       isFullyPowered = false;
     }
     snprintf(m + copied, SCRATCH_SIZE - copied, "%s operation failed \r\n", argv[0]);

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -107,21 +107,11 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
     return pdFALSE;
   }
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s is programming clock %s. \r\n", argv[0], clk_ids[i]);
-  int status = -1;             // shut up clang compiler warning
-  bool isFullyPowered = false; // assume not fully powered
+  int status = -1; // shut up clang compiler warning
   enum power_system_state power_state = getPowerControlState();
   if (power_state != POWER_ON) { // if the power state is not fully on
-    if (!isFullyPowered) {       // was previously on
-      copied += snprintf(m + copied, SCRATCH_SIZE - copied, " 3V3 died. skip loadclock\r\n");
-      isFullyPowered = false;
-    }
-    snprintf(m + copied, SCRATCH_SIZE - copied, "%s operation failed \r\n", argv[0]);
+    snprintf(m + copied, SCRATCH_SIZE - copied, " 3V3 died. skip loadclock\r\n");
     return pdFALSE; // skip this iteration
-  }
-  else {                   // if the power state is fully on
-    if (!isFullyPowered) { // was previously off
-      isFullyPowered = true;
-    }
   }
   // grab the semaphore to ensure unique access to I2C controller
   while (xSemaphoreTake(i2c2_sem, (TickType_t)10) == pdFALSE)

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -107,12 +107,12 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
     return pdFALSE;
   }
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s is programming clock %s. \r\n", argv[0], clk_ids[i]);
-  int status = -1; // shut up clang compiler warning
+  int status = -1;             // shut up clang compiler warning
   bool isFullyPowered = false; // assume not fully powered
   enum power_system_state power_state = getPowerControlState();
   if (power_state != POWER_ON) { // if the power state is not fully on
     if (isFullyPowered) {        // was previously on
-      snprintf(m + copied, SCRATCH_SIZE - copied," 3V3 died. Skipping loading clock.\r\n");
+      snprintf(m + copied, SCRATCH_SIZE - copied, " 3V3 died. Skipping loading clock.\r\n");
       isFullyPowered = false;
     }
     snprintf(m + copied, SCRATCH_SIZE - copied, "%s operation failed \r\n", argv[0]);


### PR DESCRIPTION
issue : `loadclock` stuck when `cmpwrdown` but does the job when `cmpwrup` 
solution : we just add a check on this in a commandline code of a loadclock command. 
conclusion : yes, `cmpwrdown` was the issue and now loadclock will quite when pwr is off. 

note that this was tested on Apollo213 on 10/28/2022