### PR TITLE
Add check to every Semaphore Take and Give 

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -115,10 +115,16 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
   }
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
-	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    snprintf(m + copied , SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
+    status = -1;
+    return pdFALSE;
   }
   status = init_load_clk(i); // status is 0 if all registers can be written to a clock chip. otherwise, it implies that some write registers fail in a certain list.
-  xSemaphoreGive(i2c2_sem);
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c2_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c2_sem);
+  }
+
   if (status == 0) {
     snprintf(m + copied, SCRATCH_SIZE - copied,
              "clock synthesizer with id %s successfully programmed. \r\n", clk_ids[i]);

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -115,7 +115,7 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
   }
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
-    snprintf(m + copied , SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
+    snprintf(m + copied, SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
     status = -1;
     return pdFALSE;
   }

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -114,8 +114,9 @@ static BaseType_t init_load_clock_ctl(int argc, char **argv, char *m)
     return pdFALSE; // skip this iteration
   }
   // grab the semaphore to ensure unique access to I2C controller
-  while (xSemaphoreTake(i2c2_sem, (TickType_t)10) == pdFALSE)
-    ;
+  if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
+	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+  }
   status = init_load_clk(i); // status is 0 if all registers can be written to a clock chip. otherwise, it implies that some write registers fail in a certain list.
   xSemaphoreGive(i2c2_sem);
   if (status == 0) {

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -48,6 +48,7 @@ void InitTask(void *parameters)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   for (int i = 0; i < 5; ++i) {
     init_load_clk(i); // load each clock config from EEPROM

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -46,8 +46,9 @@ void InitTask(void *parameters)
   log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");
 #ifdef REV2
   // grab the semaphore to ensure unique access to I2C controller
-  while (xSemaphoreTake(i2c2_sem, (TickType_t)10) == pdFALSE)
-    ;
+  if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
+	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+  }
   for (int i = 0; i < 5; ++i) {
     init_load_clk(i); // load each clock config from EEPROM
   }

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -64,7 +64,7 @@ void InitTask(void *parameters)
   getFFpart_FPGA1();
   getFFpart_FPGA2();
 
-#endif         // REV2
+#endif // REV2
   vTaskSuspend(NULL);
   // Delete this task
   vTaskDelete(xTaskGetCurrentTaskHandle());

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -47,7 +47,7 @@ void InitTask(void *parameters)
 #ifdef REV2
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
-	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
   }
   for (int i = 0; i < 5; ++i) {
     init_load_clk(i); // load each clock config from EEPROM

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -48,17 +48,18 @@ void InitTask(void *parameters)
 #ifdef REV2
   // grab the semaphore to ensure unique access to I2C controller
   // if it is not available, continue indefinitely until we can grab one
-  while (acquireI2CSemaphore(i2c2_sem) == pdFAIL)
-    ;
-  for (int i = 0; i < 5; ++i) {
-    init_load_clk(i); // load each clock config from EEPROM
-  }
-  // check if we have the semaphore
-  if (xSemaphoreGetMutexHolder(i2c2_sem) == xTaskGetCurrentTaskHandle()) {
-    xSemaphoreGive(i2c2_sem);
-  }
 
-  log_info(LOG_SERVICE, "Clocks configured\r\n");
+  if (acquireI2CSemaphoreBlock(i2c2_sem) != pdFAIL) {
+    for (int i = 0; i < 5; ++i) {
+      init_load_clk(i); // load each clock config from EEPROM
+    }
+    // check if we have the semaphore
+    if (xSemaphoreGetMutexHolder(i2c2_sem) == xTaskGetCurrentTaskHandle()) {
+      xSemaphoreGive(i2c2_sem);
+    }
+
+    log_info(LOG_SERVICE, "Clocks configured\r\n");
+  }
   getFFpart(); // the order of where to check FF part matters -- it won't be able to read anything if check sooner
 #endif         // REV2
   vTaskSuspend(NULL);

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -56,10 +56,7 @@ void InitTask(void *parameters)
   if (xSemaphoreGetMutexHolder(i2c2_sem) == xTaskGetCurrentTaskHandle()) {
     xSemaphoreGive(i2c2_sem);
   }
-  else {
-    log_info(LOG_SERVICE, "tried to release semaphore I don't own\r\n");
-  }
-  //xSemaphoreGive(i2c2_sem);
+
   log_info(LOG_SERVICE, "Clocks configured\r\n");
   getFFpart(); // the order of where to check FF part matters -- it won't be able to read anything if check sooner
 #endif         // REV2

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -44,12 +44,12 @@ void InitTask(void *parameters)
   init_registers_clk(); // initialize I/O expander for clocks
   readFFpresent();
   log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");
+
 #ifdef REV2
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
-  }
+  // if it is not available, continue indefinitely until we can grab one
+  while (acquireI2CSemaphore(i2c2_sem) == pdFAIL)
+    ;
   for (int i = 0; i < 5; ++i) {
     init_load_clk(i); // load each clock config from EEPROM
   }

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -611,14 +611,12 @@ void getFFpart(int which_fpga)
   uint32_t vendor_char;
   int8_t vendor_part[17];
 
-
   uint8_t ven_addr_start = VENDOR_START_BIT_FF12;
   uint8_t ven_addr_stop = VENDOR_STOP_BIT_FF12;
 
   uint8_t data;
 
-
-  if (which_fpga == 1){ // checking the FF 12-ch part connected to FPGA1 (need to check from Rx devices (i.e devices[odd]))
+  if (which_fpga == 1) { // checking the FF 12-ch part connected to FPGA1 (need to check from Rx devices (i.e devices[odd]))
 
     // grab the semaphore to ensure unique access to I2C controller
     // otherwise, block its operations indefinitely until it's available
@@ -663,7 +661,7 @@ void getFFpart(int which_fpga)
       xSemaphoreGive(i2c4_sem);
     }
   }
-  else{ // checking the FF 12-ch part connected to FPGA2 (need to check from Rx devices (i.e devices[odd]))
+  else { // checking the FF 12-ch part connected to FPGA2 (need to check from Rx devices (i.e devices[odd]))
 
     // grab the semaphore to ensure unique access to I2C controller
     // otherwise, block its operations indefinitely until it's available
@@ -706,10 +704,7 @@ void getFFpart(int which_fpga)
     if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(i2c3_sem);
     }
-
   }
