### PR TITLE
Add a state machine #6 for controlling V3.8 needed for Semtec 12-ch 25Gbs

### DIFF
--- a/common/power_ctl.c
+++ b/common/power_ctl.c
@@ -102,6 +102,7 @@ struct gpio_pin_t oks[N_PS_OKS] = {
     { PG_F2_AVCC, "PG_F2_AVCC", 4},
     { PG_F1_AVTT,  "PG_F1_AVTT", 5},
     { PG_F2_AVTT, "PG_F2_AVTT", 5},
+    { PG_4V0, "PG_4V0",   6},
 };
 
 #else

--- a/common/power_ctl.h
+++ b/common/power_ctl.h
@@ -44,7 +44,7 @@ void setPSStatus(int i, enum ps_state theState);
 // -----------------------------------------------------
 // Number of enable and power good/OK pins
 #define N_PS_ENABLES 16
-#define N_PS_OKS     14
+#define N_PS_OKS     15
 // Masks for the ENABLE bits and the OK/PG (power good)
 // bits, for the pins defined in the enables[]
 // and oks[] arrays.
@@ -61,13 +61,15 @@ void setPSStatus(int i, enum ps_state theState);
 // these are indices into the oks[] array
 // L1-L5, note NO L3!!! no PG on the L3 supplies
 #define PS_OKS_F1_MASK_L1 0x0003U
-#define PS_OKS_F1_MASK_L2 0x0030U // these are common to VU and KU
+#define PS_OKS_F1_MASK_L2 0x0030U // these two pins are common to VU and KU
 #define PS_OKS_F1_MASK_L4 0x0300U
 #define PS_OKS_F1_MASK_L5 0x0C00U
+#define PS_OKS_F1_MASK_L6 0x0000U // no 4v0 pin in Rev1
 #define PS_OKS_F2_MASK_L1 0x000CU
 #define PS_OKS_F2_MASK_L2 PS_OKS_F1_MASK_L2
 #define PS_OKS_F2_MASK_L4 0x00C0U
 #define PS_OKS_F2_MASK_L5 0x3000U
+#define PS_OKS_F2_MASK_L6 PS_OKS_F1_MASK_L6 // no 4v0 pin in Rev1
 
 #elif defined(REV2) // Rev 2
 // -----------------------------------------------------
@@ -78,11 +80,11 @@ void setPSStatus(int i, enum ps_state theState);
 // Number of enable and power good/OK pins
 
 #define N_PS_ENABLES    10
-#define N_PS_OKS        12
+#define N_PS_OKS        13
 #define PS_OKS_MASK     ((1U << N_PS_OKS) - 1)
 #define PS_OKS_F1_MASK  0x543U
 #define PS_OKS_F2_MASK  0xA8CU
-#define PS_OKS_GEN_MASK 0x030U
+#define PS_OKS_GEN_MASK 0x1030U  // includes 4v0 pin
 #define PS_ENS_MASK     ((1U << N_PS_ENABLES) - 1)
 #define PS_ENS_GEN_MASK 0x00CU
 #define PS_ENS_F1_MASK  0x151U
@@ -90,17 +92,20 @@ void setPSStatus(int i, enum ps_state theState);
 
 // OK masks for various stages of the turn-on.
 // these are indices into the oks[] array
-// L1-L5
+// L1-L6
 #define PS_OKS_F1_MASK_L1 0x003U
-#define PS_OKS_F1_MASK_L2 0x030U // these are common to F1 and F2
+#define PS_OKS_F1_MASK_L2 0x030U // these two pins are common to F1 and F2
 #define PS_OKS_F1_MASK_L3 0x040U
 #define PS_OKS_F1_MASK_L4 0x100U
 #define PS_OKS_F1_MASK_L5 0x400U
+#define PS_OKS_F1_MASK_L6 0x1000U // this one pin is common to F1 and F2
 #define PS_OKS_F2_MASK_L1 0x00CU
 #define PS_OKS_F2_MASK_L2 PS_OKS_F1_MASK_L2
 #define PS_OKS_F2_MASK_L3 0x080U
 #define PS_OKS_F2_MASK_L4 0x200U
 #define PS_OKS_F2_MASK_L5 0x800U
