### PR TITLE
add new 'powering down' state to PS state machine

### DIFF
--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -61,6 +61,9 @@ tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus3, &eStat
 
 #define MAX_BYTES_ADDR 2
 #define MAX_BYTES      4
+
+#define I2C_MAX_TRIES 25
+
 int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t data[MAX_BYTES])
 {
   tSMBus *p_sMaster = pSMBus[device];
@@ -77,7 +80,7 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
     int tries = 0;
     while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
       vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > 100) {
+      if (tries++ > I2C_MAX_TRIES) {
         log_warn(LOG_I2C, "transfer stuck\r\n");
         break;
       }
@@ -109,7 +112,7 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
     int tries = 0;
     while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
       vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > 100) {
+      if (tries++ > I2C_MAX_TRIES) {
         log_warn(LOG_I2C, "transfer stuck\r\n");
         break;
       }
@@ -155,7 +158,7 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
     int tries = 0;
     while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
       vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > 100) {
+      if (tries++ > I2C_MAX_TRIES) {
         log_warn(LOG_I2C, "transfer stuck\r\n");
         break;
       }
@@ -187,7 +190,7 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
     int tries = 0;
     while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
       vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > 100) {
+      if (tries++ > I2C_MAX_TRIES) {
         log_warn(LOG_I2C, "transfer stuck\r\n");
         break;
       }
@@ -214,7 +217,7 @@ int apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_status, bo
   int tries = 0;
   while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
     vTaskDelay(pdMS_TO_TICKS(10));
-    if (tries++ > 100) {
+    if (tries++ > I2C_MAX_TRIES) {
       log_warn(LOG_I2C, "transfer stuck\r\n");
       break;
     }
@@ -236,7 +239,7 @@ int apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_status, bo
   tries = 0;
   while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
     vTaskDelay(pdMS_TO_TICKS(10));
-    if (tries++ > 100) {
+    if (tries++ > I2C_MAX_TRIES) {
       log_warn(LOG_I2C, "transfer stuck\r\n");
       break;
     }

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -213,7 +213,7 @@ void PowerSupplyTask(void *parameters)
     // ON1 .. ON5 are the five states of the turn-on sequence
     // OFF1 .. OFF5 are the five states of the turn-off sequence
     // in the transition to FAIL we turn off all the supplies in sequence,
-    // even if they were not yet tured on (i.e., transition from ON3 -> FAIL)
+    // even if they were not yet turned on (i.e., transition from ON3 -> FAIL)
     //                     +-------------------+
     //              +------+       FAIL        +<-----+
     // +-------+    |      +--+-------------+--+      |
@@ -222,8 +222,9 @@ void PowerSupplyTask(void *parameters)
     //     |     ---+--+   +--+-+         +-+--+  +---+--+
     //     +---->+ OFF +---> ON1+-> ....  | ON5+->+  ON  |
     //           +--+--+   +----+         +----+  +---+--+
-    //              |                                 |
-    //              +---------------------------------+
+    //              |            +------+             |
+    //              +-----<------| DOWN <-------------+
+    //                           +------+
 
     // Nota Bene:
     // ON3 does not have a FAIL transition because those supplies
@@ -259,13 +260,18 @@ void PowerSupplyTask(void *parameters)
         }
         else if (!blade_power_enable || cli_powerdown_request) {
           log_info(LOG_PWRCTL, "power-down requested\r\n");
-          disable_ps();
-          errbuffer_put(EBUF_POWER_OFF, 0);
-          nextState = POWER_OFF;
+          nextState = POWER_DOWN;
         }
         else {
           nextState = POWER_ON;
         }
+        break;
+      }
+      case POWER_DOWN: {
+        disable_ps();
+        errbuffer_put(EBUF_POWER_OFF, 0);
+        log_info(LOG_PWRCTL, "power-down completed\r\n");
+        nextState = POWER_OFF;
         break;
       }
       case POWER_OFF: {

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -64,6 +64,7 @@ extern QueueHandle_t xPwrQueue;
 enum power_system_state {
   POWER_FAILURE,
   POWER_INIT,
+  POWER_DOWN,
   POWER_OFF,
   POWER_L1ON,
   POWER_L2ON,


### PR DESCRIPTION
I think this finally fixes the issue with apollo205. The fix adds a state to the power-control state machine that is between ON and OFF so we go from ON -> DOWN -> OFF. Other tasks can now see that the power is no longer ON but it is still ON long enough to allow the current set of tasks to complete, thereby avoiding the weird behavior where it appears that one of the I2C controllers goes into a loop where it continually fires an interrupt when power gets removed, thereby starving the rest of the MCU tasks of resources, which causes the CLI to lock up and the MCU to no longer respond to power-control requests.