-
-
 }
 
 #define FPGA_MON_NDEVICES_PER_FPGA  2

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -441,6 +441,7 @@ void readFFpresent(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
 #ifdef REV1
   uint32_t present_0X20_F2, present_0X21_F2, present_FFLDAQ_F1, present_FFL12_F1, present_FFLDAQ_0X20_F2, present_FFL12_0X20_F2, present_FFLDAQ_0X21_F2, present_FFL12_0X21_F2;
@@ -472,6 +473,7 @@ void readFFpresent(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
 #ifdef REV1
   // to port 0
@@ -608,6 +610,7 @@ void getFFpart(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // Write device vendor part for identifying FF devices
   // FF connecting to FPGA1
@@ -846,6 +849,7 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // page register
   int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, add, &extra_cmds[0], &page);
@@ -894,6 +898,7 @@ void LGA80D_init(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   log_info(LOG_SERVICE, "LGA80D_init\r\n");
   // set up the switching frequency
@@ -1081,6 +1086,7 @@ void init_registers_clk()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // # set I2C switch on channel 2 (U94, address 0x70) to port 6
   apollo_i2c_ctl_w(2, 0x70, 1, 0x40);
@@ -1138,6 +1144,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // # set first I2C switch on channel 4 (U100, address 0x70) to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
@@ -1183,6 +1190,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // =====================================================
   // CMv1 Schematic 4.06 I2C VU7P OPTICS
@@ -1241,6 +1249,7 @@ void init_registers_clk()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // # set I2C switch on channel 2 (U84, address 0x70) to port 6
   apollo_i2c_ctl_w(2, 0x70, 1, 0x40);
@@ -1304,6 +1313,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // # set first I2C switch on channel 4 (U14, address 0x70) to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
@@ -1343,6 +1353,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
   }
   // =====================================================
   // CMv2 Schematic 4.06 I2C FPGA#2 OPTICS
@@ -1549,6 +1560,7 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
       log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+      vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
     }
     // mux setting
     int result = apollo_i2c_ctl_w(i2c_device[i], muxaddr, 1, muxbit);

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -440,7 +440,7 @@ void readFFpresent(void)
 {
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
-	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
   }
 #ifdef REV1
   uint32_t present_0X20_F2, present_0X21_F2, present_FFLDAQ_F1, present_FFL12_F1, present_FFLDAQ_0X20_F2, present_FFL12_0X20_F2, present_FFLDAQ_0X21_F2, present_FFL12_0X21_F2;
@@ -471,7 +471,7 @@ void readFFpresent(void)
 
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
-	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
   }
 #ifdef REV1
   // to port 0
@@ -607,7 +607,7 @@ void getFFpart(void)
 {
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
-	log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
   }
   // Write device vendor part for identifying FF devices
   // FF connecting to FPGA1
@@ -845,7 +845,7 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
 {
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
-  	log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
   }
   // page register
   int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, add, &extra_cmds[0], &page);
@@ -893,7 +893,7 @@ void LGA80D_init(void)
 {
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
-     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
   }
   log_info(LOG_SERVICE, "LGA80D_init\r\n");
   // set up the switching frequency
@@ -1223,7 +1223,6 @@ void init_registers_ff()
   if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
     xSemaphoreGive(i2c3_sem);
   }
-
 }
 #endif // REV1
 #ifdef REV2
@@ -1548,9 +1547,9 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
     }
     // grab the relevant semaphore
     // grab the semaphore to ensure unique access to I2C controller
-      if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
-        log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-      }
+    if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
+      log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    }
     // mux setting
     int result = apollo_i2c_ctl_w(i2c_device[i], muxaddr, 1, muxbit);
     if (result) {
@@ -1570,7 +1569,6 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
     if (xSemaphoreGetMutexHolder(semaphores[i]) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(semaphores[i]);
     }
-
   }
   return 0;
 }

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -464,7 +464,11 @@ void readFFpresent(void)
   apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFLDAQ_F1);
 #endif
 
-  xSemaphoreGive(i2c4_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c4_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c4_sem);
+  }
+
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
 	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
@@ -484,7 +488,10 @@ void readFFpresent(void)
   apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
   apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFLDAQ_F2);
 #endif
-  xSemaphoreGive(i2c3_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c3_sem);
+  }
 
 #ifdef REV1
   uint32_t present_FFL12_BOTTOM_F1 = present_FFL12_F1 & 0x3FU;    // bottom 6 bits
@@ -687,8 +694,10 @@ void getFFpart(void)
   if ((strstr(vendor_string2, "14") != NULL)) {
     ffl12_f2_args.commands = sm_command_fflit_f2; // if the 14Gbsp 12-ch part is found, change the set of commands to sm_command_fflit_f2
   }
-
-  xSemaphoreGive(i2c4_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c4_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c4_sem);
+  }
 }
 
 #define FPGA_MON_NDEVICES_PER_FPGA  2
@@ -870,7 +879,11 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
       log_error(LOG_SERVICE, "error reset\r\n");
     }
   }
-  xSemaphoreGive(i2c1_sem);
+
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c1_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c1_sem);
+  }
 }
 
 // Initialization function for the LGA80D. These settings
@@ -919,8 +932,11 @@ void LGA80D_init(void)
       }
     }
   }
-  xSemaphoreGive(i2c1_sem);
 
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c1_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c1_sem);
+  }
   return;
 }
 
@@ -1105,7 +1121,10 @@ void init_registers_clk()
   // 2b) U92 default output values (I2C address 0x21 on I2C channel #2)
   // All signals are inputs so nothing needs to be done.
 
-  xSemaphoreGive(i2c2_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c2_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c2_sem);
+  }
 }
 void init_registers_ff()
 {
@@ -1156,7 +1175,10 @@ void init_registers_ff()
   apollo_i2c_ctl_reg_w(4, 0x21, 1, 0x02, 1, 0x00); // 00000000 [P07..P00]
   apollo_i2c_ctl_reg_w(4, 0x21, 1, 0x03, 1, 0x03); // 00000011 [P17..P10]
 
-  xSemaphoreGive(i2c4_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c4_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c4_sem);
+  }
 
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
@@ -1197,7 +1219,11 @@ void init_registers_ff()
   apollo_i2c_ctl_reg_w(3, 0x22, 1, 0x06, 1, 0xff); // 11111111 [P07..P00]
   apollo_i2c_ctl_reg_w(3, 0x22, 1, 0x07, 1, 0xf0); // 11110000 [P17..P10]
 
-  xSemaphoreGive(i2c3_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c3_sem);
+  }
+
 }
 #endif // REV1
 #ifdef REV2
@@ -1262,7 +1288,10 @@ void init_registers_clk()
   apollo_i2c_ctl_reg_w(2, 0x21, 1, 0x02, 1, 0x80); //  10000000 [P07..P00]
   apollo_i2c_ctl_reg_w(2, 0x21, 1, 0x03, 1, 0x03); //  00000011 [P17..P10]
 