+#define PS_OKS_F2_MASK_L6 PS_OKS_F1_MASK_L6
+
 
 
 

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -57,10 +57,10 @@ static uint16_t getPSFailMask(void)
   static uint32_t ps_ignore_mask;
   if (!configured) {
     ps_ignore_mask = read_eeprom_single(EEPROM_ID_PS_IGNORE_MASK);
-    if (ps_ignore_mask & ~(PS_OKS_F1_MASK_L4 | PS_OKS_F1_MASK_L5 | PS_OKS_F2_MASK_L4 | PS_OKS_F2_MASK_L5)) {
+    if (ps_ignore_mask & ~(PS_OKS_F1_MASK_L4 | PS_OKS_F1_MASK_L5 | PS_OKS_F1_MASK_L6 | PS_OKS_F2_MASK_L4 | PS_OKS_F2_MASK_L5 | PS_OKS_F2_MASK_L6)) {
       log_warn(LOG_PWRCTL, "Warning: mask 0x%x included masks at below L4; ignoring\r\n", ps_ignore_mask);
       // mask out supplies at startup L1, L2 or L3. We do not allow those to fail.
-      ps_ignore_mask &= (PS_OKS_F1_MASK_L4 | PS_OKS_F1_MASK_L5 | PS_OKS_F2_MASK_L4 | PS_OKS_F2_MASK_L5);
+      ps_ignore_mask &= (PS_OKS_F1_MASK_L4 | PS_OKS_F1_MASK_L5 | PS_OKS_F1_MASK_L6 | PS_OKS_F2_MASK_L4 | PS_OKS_F2_MASK_L5 | PS_OKS_F2_MASK_L6);
     }
     configured = true;
   }
@@ -83,6 +83,7 @@ static const char *const power_system_state_names[] = {
     "L3ON",
     "L4ON",
     "L5ON",
+    "L6ON",
     "ON",
 };
 
@@ -118,7 +119,7 @@ void PowerSupplyTask(void *parameters)
   // masks to enable/check appropriate supplies
   uint16_t supply_ok_mask = PS_OKS_GEN_MASK;
   uint16_t supply_ok_mask_L1 = 0U, supply_ok_mask_L2 = 0U, supply_ok_mask_L4 = 0U,
-           supply_ok_mask_L5 = 0U;
+           supply_ok_mask_L5 = 0U, supply_ok_mask_L6 = 0U;
 
   bool f1_enable = isFPGAF1_PRESENT();
   bool f2_enable = isFPGAF2_PRESENT();
@@ -135,6 +136,7 @@ void PowerSupplyTask(void *parameters)
     supply_ok_mask_L2 = supply_ok_mask_L1 | PS_OKS_F1_MASK_L2;
     supply_ok_mask_L4 = supply_ok_mask_L2 | PS_OKS_F1_MASK_L4;
     supply_ok_mask_L5 = supply_ok_mask_L4 | PS_OKS_F1_MASK_L5;
+    supply_ok_mask_L6 = supply_ok_mask_L5 | PS_OKS_F1_MASK_L6;
   }
   if (f2_enable) {
     supply_ok_mask |= PS_OKS_F2_MASK;
@@ -142,6 +144,7 @@ void PowerSupplyTask(void *parameters)
     supply_ok_mask_L2 |= supply_ok_mask_L1 | PS_OKS_F2_MASK_L2;
     supply_ok_mask_L4 |= supply_ok_mask_L2 | PS_OKS_F2_MASK_L4;
     supply_ok_mask_L5 |= supply_ok_mask_L4 | PS_OKS_F2_MASK_L5;
+    supply_ok_mask_L6 |= supply_ok_mask_L5 | PS_OKS_F2_MASK_L6;
   }
   // exceptions are stored in the internal EEPROM -- the IGNORE mask.
   ignore_mask = getPSFailMask();
@@ -160,6 +163,7 @@ void PowerSupplyTask(void *parameters)
     supply_ok_mask_L2 &= ~ignore_mask; // mask out the ignored bits.
     supply_ok_mask_L4 &= ~ignore_mask; // mask out the ignored bits.
     supply_ok_mask_L5 &= ~ignore_mask; // mask out the ignored bits.
