### PR TITLE
Bug fix: update how stale data is handled for monitor tasks

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -501,6 +501,8 @@ void float_to_ints(float val, int *tens, int *fraction)
   return;
 }
 
+// compare two times in seconds and make sure they are within the last 60 seconds
+// if not the value is 'stale' and the function returns true
 bool checkStale(unsigned oldTime, unsigned newTime)
 {
   return ((oldTime < newTime) && (newTime - oldTime) > 60);

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -561,7 +561,7 @@ unsigned isFFStale(void)
 // this will return the tick of the _lowest_ set bit.
 TickType_t getFFupdateTick(int mask)
 {
-  log_debug(LOG_SERVICE, "%s mask = %x\r\n", __func__, mask);
+  log_debug(LOG_SERVICE, "mask = %x\r\n", mask);
   if ( __builtin_popcount(mask) == 0 ) {
     log_warn(LOG_SERVICE, "empty mask\r\n");
   }

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -13,7 +13,7 @@
 #include <stdint.h>
 #include <string.h> // memset
 #include <sys/_types.h>
-#include <time.h>   // struct tm
+#include <time.h> // struct tm
 
 // ROM header must come before MAP header
 #include "driverlib/rom.h"
@@ -551,7 +551,7 @@ unsigned isFFStale(void)
   unsigned mask = 0U;
   for (int ff_t = 0; ff_t < 4; ++ff_t) {
     if (checkStale(last[ff_t], now)) {
-      mask |= (1U<< ff_t);
+      mask |= (1U << ff_t);
     }
   }
 
@@ -562,7 +562,7 @@ unsigned isFFStale(void)
 TickType_t getFFupdateTick(int mask)
 {
   log_debug(LOG_SERVICE, "mask = %x\r\n", mask);
-  if ( __builtin_popcount(mask) == 0 ) {
+  if (__builtin_popcount(mask) == 0) {
     log_warn(LOG_SERVICE, "empty mask\r\n");
   }
   if (mask & 0x1U) {

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h> // memset
+#include <sys/_types.h>
 #include <time.h>   // struct tm
 
 // ROM header must come before MAP header
@@ -538,37 +539,39 @@ bool isEnabledFF(int ff)
   }
 }
 
-int getFFcheckStale(void)
+unsigned isFFStale(void)
 {
-  TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+  TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
   TickType_t last[4];
-  last[0] = ffl12_f1_args.updateTick;
-  last[1] = ffldaq_f1_args.updateTick;
-  last[2] = ffl12_f2_args.updateTick;
-  last[3] = ffldaq_f2_args.updateTick;
+  last[0] = pdTICKS_TO_S(ffl12_f1_args.updateTick);
+  last[1] = pdTICKS_TO_S(ffldaq_f1_args.updateTick);
+  last[2] = pdTICKS_TO_S(ffl12_f2_args.updateTick);
+  last[3] = pdTICKS_TO_S(ffldaq_f2_args.updateTick);
 
-  int ff_t = 0;
-  for (; ff_t < 4; ++ff_t) {
-    if (!checkStale(pdTICKS_TO_MS(last[ff_t]) / 1000, now)) {
-      ff_t -= 4;
-      break;
+  unsigned mask = 0U;
+  for (int ff_t = 0; ff_t < 4; ++ff_t) {
+    if (checkStale(last[ff_t], now)) {
+      mask |= (1U<< ff_t);
     }
   }
 
-  return (ff_t - 3); // convert ff_t to exit codes -7,-6,-5 -4, 0 with no stale, stale at least 1, 2 and 3, or all stale
+  return mask; // bits set for stale tasks. no bits set == not stale.
 }
 
-TickType_t getFFupdateTick(int ff_t)
+// this will return the tick of the _lowest_ set bit.
+TickType_t getFFupdateTick(int mask)
 {
-  ff_t += 7; // convert exit codes -7,-6,-5,-4 back to ff_t
-  log_debug(LOG_SERVICE, "ff_updateTick is ff_t = %d \r\n", ff_t);
-  if (ff_t == 0) {
+  log_debug(LOG_SERVICE, "%s mask = %x\r\n", __func__, mask);
+  if ( __builtin_popcount(mask) == 0 ) {
+    log_warn(LOG_SERVICE, "empty mask\r\n");
+  }
+  if (mask & 0x1U) {
     return ffl12_f1_args.updateTick;
   }
-  else if (ff_t == 1) {
+  else if (mask & 0x02U) {
     return ffldaq_f1_args.updateTick;
   }
-  else if (ff_t == 2) {
+  else if (mask & 0x04U) {
     return ffl12_f2_args.updateTick;
   }
   else {
@@ -1060,7 +1063,7 @@ void initFPGAMon(void)
 // initialize the real-time clock, which lives in the Hibernate Module in the TM4C1294NCPDT
 extern uint32_t g_ui32SysClock;
 
-void InitRTC()
+void InitRTC(void)
 {
   // Enable the RTC module
   ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_HIBERNATE);
@@ -1078,7 +1081,7 @@ void InitRTC()
 }
 #endif // REV2
 #ifdef REV1
-void init_registers_clk()
+void init_registers_clk(void)
 {
   // =====================================================
   // CMv1 Schematic 4.03 I2C CLOCK SOURCE CONTROL
@@ -1135,7 +1138,7 @@ void init_registers_clk()
     xSemaphoreGive(i2c2_sem);
   }
 }
-void init_registers_ff()
+void init_registers_ff(void)
 {
 
   // =====================================================
@@ -1235,7 +1238,7 @@ void init_registers_ff()
 }
 #endif // REV1
 #ifdef REV2
-void init_registers_clk()
+void init_registers_clk(void)
 {
   // initialize the external I2C registers for the clocks and for the optical devices.
 
@@ -1301,7 +1304,7 @@ void init_registers_clk()
     xSemaphoreGive(i2c2_sem);
   }
 }
-void init_registers_ff()
+void init_registers_ff(void)
 {
 
   // =====================================================

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -132,7 +132,7 @@ void MonitorI2CTask(void *parameters)
           good = false;
           task_watchdog_unregister_task(kWatchdogTaskID_MonitorI2CTask);
         }
-        vTaskDelayUntil(&(args->updateTick), pdMS_TO_TICKS(500));
+        vTaskDelay(pdMS_TO_TICKS(500));
         continue;
       }
       else if (getPowerControlState() == POWER_ON) { // power is on, and ...
@@ -189,6 +189,7 @@ void MonitorI2CTask(void *parameters)
 
       } // loop over commands
       log_debug(LOG_MONI2C, "%s: end loop commands\r\n", args->name);
+      args->updateTick = xTaskGetTickCount(); // current time in ticks
 
     } // loop over devices
 
@@ -196,7 +197,6 @@ void MonitorI2CTask(void *parameters)
     if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);
     }
-    args->updateTick = xTaskGetTickCount(); // current time in ticks
 
     // monitor stack usage for this task
     CHECK_TASK_STACK_USAGE(args->stack_size);

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -90,7 +90,6 @@ void MonitorI2CTask(void *parameters)
       continue;
     }
 
-    args->updateTick = xTaskGetTickCount(); // current time in ticks
     // -------------------------------
     // loop over devices in the device-type instance
     // -------------------------------
@@ -124,7 +123,6 @@ void MonitorI2CTask(void *parameters)
 #error "Define either Rev1 or Rev2"
 #endif
         }
-        args->updateTick = xTaskGetTickCount();
       }
       log_debug(LOG_MONI2C, "%s: powercheck\r\n", args->name);
 