-  xSemaphoreGive(i2c2_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c2_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c2_sem);
+  }
 }
 void init_registers_ff()
 {
@@ -1307,7 +1336,10 @@ void init_registers_ff()
   apollo_i2c_ctl_reg_w(4, 0x21, 1, 0x02, 1, 0x00); //  00000000 [P07..P00]
   apollo_i2c_ctl_reg_w(4, 0x21, 1, 0x03, 1, 0x01); //  00000001 [P17..P10]
 
-  xSemaphoreGive(i2c4_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c4_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c4_sem);
+  }
 
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
@@ -1349,7 +1381,10 @@ void init_registers_ff()
   apollo_i2c_ctl_reg_w(3, 0x21, 1, 0x02, 1, 0x00); //  00000000 [P07..P00]
   apollo_i2c_ctl_reg_w(3, 0x21, 1, 0x03, 1, 0x01); //  00000001 [P17..P10]
 
-  xSemaphoreGive(i2c3_sem); // if we have a semaphore, give it
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(i2c3_sem);
+  }
 }
 #endif // REV2
 
@@ -1512,8 +1547,10 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
       continue;
     }
     // grab the relevant semaphore
-    xSemaphoreTake(semaphores[i], portMAX_DELAY); // blocks eternally
-
+    // grab the semaphore to ensure unique access to I2C controller
+      if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
+        log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+      }
     // mux setting
     int result = apollo_i2c_ctl_w(i2c_device[i], muxaddr, 1, muxbit);
     if (result) {
@@ -1528,8 +1565,12 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
         log_warn(LOG_I2C, "expand wr %d\r\n", result);
       }
     }
-    // release the semaphore
-    xSemaphoreGive(semaphores[i]);
+
+    // if we have a semaphore, give it
+    if (xSemaphoreGetMutexHolder(semaphores[i]) == xTaskGetCurrentTaskHandle()) {
+      xSemaphoreGive(semaphores[i]);
+    }
+
   }
   return 0;
 }

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -439,10 +439,9 @@ void setFFmask(uint32_t ff_combined_present)
 void readFFpresent(void)
 {
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c4_sem);
+
 #ifdef REV1
   uint32_t present_0X20_F2, present_0X21_F2, present_FFLDAQ_F1, present_FFL12_F1, present_FFLDAQ_0X20_F2, present_FFL12_0X20_F2, present_FFLDAQ_0X21_F2, present_FFL12_0X21_F2;
 #elif defined(REV2)
@@ -471,10 +470,9 @@ void readFFpresent(void)
   }
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c3_sem);
+
 #ifdef REV1
   // to port 0
   apollo_i2c_ctl_w(3, 0x72, 1, 0x01);
@@ -605,102 +603,113 @@ int8_t getFFtemp(const uint8_t i)
   return val;
 }
 