+    supply_ok_mask_L6 &= ~ignore_mask; // mask out the ignored bits.
   }
 
 #if defined(ECN001) || defined(REV2)
@@ -345,10 +349,11 @@ void PowerSupplyTask(void *parameters)
 
         break;
       }
+#ifdef REV1
       case POWER_L5ON: {
         if (((supply_bitset & supply_ok_mask_L5) != supply_ok_mask_L5) && !ignorefail) {
           failed_mask = (~supply_bitset) & supply_ok_mask_L5;
-          printfail(failed_mask, supply_ok_mask_L5, supply_bitset);
+          printfail(failed_mask, supply_ok_mask_L6, supply_bitset);
           errbuffer_power_fail(failed_mask);
 
           disable_ps();
@@ -362,6 +367,42 @@ void PowerSupplyTask(void *parameters)
 
         break;
       }
+#elif defined(REV2)
+      case POWER_L5ON: {
+        if (((supply_bitset & supply_ok_mask_L5) != supply_ok_mask_L5) && !ignorefail) {
+          failed_mask = (~supply_bitset) & supply_ok_mask_L5;
+          printfail(failed_mask, supply_ok_mask_L5, supply_bitset);
+          errbuffer_power_fail(failed_mask);
+
+          disable_ps();
+          power_supply_alarm = true;
+          nextState = POWER_FAILURE;
+        }
+        else {
+          turn_on_ps_at_prio(f2_enable, f1_enable, 5);
+          nextState = POWER_L6ON;
+        }
+
+        break;
+      }
+      case POWER_L6ON: {
+        if (((supply_bitset & supply_ok_mask_L6) != supply_ok_mask_L6) && !ignorefail) {
+          failed_mask = (~supply_bitset) & supply_ok_mask_L6;
+          printfail(failed_mask, supply_ok_mask_L6, supply_bitset);
+          errbuffer_power_fail(failed_mask);
+
+          disable_ps();
+          power_supply_alarm = true;
+          nextState = POWER_FAILURE;
+        }
+        else {
+          blade_power_ok(true);
+          nextState = POWER_ON;
+        }
+
+        break;
+      }
+#endif // REV1
       case POWER_FAILURE: {                           // we go through POWER_OFF state before turning on.
         if (!power_supply_alarm && !external_alarm) { // errors cleared
           nextState = POWER_OFF;

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -211,8 +211,8 @@ void PowerSupplyTask(void *parameters)
     }
 
     // MAIN POWER SUPPLY TASK STATE MACHINE
-    // ON1 .. ON5 are the five states of the turn-on sequence
-    // OFF1 .. OFF5 are the five states of the turn-off sequence
+    // ON1 .. ON6 are the six states of the turn-on sequence
+    // OFF1 .. OFF6 are the six states of the turn-off sequence
     // in the transition to FAIL we turn off all the supplies in sequence,
     // even if they were not yet turned on (i.e., transition from ON3 -> FAIL)
     //                     +-------------------+
@@ -221,7 +221,7 @@ void PowerSupplyTask(void *parameters)
     // | INIT  |    |         ^             ^         |
     // +---+---+    v         |             |         |
     //     |     ---+--+   +--+-+         +-+--+  +---+--+
-    //     +---->+ OFF +---> ON1+-> ....  | ON5+->+  ON  |
+    //     +---->+ OFF +---> ON1+-> ....  | ON6+->+  ON  |
     //           +--+--+   +----+         +----+  +---+--+
     //              |            +------+             |
     //              +-----<------| DOWN <-------------+

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -86,6 +86,7 @@ enum power_system_state {
   POWER_L3ON,
   POWER_L4ON,
   POWER_L5ON,
+  POWER_L6ON,
   POWER_ON,
 };
 enum power_system_state getPowerControlState(void);


### PR DESCRIPTION
This PR will resolve #140. 

Note that this change is only needed for REV2. Currently, the infrastructure of this state machine is ready to be reviewed. We only need to add a bit mask to ff struct such as `ffl12_f1_args`  and `ffl12_f2_args` to store information if a vendor part of each ch is a 25Gb one to enable V3.8, and the state machine condition. 