@@ -198,6 +196,7 @@ void MonitorI2CTask(void *parameters)
     if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);
     }
+    args->updateTick = xTaskGetTickCount(); // current time in ticks
 
     // monitor stack usage for this task
     CHECK_TASK_STACK_USAGE(args->stack_size);

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -185,7 +185,7 @@ void MonitorTask(void *parameters)
           }
           args->pm_values[index] = val;
           // wait here for the x msec, where x is 2nd argument below.
-          args->updateTick = xTaskGetTickCount(); // current time in ticks
+          args->updateTick = xTaskGetTickCount(); // current time in ticks, for the sake of stale data
           vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(10));
         } // loop over commands
       }   // loop over pages
@@ -194,7 +194,6 @@ void MonitorTask(void *parameters)
     if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);
     }
-    args->updateTick = xTaskGetTickCount(); // current time in ticks
 
     CHECK_TASK_STACK_USAGE(args->stack_size);
 

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -75,7 +75,6 @@ void MonitorTask(void *parameters)
       }
     }
 
-    args->updateTick = xTaskGetTickCount(); // current time in ticks
     // loop over devices
     for (int ps = 0; ps < args->n_devices; ++ps) {
       // handle case where only management power is on
@@ -186,6 +185,7 @@ void MonitorTask(void *parameters)
           }
           args->pm_values[index] = val;
           // wait here for the x msec, where x is 2nd argument below.
+          args->updateTick = xTaskGetTickCount(); // current time in ticks
           vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(10));
         } // loop over commands
       }   // loop over pages
@@ -194,6 +194,7 @@ void MonitorTask(void *parameters)
     if (xSemaphoreGetMutexHolder(args->xSem) == xTaskGetCurrentTaskHandle()) {
       xSemaphoreGive(args->xSem);
     }