-void getFFpart(void)
+void getFFpart(int which_fpga)
 {
-  // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
-  // Write device vendor part for identifying FF devices
-  // FF connecting to FPGA1
-  uint8_t vendor_data1[4];
-  uint32_t vendor_char1;
-  int8_t vendor_part1[17];
 
-  // FF connecting to FPGA2
-  uint8_t vendor_data2[4];
-  uint32_t vendor_char2;
-  int8_t vendor_part2[17];
+  // Write device vendor part for identifying FF devices
+  uint8_t vendor_data[4];
+  uint32_t vendor_char;
+  int8_t vendor_part[17];
+
 
   uint8_t ven_addr_start = VENDOR_START_BIT_FF12;
   uint8_t ven_addr_stop = VENDOR_STOP_BIT_FF12;
 
-  // checking the FF 12-ch part connected to FPGA1 (need to check from Rx devices (i.e devices[odd]))
-  uint8_t data1;
+  uint8_t data;
 
-  data1 = 0x1U << ffl12_f1_args.devices[3].mux_bit;
-  log_debug(LOG_MONI2C, "Mux set to 0x%02x\r\n", data1);
-  int rmux = apollo_i2c_ctl_w(ffl12_f1_args.i2c_dev, ffl12_f1_args.devices[3].mux_addr, 1, data1);
-  if (rmux != 0) {
-    log_warn(LOG_MONI2C, "Mux write error %s\r\n", SMBUS_get_error(rmux));
-  }
-  for (uint8_t i = ven_addr_start; i < ven_addr_stop; i++) {
-    int res = apollo_i2c_ctl_reg_r(ffl12_f1_args.i2c_dev, ffl12_f1_args.devices[3].dev_addr, 1, (uint16_t)i, 1, &vendor_char1);
-    if (res != 0) {
-      log_warn(LOG_SERVICE, "GetFFpart read Error %s, break\r\n", SMBUS_get_error(res));
-      vendor_part1[i - ven_addr_start] = 0;
-      break;
+
+  if (which_fpga == 1){ // checking the FF 12-ch part connected to FPGA1 (need to check from Rx devices (i.e devices[odd]))
+
+    // grab the semaphore to ensure unique access to I2C controller
+    // otherwise, block its operations indefinitely until it's available
+    acquireI2CSemaphoreBlock(i2c4_sem);
+
+    data = 0x1U << ffl12_f1_args.devices[3].mux_bit;
+    log_debug(LOG_MONI2C, "Mux set to 0x%02x\r\n", data);
+    int rmux = apollo_i2c_ctl_w(ffl12_f1_args.i2c_dev, ffl12_f1_args.devices[3].mux_addr, 1, data);
+    if (rmux != 0) {
+      log_warn(LOG_MONI2C, "Mux write error %s\r\n", SMBUS_get_error(rmux));
     }
-    for (int j = 0; j < 4; ++j) {
-      vendor_data1[j] = (vendor_char1 >> (3 - j) * 8) & 0xFF;
+    for (uint8_t i = ven_addr_start; i < ven_addr_stop; i++) {
+      int res = apollo_i2c_ctl_reg_r(ffl12_f1_args.i2c_dev, ffl12_f1_args.devices[3].dev_addr, 1, (uint16_t)i, 1, &vendor_char);
+      if (res != 0) {
+        log_warn(LOG_SERVICE, "GetFFpart read Error %s, break\r\n", SMBUS_get_error(res));
+        vendor_part[i - ven_addr_start] = 0;
+        break;
+      }
+      for (int j = 0; j < 4; ++j) {
+        vendor_data[j] = (vendor_char >> (3 - j) * 8) & 0xFF;
+      }
+
+      typedef union {
+        uint8_t us;
+        int8_t s;
+      } convert_8_t;
+      convert_8_t tmp1;
+
+      tmp1.us = vendor_data[3]; // change from uint_8 to int8_t, preserving bit pattern
+      vendor_part[i - ven_addr_start] = tmp1.s;
+      vendor_part[i - ven_addr_start + 1] = '\0'; // null-terminated
     }
 
-    typedef union {
-      uint8_t us;
-      int8_t s;
-    } convert_8_t;
-    convert_8_t tmp1;
-
-    tmp1.us = vendor_data1[3]; // change from uint_8 to int8_t, preserving bit pattern
-    vendor_part1[i - ven_addr_start] = tmp1.s;
-    vendor_part1[i - ven_addr_start + 1] = '\0'; // null-terminated
-  }
-
-  char *vendor_string1 = (char *)vendor_part1;
-  log_info(LOG_SERVICE, "Getting Firefly 12-ch part (FPGA1): %s \r\n:", vendor_string1);
-  if ((strstr(vendor_string1, "14") != NULL)) {
-    ffl12_f1_args.commands = sm_command_fflit_f1; // if the 14Gbsp 12-ch part is found, change the set of commands to sm_command_fflit_f1
-  }
-
-  // checking the FF 12-ch part connected to FPGA2 (need to check from Rx devices (i.e devices[odd]))
-  uint8_t data2;
-  data2 = 0x1U << ffl12_f2_args.devices[3].mux_bit; // mux_bit
-  log_debug(LOG_MONI2C, "Mux set to 0x%02x\r\n", data2);
-  rmux = apollo_i2c_ctl_w(ffl12_f2_args.i2c_dev, ffl12_f2_args.devices[3].mux_addr, 1, data2);
-  if (rmux != 0) {
-    log_warn(LOG_MONI2C, "Mux write error %s\r\n", SMBUS_get_error(rmux));
-  }
-  for (uint8_t i = ven_addr_start; i < ven_addr_stop; i++) {
-    int res = apollo_i2c_ctl_reg_r(ffl12_f2_args.i2c_dev, ffl12_f2_args.devices[3].dev_addr, 1, (uint16_t)i, 1, &vendor_char2);
-    if (res != 0) {
-      log_warn(LOG_SERVICE, "GetFFpart read Error %s, break\r\n", SMBUS_get_error(res)); // expected ACK_ADDR_ERR because of no devices[3] for FPGA2 connection as of 08.04.22
-      vendor_part2[i - ven_addr_start] = 0;
-      break;
+    char *vendor_string = (char *)vendor_part;
+    log_info(LOG_SERVICE, "Getting Firefly 12-ch part (FPGA1): %s \r\n:", vendor_string);
+    if ((strstr(vendor_string, "14") != NULL)) {
+      ffl12_f1_args.commands = sm_command_fflit_f1; // if the 14Gbsp 12-ch part is found, change the set of commands to sm_command_fflit_f1
     }
-    for (int j = 0; j < 4; ++j) {
-      vendor_data2[j] = (vendor_char2 >> (3 - j) * 8) & 0xFF;
+
+    // if we have a semaphore, give it
+    if (xSemaphoreGetMutexHolder(i2c4_sem) == xTaskGetCurrentTaskHandle()) {
+      xSemaphoreGive(i2c4_sem);
     }
-    typedef union {
-      uint8_t us;
-      int8_t s;
-    } convert_8_t;
-    convert_8_t tmp1;
+  }
+  else{ // checking the FF 12-ch part connected to FPGA2 (need to check from Rx devices (i.e devices[odd]))
 
-    tmp1.us = vendor_data2[3]; // change from uint_8 to int8_t, preserving bit pattern
-    vendor_part2[i - ven_addr_start] = tmp1.s;
-    vendor_part2[i - ven_addr_start + 1] = '\0'; // null-terminated
+    // grab the semaphore to ensure unique access to I2C controller
+    // otherwise, block its operations indefinitely until it's available
+    acquireI2CSemaphoreBlock(i2c3_sem);
+
+    data = 0x1U << ffl12_f2_args.devices[3].mux_bit; // mux_bit
+    log_debug(LOG_MONI2C, "Mux set to 0x%02x\r\n", data);
+    int rmux = apollo_i2c_ctl_w(ffl12_f2_args.i2c_dev, ffl12_f2_args.devices[3].mux_addr, 1, data);
+    if (rmux != 0) {
+      log_warn(LOG_MONI2C, "Mux write error %s\r\n", SMBUS_get_error(rmux));
+    }
+    for (uint8_t i = ven_addr_start; i < ven_addr_stop; i++) {
+      int res = apollo_i2c_ctl_reg_r(ffl12_f2_args.i2c_dev, ffl12_f2_args.devices[3].dev_addr, 1, (uint16_t)i, 1, &vendor_char);
+      if (res != 0) {
+        log_warn(LOG_SERVICE, "GetFFpart read Error %s, break\r\n", SMBUS_get_error(res)); // expected ACK_ADDR_ERR because of no devices[3] for FPGA2 connection as of 08.04.22
+        vendor_part[i - ven_addr_start] = 0;
+        break;
+      }
+      for (int j = 0; j < 4; ++j) {
+        vendor_data[j] = (vendor_char >> (3 - j) * 8) & 0xFF;
+      }
+      typedef union {
+        uint8_t us;
+        int8_t s;
+      } convert_8_t;
+      convert_8_t tmp1;
+
+      tmp1.us = vendor_data[3]; // change from uint_8 to int8_t, preserving bit pattern
+      vendor_part[i - ven_addr_start] = tmp1.s;
+      vendor_part[i - ven_addr_start + 1] = '\0'; // null-terminated
+    }
+
+    char *vendor_string = (char *)vendor_part;
+    log_info(LOG_SERVICE, "Getting Firefly 12-ch part (FPGA2) : %s \r\n:", vendor_string);
+    if ((strstr(vendor_string, "14") != NULL)) {
+      ffl12_f2_args.commands = sm_command_fflit_f2; // if the 14Gbsp 12-ch part is found, change the set of commands to sm_command_fflit_f2
+    }
+
+    // if we have a semaphore, give it
+    if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
+      xSemaphoreGive(i2c3_sem);
+    }
+
   }
 
-  char *vendor_string2 = (char *)vendor_part2;
-  log_info(LOG_SERVICE, "Getting Firefly 12-ch part (FPGA2) : %s \r\n:", vendor_string2);
-  if ((strstr(vendor_string2, "14") != NULL)) {
-    ffl12_f2_args.commands = sm_command_fflit_f2; // if the 14Gbsp 12-ch part is found, change the set of commands to sm_command_fflit_f2
-  }
-  // if we have a semaphore, give it
-  if (xSemaphoreGetMutexHolder(i2c4_sem) == xTaskGetCurrentTaskHandle()) {
-    xSemaphoreGive(i2c4_sem);
-  }
+
 }
 
 #define FPGA_MON_NDEVICES_PER_FPGA  2
@@ -895,11 +904,11 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
 // this is currently not ensured in this code.
 void LGA80D_init(void)
 {
+
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c1_sem);
+
   log_info(LOG_SERVICE, "LGA80D_init\r\n");
   // set up the switching frequency
   uint16_t freqlin11 = float_to_linear11(457.14f);
@@ -1084,10 +1093,9 @@ void init_registers_clk()
   // All unused signals should be inputs [P07..P04], [P17..P15].
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c1_sem);
+
   // # set I2C switch on channel 2 (U94, address 0x70) to port 6
   apollo_i2c_ctl_w(2, 0x70, 1, 0x40);
   apollo_i2c_ctl_reg_w(2, 0x20, 1, 0x06, 1, 0xf0); // 11110000 [P07..P00]
@@ -1142,10 +1150,9 @@ void init_registers_ff()
   // All signals are inputs.
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c4_sem);
+
   // # set first I2C switch on channel 4 (U100, address 0x70) to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
   apollo_i2c_ctl_reg_w(4, 0x20, 1, 0x06, 1, 0xff); // 11111111 [P07..P00]
@@ -1188,10 +1195,9 @@ void init_registers_ff()
   }
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c3_sem);
+
   // =====================================================
   // CMv1 Schematic 4.06 I2C VU7P OPTICS
 
