### PR TITLE
Bug fix: add 'DOWN' state to power control state machine strings

### DIFF
--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -76,6 +76,7 @@ void printfail(uint16_t failed_mask, uint16_t supply_ok_mask, uint16_t supply_bi
 static const char *const power_system_state_names[] = {
     "FAIL",
     "INIT",
+    "DOWN",
     "OFF",
     "L1ON",
     "L2ON",


### PR DESCRIPTION
Mistake that I didn't catch in PR #169 