+    args->updateTick = xTaskGetTickCount(); // current time in ticks
 
     CHECK_TASK_STACK_USAGE(args->stack_size);
 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -19,6 +19,7 @@
 #include "driverlib/eeprom.h"
 
 #include "common/printf.h"
+#include <sys/_types.h>
 
 #ifdef __INTELLISENSE__
 #define __fp16 float
@@ -174,7 +175,7 @@ void getFFpart(int which_fpga);
   getFFpart(2);
 
 uint8_t getFFstatus(const uint8_t i);
-int getFFcheckStale(void);
+unsigned isFFStale(void);
 TickType_t getFFupdateTick(int ff_t);
 void init_registers_ff(void);
 

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -256,7 +256,7 @@ void zm_set_firefly_temps(struct zynqmon_data_t data[], int start)
   // update the data for ZMON
   for (int i = 0; i < NFIREFLIES; i++) {
     data[i].sensor = i + start; // sensor id
-    if (getFFcheckStale()) {
+    if (!isFFStale()) {
       data[i].data.i = getFFtemp(i); // sensor value and type
     }
     else {

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -594,10 +594,10 @@ BaseType_t ff_status(int argc, char **argv, char *m)
 
   if (whichff == 0) {
     // check for stale data
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
 
-    if (getFFcheckStale() == 0) {
-      TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
+    if (isFFStale()) {
+      TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
@@ -651,10 +651,10 @@ BaseType_t ff_los_alarm(int argc, char **argv, char *m)
 
   if (whichff == 0) {
     // check for stale data
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
 
-    if (getFFcheckStale() == 0) {
-      TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
+    if (isFFStale()) {
+      TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
@@ -720,10 +720,10 @@ BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m)
 
   if (whichff == 0) {
     // check for stale data
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
 
-    if (getFFcheckStale() == 0) {
-      TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
+    if (isFFStale()) {
+      TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
@@ -790,10 +790,10 @@ BaseType_t ff_temp(int argc, char **argv, char *m)
 
   if (whichff == 0) {
     // check for stale data
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
 
-    if (getFFcheckStale() == 0) {
-      TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
+    if (isFFStale()) {
+      TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
       int mins = (now - last) / 60;
       copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                          "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
@@ -846,8 +846,8 @@ BaseType_t ff_ctl(int argc, char **argv, char *m)
   // check for stale data
   TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
 
-  if (getFFcheckStale() == 0) {
-    TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
+  if (isFFStale()) {
+    TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
     int mins = (now - last) / 60;
     copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                        "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
@@ -1048,7 +1048,8 @@ BaseType_t clkmon_ctl(int argc, char **argv, char *m)
   if (i == 0) {
 
     // update times, in seconds
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
+
     TickType_t last = pdTICKS_TO_MS(clockr0a_args.updateTick) / 1000;
 
     if (checkStale(last, now)) {
@@ -1077,7 +1078,8 @@ BaseType_t clkmon_ctl(int argc, char **argv, char *m)
   else {
 
     // update times, in seconds
-    TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
+    TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
+
     TickType_t last = pdTICKS_TO_MS(clock_args.updateTick) / 1000;
 
     if (checkStale(last, now)) {
@@ -1134,9 +1136,10 @@ BaseType_t fpga_ctl(int argc, char **argv, char *m)
     static int whichfpga = 0;
     int howmany = fpga_args.n_devices * fpga_args.n_pages;
     if (whichfpga == 0) {
-      TickType_t now = pdTICKS_TO_MS(xTaskGetTickCount()) / 1000;
-      if (getFFcheckStale() == 0) {
-        TickType_t last = pdTICKS_TO_MS(getFFupdateTick(getFFcheckStale())) / 1000;
+      TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
+
+      if (isFFStale()) {
+        TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
         int mins = (now - last) / 60;
         copied += snprintf(m + copied, SCRATCH_SIZE - copied,
                            "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1015,6 +1015,7 @@ BaseType_t ff_ctl(int argc, char **argv, char *m)
   return pdFALSE;
 }
 
+#if 0
 extern struct dev_moni2c_addr_t ff_moni2c_addrs[NFIREFLIES];
 
 extern struct arg_moni2c_ff_t ff_moni2c_arg[NFIREFLY_ARG];
@@ -1022,7 +1023,7 @@ extern struct MonitorI2CTaskArgs_t ffldaq_f1_args;
 extern struct MonitorI2CTaskArgs_t ffl12_f1_args;
 extern struct MonitorI2CTaskArgs_t ffldaq_f2_args;
 extern struct MonitorI2CTaskArgs_t ffl12_f2_args;
-
+#endif // 0
 // dump clock monitor information
 BaseType_t clkmon_ctl(int argc, char **argv, char *m)
 {


### PR DESCRIPTION
seems that some tasks' data are not being marked as stale when they should be. This tries to fix that. 