@@ -1247,10 +1253,9 @@ void init_registers_clk()
   // The remaining 10 signals are outputs.
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c2_sem);
+
   // # set I2C switch on channel 2 (U84, address 0x70) to port 6
   apollo_i2c_ctl_w(2, 0x70, 1, 0x40);
   apollo_i2c_ctl_reg_w(2, 0x20, 1, 0x06, 1, 0x70); //  01110000 [P07..P00]
@@ -1311,10 +1316,9 @@ void init_registers_ff()
   // All signals are inputs.
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c4_sem);
+
   // # set first I2C switch on channel 4 (U14, address 0x70) to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
   apollo_i2c_ctl_reg_w(4, 0x20, 1, 0x06, 1, 0xff); //  11111111 [P07..P00]
@@ -1351,10 +1355,9 @@ void init_registers_ff()
   }
 
   // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
+  // otherwise, block its operations indefinitely until it's available
+  acquireI2CSemaphoreBlock(i2c3_sem);
+
   // =====================================================
   // CMv2 Schematic 4.06 I2C FPGA#2 OPTICS
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -1558,7 +1558,7 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
       log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-      return -2;
+      return 5;
     }
     // mux setting
     int result = apollo_i2c_ctl_w(i2c_device[i], muxaddr, 1, muxbit);

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -441,7 +441,7 @@ void readFFpresent(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
 #ifdef REV1
   uint32_t present_0X20_F2, present_0X21_F2, present_FFLDAQ_F1, present_FFL12_F1, present_FFLDAQ_0X20_F2, present_FFL12_0X20_F2, present_FFLDAQ_0X21_F2, present_FFL12_0X21_F2;
@@ -473,7 +473,7 @@ void readFFpresent(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
 #ifdef REV1
   // to port 0
@@ -610,7 +610,7 @@ void getFFpart(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // Write device vendor part for identifying FF devices
   // FF connecting to FPGA1
@@ -849,7 +849,7 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // page register
   int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, add, &extra_cmds[0], &page);
@@ -898,7 +898,7 @@ void LGA80D_init(void)
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   log_info(LOG_SERVICE, "LGA80D_init\r\n");
   // set up the switching frequency
@@ -1086,7 +1086,7 @@ void init_registers_clk()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // # set I2C switch on channel 2 (U94, address 0x70) to port 6
   apollo_i2c_ctl_w(2, 0x70, 1, 0x40);
@@ -1144,7 +1144,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // # set first I2C switch on channel 4 (U100, address 0x70) to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
@@ -1190,7 +1190,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // =====================================================
   // CMv1 Schematic 4.06 I2C VU7P OPTICS
@@ -1249,7 +1249,7 @@ void init_registers_clk()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c2_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // # set I2C switch on channel 2 (U84, address 0x70) to port 6
   apollo_i2c_ctl_w(2, 0x70, 1, 0x40);
@@ -1313,7 +1313,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c4_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // # set first I2C switch on channel 4 (U14, address 0x70) to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
@@ -1353,7 +1353,7 @@ void init_registers_ff()
   // grab the semaphore to ensure unique access to I2C controller
   if (acquireI2CSemaphore(i2c3_sem) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+    return;
   }
   // =====================================================
   // CMv2 Schematic 4.06 I2C FPGA#2 OPTICS
@@ -1560,7 +1560,7 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
       log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-      vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
+      return -2;
     }
     // mux setting
     int result = apollo_i2c_ctl_w(i2c_device[i], muxaddr, 1, muxbit);

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -86,7 +86,8 @@ void MonitorI2CTask(void *parameters)
     log_debug(LOG_MONI2C, "%s: grab semaphore\r\n", args->name);
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
-      log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+      log_warn(LOG_SERVICE, "%s could not get semaphore in time\r\n", args->name);
+      vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
       // break;
     }
 

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -86,8 +86,8 @@ void MonitorI2CTask(void *parameters)
     log_debug(LOG_MONI2C, "%s: grab semaphore\r\n", args->name);
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
-    	log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    	//break;
+      log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+      // break;
     }
 
     args->updateTick = xTaskGetTickCount(); // current time in ticks

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -32,6 +32,7 @@
 #include "common/log.h"
 #include "Tasks.h"
 #include "I2CCommunication.h"
+#include "Semaphore.h"
 
 // local prototype
 
@@ -84,8 +85,10 @@ void MonitorI2CTask(void *parameters)
   for (;;) {
     log_debug(LOG_MONI2C, "%s: grab semaphore\r\n", args->name);
     // grab the semaphore to ensure unique access to I2C controller
-    while (xSemaphoreTake(args->xSem, (TickType_t)10) == pdFALSE)
-      ;
+    if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
+    	log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    }
+
     args->updateTick = xTaskGetTickCount(); // current time in ticks
     // -------------------------------
     // loop over devices in the device-type instance

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -86,9 +86,8 @@ void MonitorI2CTask(void *parameters)
     log_debug(LOG_MONI2C, "%s: grab semaphore\r\n", args->name);
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
-      log_warn(LOG_SERVICE, "%s could not get semaphore in time\r\n", args->name);
-      vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
-      // break;
+      log_warn(LOG_SERVICE, "%s could not get semaphore in time; continue\r\n", args->name);
+      continue;
     }
 
     args->updateTick = xTaskGetTickCount(); // current time in ticks

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -87,6 +87,7 @@ void MonitorI2CTask(void *parameters)
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
     	log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    	//break;
     }
 
     args->updateTick = xTaskGetTickCount(); // current time in ticks
@@ -193,14 +194,10 @@ void MonitorI2CTask(void *parameters)
 
     } // loop over devices
 
+    // if we have a semaphore, give it
     if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);
     }
-    else {
-      log_info(LOG_MONI2C, "tried to release semaphore I don't own\r\n");
-    }
-
-    //xSemaphoreGive(args->xSem);
 
     // monitor stack usage for this task
     CHECK_TASK_STACK_USAGE(args->stack_size);

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -44,7 +44,7 @@
 // break out of loop, releasing semaphore if we have it
 #define release_break()           \
   {                               \
-    if (args->xSem != NULL)       \
+    if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle())       \
       xSemaphoreGive(args->xSem); \
     break;                        \
   }
@@ -71,6 +71,7 @@ void MonitorTask(void *parameters)
     if (args->xSem != NULL) {
     	if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
     		log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    		//break;
     	}
     }
     args->updateTick = xTaskGetTickCount(); // current time in ticks
@@ -188,8 +189,10 @@ void MonitorTask(void *parameters)
         }                   // loop over commands
       }                     // loop over pages
     }                       // loop over power supplies
-    if (args->xSem != NULL) // if we have a semaphore, give it
+    // if we have a semaphore, give it
+    if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);
+    }
 
     CHECK_TASK_STACK_USAGE(args->stack_size);
 

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -70,11 +70,11 @@ void MonitorTask(void *parameters)
     // grab the semaphore to ensure unique access to I2C controller
     if (args->xSem != NULL) {
       if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
-        log_warn(LOG_SERVICE, "%s could not get semaphore in time\r\n", args->name);
-        vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
-        // break;
+        log_warn(LOG_SERVICE, "%s could not get semaphore in time; continue\r\n", args->name);
+        continue;
       }
     }
+
     args->updateTick = xTaskGetTickCount(); // current time in ticks
     // loop over devices
     for (int ps = 0; ps < args->n_devices; ++ps) {

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -42,11 +42,11 @@
 #define PAGE_COMMAND 0x0
 
 // break out of loop, releasing semaphore if we have it
-#define release_break()           \
-  {                               \
-    if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle())       \
-      xSemaphoreGive(args->xSem); \
-    break;                        \
+#define release_break()                                                      \
+  {                                                                          \
+    if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) \
+      xSemaphoreGive(args->xSem);                                            \
+    break;                                                                   \
   }
 
 void MonitorTask(void *parameters)
@@ -69,10 +69,10 @@ void MonitorTask(void *parameters)
   for (;;) {
     // grab the semaphore to ensure unique access to I2C controller
     if (args->xSem != NULL) {
-    	if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
-    		log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    		//break;
-    	}
+      if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
+        log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+        // break;
+      }
     }
     args->updateTick = xTaskGetTickCount(); // current time in ticks
     // loop over devices
@@ -186,9 +186,9 @@ void MonitorTask(void *parameters)
           args->pm_values[index] = val;
           // wait here for the x msec, where x is 2nd argument below.
           vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(10));
-        }                   // loop over commands
-      }                     // loop over pages
-    }                       // loop over power supplies
+        } // loop over commands
+      }   // loop over pages
+    }     // loop over power supplies
     // if we have a semaphore, give it
     if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -34,6 +34,7 @@
 #include "common/power_ctl.h"
 #include "MonitorTask.h"
 #include "Tasks.h"
+#include "Semaphore.h"
 
 // Todo: rewrite to get away from awkward/bad SMBUS implementation from TI
 
@@ -68,8 +69,9 @@ void MonitorTask(void *parameters)
   for (;;) {
     // grab the semaphore to ensure unique access to I2C controller
     if (args->xSem != NULL) {
-      while (xSemaphoreTake(args->xSem, (TickType_t)10) == pdFALSE)
-        ;
+    	if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
+    		log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    	}
     }
     args->updateTick = xTaskGetTickCount(); // current time in ticks
     // loop over devices

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -70,7 +70,8 @@ void MonitorTask(void *parameters)
     // grab the semaphore to ensure unique access to I2C controller
     if (args->xSem != NULL) {
       if (acquireI2CSemaphore(args->xSem) == pdFAIL) {
-        log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+        log_warn(LOG_SERVICE, "%s could not get semaphore in time\r\n", args->name);
+        vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
         // break;
       }
     }

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -56,7 +56,7 @@ SemaphoreHandle_t getSemaphore(int number)
   return s;
 }
 
-#define MAX_TRIES 50
+#define MAX_TRIES 500
 int acquireI2CSemaphore(SemaphoreHandle_t s)
 {
   int retval = pdTRUE;

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -57,14 +57,16 @@ SemaphoreHandle_t getSemaphore(int number)
 }
 
 #define MAX_TRIES 500
-int acquireI2CSemaphore(SemaphoreHandle_t s)
+
+
+int acquireI2CSemaphoreTime(SemaphoreHandle_t s, TickType_t tickWaits)
 {
   int retval = pdTRUE;
   if (s == NULL) {
     return pdFAIL;
   }
   int tries = 0;
-  while (xSemaphoreTake(s, (TickType_t)10) == pdFALSE) {
+  while (xSemaphoreTake(s, tickWaits) == pdFALSE) {
     ++tries;
     if (tries > MAX_TRIES) {
       retval = pdFAIL;

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -26,3 +26,50 @@ void initSemaphores(void)
   i2c5_sem = xSemaphoreCreateMutex();
   i2c6_sem = xSemaphoreCreateMutex();
 }
+
+SemaphoreHandle_t getSemaphore(int number)
+{
+  SemaphoreHandle_t s;
+  switch (number) {
+    case 1:
+      s = i2c1_sem;
+      break;
+    case 2:
+      s = i2c2_sem;
+      break;
+    case 3:
+      s = i2c3_sem;
+      break;
+    case 4:
+      s = i2c4_sem;
+      break;
+    case 5:
+      s = i2c5_sem;
+      break;
+    case 6:
+      s = i2c6_sem;
+      break;
+    default:
+      s = 0;
+      break;
+  }
+  return s;
+}
+
+#define MAX_TRIES 50
+int acquireI2CSemaphore(SemaphoreHandle_t s)
+{
+  int retval = pdTRUE;
+  if (s == NULL) {
+    return pdFAIL;
+  }
+  int tries = 0;
+  while (xSemaphoreTake(s, (TickType_t)10) == pdFALSE) {
+    ++tries;
+    if (tries > MAX_TRIES) {
+      retval = pdFAIL;
+      break;
+    }
+  }
+  return retval;
+}

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -58,7 +58,6 @@ SemaphoreHandle_t getSemaphore(int number)
 
 #define MAX_TRIES 500
 
-
 int acquireI2CSemaphoreTime(SemaphoreHandle_t s, TickType_t tickWaits)
 {
   int retval = pdTRUE;

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -73,3 +73,4 @@ int acquireI2CSemaphore(SemaphoreHandle_t s)
   }
   return retval;
 }
+

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -73,4 +73,3 @@ int acquireI2CSemaphore(SemaphoreHandle_t s)
   }
   return retval;
 }
-

--- a/projects/cm_mcu/Semaphore.h
+++ b/projects/cm_mcu/Semaphore.h
@@ -23,4 +23,8 @@ extern SemaphoreHandle_t i2c6_sem;
 
 void initSemaphores(void);
 
+SemaphoreHandle_t getSemaphore(int number);
+
+int acquireI2CSemaphore(SemaphoreHandle_t s);
+
 #endif /* PROJECTS_CM_MCU_SEMAPHORE_H_ */

--- a/projects/cm_mcu/Semaphore.h
+++ b/projects/cm_mcu/Semaphore.h
@@ -25,6 +25,12 @@ void initSemaphores(void);
 
 SemaphoreHandle_t getSemaphore(int number);
 
-int acquireI2CSemaphore(SemaphoreHandle_t s);
+int acquireI2CSemaphoreTime(SemaphoreHandle_t s, TickType_t tickWaits);
+
+#define acquireI2CSemaphore(s) \
+  acquireI2CSemaphoreTime(s, 10)
+
+#define acquireI2CSemaphoreBlock(s) \
+  acquireI2CSemaphoreTime(s, 0)
 
 #endif /* PROJECTS_CM_MCU_SEMAPHORE_H_ */

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -169,9 +169,9 @@ void readFFpresent(void);
 int8_t getFFtemp(const uint8_t i);
 void getFFpart(int which_fpga);
 #define getFFpart_FPGA1(void) \
-    getFFpart(1);
+  getFFpart(1);
 #define getFFpart_FPGA2(void) \
-    getFFpart(2);
+  getFFpart(2);
 
 uint8_t getFFstatus(const uint8_t i);
 int getFFcheckStale(void);

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -167,7 +167,12 @@ bool isEnabledFF(int ff);
 void setFFmask(uint32_t ff_combined_mask);
 void readFFpresent(void);
 int8_t getFFtemp(const uint8_t i);
-void getFFpart(void);
+void getFFpart(int which_fpga);
+#define getFFpart_FPGA1(void) \
+    getFFpart(1);
+#define getFFpart_FPGA2(void) \
+    getFFpart(2);
+
 uint8_t getFFstatus(const uint8_t i);
 int getFFcheckStale(void);
 TickType_t getFFupdateTick(int ff_t);

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -334,6 +334,8 @@ BaseType_t gpio_ctl(int argc, char **argv, char *m)
 // interface: v38 on|off 1|2
 BaseType_t v38_ctl(int argc, char **argv, char *m)
 {
+  // argument handling
+  int copied = 0;
   bool turnOn = true;
   if (strncmp(argv[1], "off", 3) == 0)
     turnOn = false;
@@ -344,8 +346,14 @@ BaseType_t v38_ctl(int argc, char **argv, char *m)
   }
   UBaseType_t ffmask[2] = {0, 0};
   ffmask[whichFF - 1] = 0xe;
-  enable_3v8(ffmask, !turnOn);
-  snprintf(m, SCRATCH_SIZE, "%s: 3V8 turned %s for F%ld\r\n", argv[0],
+  int ret = enable_3v8(ffmask, !turnOn);
+  if (ret != 0) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "enable 3v8 failed with %d\r\n", ret);
+    if (ret == 5)
+      snprintf(m + copied, SCRATCH_SIZE - copied, "please release semaphore \r\n");
+    return pdFALSE;
+  }
+  snprintf(m + copied, SCRATCH_SIZE - copied, "%s: 3V8 turned %s for F%ld\r\n", argv[0],
            turnOn == true ? "on" : "off", whichFF);
   return pdFALSE;
 }

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -162,7 +162,6 @@ BaseType_t i2c_scan(int argc, char **argv, char *m)
   }
   if (acquireI2CSemaphore(s) == pdFAIL) {
     snprintf(m, SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
-    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
     return pdFALSE;
   }
 

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -11,52 +11,6 @@
 #include "Semaphore.h"
 #include "projdefs.h"
 
-SemaphoreHandle_t getSemaphore(int number)
-{
-  SemaphoreHandle_t s;
-  switch (number) {
-    case 1:
-      s = i2c1_sem;
-      break;
-    case 2:
-      s = i2c2_sem;
-      break;
-    case 3:
-      s = i2c3_sem;
-      break;
-    case 4:
-      s = i2c4_sem;
-      break;
-    case 5:
-      s = i2c5_sem;
-      break;
-    case 6:
-      s = i2c6_sem;
-      break;
-    default:
-      s = 0;
-      break;
-  }
-  return s;
-}
-#define MAX_TRIES 10
-static int acquireI2CSemaphore(SemaphoreHandle_t s)
-{
-  int retval = pdTRUE;
-  if (s == NULL) {
-    return pdFAIL;
-  }
-  int tries = 0;
-  while (xSemaphoreTake(s, (TickType_t)10) == pdFALSE) {
-    ++tries;
-    if (tries > MAX_TRIES) {
-      retval = pdFAIL;
-      break;
-    }
-  }
-  return retval;
-}
-
 static bool isValidDevice(int device)
 {
 #ifdef REV1

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -185,6 +185,10 @@ BaseType_t i2c_scan(int argc, char **argv, char *m)
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
   configASSERT(copied < SCRATCH_SIZE);
 
-  xSemaphoreGive(s);
+  // if we have a semaphore, give it
+  if (xSemaphoreGetMutexHolder(s) == xTaskGetCurrentTaskHandle()) {
+    xSemaphoreGive(s);
+  }
+
   return pdFALSE;
 }

--- a/projects/cm_mcu/commands/I2CCommands.c
+++ b/projects/cm_mcu/commands/I2CCommands.c
@@ -162,6 +162,7 @@ BaseType_t i2c_scan(int argc, char **argv, char *m)
   }
   if (acquireI2CSemaphore(s) == pdFAIL) {
     snprintf(m, SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
+    vTaskDelay(pdMS_TO_TICKS(330)); // delay 300 ms
     return pdFALSE;
   }
 

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -48,8 +48,11 @@ static int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t 
   if (i2c_device == I2C_DEVICE_F2) {
     s = i2c3_sem;
   }
-  while (xSemaphoreTake(s, (TickType_t)10) == pdFALSE)
-    ;
+
+  if (acquireI2CSemaphore(s) == pdFAIL) {
+	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+	  return -2;
+  }
 
   // write to the mux
   // select the appropriate output for the mux
@@ -96,8 +99,11 @@ static int write_ff_register(const char *name, uint8_t reg, uint16_t value, int 
   if (i2c_device == I2C_DEVICE_F2) {
     s = i2c3_sem;
   }
-  while (xSemaphoreTake(s, (TickType_t)10) == pdFALSE)
-    ;
+
+  if (acquireI2CSemaphore(s) == pdFAIL) {
+      log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+      return -2;
+  }
 
   // write to the mux
   // select the appropriate output for the mux

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1208,7 +1208,7 @@ BaseType_t psmon_reg(int argc, char **argv, char *m)
 
   // acquire the semaphore
   if (acquireI2CSemaphore(dcdc_args.xSem) == pdFAIL) {
-    snprintf(m + copied, SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
+    snprintf(m + copied, SCRATCH_SIZE - copied, "%s: could not get semaphore in time\r\n", argv[0]);
     return pdFALSE;
   }
   uint8_t ui8page = page;

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -77,7 +77,9 @@ static int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t 
     }
   }
 
-  xSemaphoreGive(s);
+  // release the semaphore
+  if (xSemaphoreGetMutexHolder(s) == xTaskGetCurrentTaskHandle())
+    xSemaphoreGive(s);
   return res;
 }
 
@@ -124,7 +126,9 @@ static int write_ff_register(const char *name, uint8_t reg, uint16_t value, int 
     }
   }
 
-  xSemaphoreGive(s);
+  // release the semaphore
+  if (xSemaphoreGetMutexHolder(s) == xTaskGetCurrentTaskHandle())
+    xSemaphoreGive(s);
   return res;
 }
 
@@ -1204,7 +1208,7 @@ BaseType_t psmon_reg(int argc, char **argv, char *m)
 
   // acquire the semaphore
   if (acquireI2CSemaphore(dcdc_args.xSem) == pdFAIL) {
-    snprintf(m, SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
+    snprintf(m + copied, SCRATCH_SIZE, "%s: could not get semaphore in time\r\n", argv[0]);
     return pdFALSE;
   }
   uint8_t ui8page = page;

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -50,8 +50,8 @@ static int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t 
   }
 
   if (acquireI2CSemaphore(s) == pdFAIL) {
-	  log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-	  return -2;
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    return -2;
   }
 
   // write to the mux
@@ -103,8 +103,8 @@ static int write_ff_register(const char *name, uint8_t reg, uint16_t value, int 
   }
 
   if (acquireI2CSemaphore(s) == pdFAIL) {
-      log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-      return -2;
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    return -2;
   }
 
   // write to the mux

--- a/projects/cm_mcu/commands/SoftwareCommands.c
+++ b/projects/cm_mcu/commands/SoftwareCommands.c
@@ -403,7 +403,7 @@ BaseType_t sem_ctl(int argc, char **argv, char *m)
     }
     else if (strncmp(argv[2], "take", 4) == 0) {
       // try to acquire the semaphore. Wait a finite amount of time.
-      if (xSemaphoreTake(s, pdMS_TO_TICKS(500)) == pdTRUE) {
+      if (xSemaphoreTake(s, pdMS_TO_TICKS(5000)) == pdTRUE) {
         snprintf(m, SCRATCH_SIZE, "%s: taking semaphore %d\r\n", argv[0], number);
         sem_status |= 0x1U << number;
       }


### PR DESCRIPTION
- replace xSemaphoreTake infinite loop by `acquireI2CSemaphore` 
- add a check of `xSemaphoreGetMutexHolder(s) == xTaskGetCurrentTaskHandle()` where s is the semaphore struct before  xSemaphoreGive 
- a few improvement such as removing misleading statement of "... tried releasing a semaphore we don't own.. " that does nothing if semaphore is not owned in the scope, and increasing maxtries in `acquireI2CSemaphore.`

Here is the test that indicates that the current code works as expected :

```
% loadclock 0                                                                                                                                                                       
loadclock is programming clock r0a.                                                                                                                                                 
clock synthesizer with id r0a successfully programmed.                                                                                                                              
% semaphore 2 take                                                                                                                                                                  
semaphore: taking semaphore 2                                                                                                                                                       
% loadclock 0                                                                                                                                                                       
202211101707 SRV WRN MonitorI2CTask.c:89:could not get semaphore in time                                                                                                            
202211101707 SRV WRN MonitorI2CTask.c:89:could not get semaphore in time                                                                                                            
loadclock is programming clock r0a.                                                                                                                                                 
loadclock: could not get semaphore in time                                                                                                                                          
% semaphore 2 release                                                                                                                                                               
semaphore: releasing semaphore 2 (mask 0x00)                                                                                                                                        
% psreg 0 10                                                                                                                                                                        
psreg: page 0 of device 3V3/1V8, reg 0x10                                                                                                                                           
psreg: read value 0x0000                                                                                                                                                            
% semaphore 1 take                                                                                                                                                                  
semaphore: failed to acquire semaphore 1 in time                                                                                                                                    
% psreg 0 10                                                                                                                                                                        
psreg: page 0 of device 3V3/1V8, reg 0x10                                                                                                                                           
psreg: read value 0x0000                                                                                                                                                            
% semaphore 1 take                                                                                                                                                                  
semaphore: taking semaphore 1                                                                                                                                                       
% psreg 0 10                                                                                                                                                                        
202211101709 SRV WRN MonitorTask.c:73:could not get semaphore in time                                                                                                               
psreg: page 0 of device 3V3/1V8, reg 0x10                                                                                                                                           
psreg: could not get semaphore in time                                                                                                                                              
%
```