### PR TITLE
Turn FreeRTOS use into a submodule

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,11 +11,8 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Steps to reproduce the behavior.
+
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,8 +13,5 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add any other context about the feature request here.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,19 +38,6 @@ jobs:
         release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
         # Directory to unpack GCC to. Defaults to a temporary directory.
         directory: ${{ runner.temp }}/arm-none-eabi
-    - name: FreeRTOS download
-      run: |
-         cd ${{runner.temp}}
-         mkdir freertos-lts
-         cd freertos-lts
-         curl -L -o freertos_code.zip https://github.com/FreeRTOS/FreeRTOS-LTS/releases/download/202012.01-LTS/FreeRTOSv202012.01-LTS.zip
-         unzip -q freertos_code.zip 
-         echo "FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel" >> $GITHUB_ENV
-         export FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel
-         echo $FREERTOS_ROOT
-         pwd
-    - name: test
-      run: echo $FREERTOS_ROOT; echo $PATH; ls -d ~/work/_temp/*
     - name: make with GCC, debug build, Rev1
       run: |
         export PATH=${PATH}:$HOME/work/_temp/arm-none-eabi/bin:
@@ -101,16 +88,6 @@ jobs:
         # Directory to unpack GCC to. Defaults to a temporary directory.
         directory: ${{ runner.temp }}/arm-none-eabi
 
-    - name: FreeRTOS download
-      run: |
-         mkdir freertos-lts
-         cd freertos-lts
-         curl -L -o freertos_code.zip https://github.com/FreeRTOS/FreeRTOS-LTS/releases/download/202012.01-LTS/FreeRTOSv202012.01-LTS.zip
-         unzip -q freertos_code.zip 
-         echo "FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel" >> $GITHUB_ENV
-         export FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel
-         echo $FREERTOS_ROOT
-         pwd
     - name: make with CLANG, Rev 1
       run: |
          export PATH=${PATH}:$HOME/work/_temp/arm-none-eabi/bin:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -114,6 +114,7 @@ jobs:
           **/*.def
           **/Makefile
           makedefs
+          **/*.md
     - name: Format changed files
       if: steps.changed-files.outputs.any_changed == 'true'
       uses: DoozyX/clang-format-lint-action@v0.14

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,17 +67,6 @@ jobs:
         release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
         # Directory to unpack GCC to. Defaults to a temporary directory.
         directory: ${{ runner.temp }}/arm-none-eabi
-    - name: FreeRTOS download
-      run: |
-         cd ${{runner.temp}}
-         mkdir freertos-lts
-         cd freertos-lts
-         curl -L -o freertos_code.zip https://github.com/FreeRTOS/FreeRTOS-LTS/releases/download/202012.01-LTS/FreeRTOSv202012.01-LTS.zip
-         unzip -q freertos_code.zip 
-         echo "FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel" >> $GITHUB_ENV
-         export FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel
-         echo $FREERTOS_ROOT
-         pwd
     - name: make with GCC
       run: |
         export PATH=${PATH}:$HOME/work/_temp/arm-none-eabi/bin:

--- a/.github/workflows/format-commit.yml
+++ b/.github/workflows/format-commit.yml
@@ -28,6 +28,7 @@ jobs:
           **/*.def
           **/Makefile
           makedefs
+          **/*.md
     - name: Format changed files
       uses: DoozyX/clang-format-lint-action@v0.14
       if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,17 +28,6 @@ jobs:
         release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
         # Directory to unpack GCC to. Defaults to a temporary directory.
         directory: ${{ runner.temp }}/arm-none-eabi
-     - name: FreeRTOS download
-       run: |
-         cd ${{runner.temp}}
-         mkdir freertos-lts
-         cd freertos-lts
-         curl -L -o freertos_code.zip https://github.com/FreeRTOS/FreeRTOS-LTS/releases/download/202012.01-LTS/FreeRTOSv202012.01-LTS.zip
-         unzip -q freertos_code.zip 
-         echo "FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel" >> $GITHUB_ENV
-         export FREERTOS_ROOT=`pwd`/FreeRTOS-LTS/FreeRTOS/FreeRTOS-Kernel
-         echo $FREERTOS_ROOT
-         pwd
      - name: make with GCC for Rev1
        run: |
         export PATH=${PATH}:$HOME/work/_temp/arm-none-eabi/bin:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "FreeRTOS-Kernel"]
+	path = FreeRTOS-Kernel
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 DIRS=projects 
 DIRSCLEAN=$(addsuffix .clean,$(DIRS))
 
-all:  $(DIRS)
+all:  check-and-reinit-submodules $(DIRS) 
 
 $(DIRS):
 	@$(MAKE) -C $@

--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,11 @@ clean: $(DIRSCLEAN)
 $(DIRSCLEAN): %.clean:
 	@$(MAKE) -C $* clean
 
+check-and-reinit-submodules:
+	@if git submodule status | egrep -q '^[-]|^[+]' ; then \
+            echo "INFO: Need to reinitialize git submodules"; \
+            git submodule update --init; \
+	fi
 
-.PHONY: all clean $(DIRS) $(DIRSCLEAN)
+
+.PHONY: all clean $(DIRS) $(DIRSCLEAN) check-and-reinit-submodules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# cm_mcu ![CI Status](https://github.com/apollo-lhc/cm_mcu/actions/workflows/c-cpp.yml/badge.svg)
+#cm_mcu ![CI Status](https \
+                     :                                                             // github.com/apollo-lhc/cm_mcu/actions/workflows/c-cpp.yml/badge.svg)
 Microcontroller source code, initially targeting the [TI Tiva TM4C1290NCPDT](https://www.ti.com/product/TM4C1290NCPDT) on the Apollo command module. This is a Cortex-M4F 32 bit processor.
 
 ## Project
@@ -17,6 +18,7 @@ If the build fails remember you have to initialize the submodule.
 ```
 % git submodule update --remote --recursive
 ```
+In theory the makefile should take care of this on the first build.
 
 The code uses the Tivaware driver library since this is stored in the ROM of the TM4C devices. (No install is required.)
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ To compile the source code simply type `make` at the top-level directory. To get
 ```
 Note that you should not mix builds w/ and w/o `DEBUG=1`; if you do the build will fail or worse do weird things.
 
+If the build fails remember you have to initialize the submodule.
+```
+% git submodule update --remote --recursive
+```
+
 The code uses the Tivaware driver library since this is stored in the ROM of the TM4C devices. (No install is required.)
 
 The build has been extensively tested on MacOS and Linux (SC7/RHEL7).  See commments below if you want to compile in Windows.
 
 ### FreeRTOS
-We are also using [FreeRTOS](https://freertos.org) also to provide basic multi-tasking. Install FreeRTOS from the above link somewhere and then set the environment variable as follows:
-```bash
-export FREERTOS_ROOT=/base/of/install/FreeRTOS/Source
-```
+We are also using [FreeRTOS](https://freertos.org) to provide basic multi-tasking. It is included via a Git submodule.
 
 ### microrl
 We are using the microrl library in our project. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-#cm_mcu ![CI Status](https \
-                     :                                                             // github.com/apollo-lhc/cm_mcu/actions/workflows/c-cpp.yml/badge.svg)
+#cm_mcu ![CI Status](https://github.com/apollo-lhc/cm_mcu/actions/workflows/c-cpp.yml/badge.svg)
 Microcontroller source code, initially targeting the [TI Tiva TM4C1290NCPDT](https://www.ti.com/product/TM4C1290NCPDT) on the Apollo command module. This is a Cortex-M4F 32 bit processor.
 
 ## Project

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -15,8 +15,8 @@ PART=TM4C1290NCPDT
 ROOT=../..
 BASE=$(shell cd ../..; pwd)
 
-# if the environment variable is not set, this is used
-FREERTOS_ROOT?=../../../FreeRTOSv10.2.0/FreeRTOS/Source
+# FreeRTOS submodule
+FREERTOS_ROOT=../../FreeRTOS-Kernel
 
 #
 # Include the common make definitions.


### PR DESCRIPTION
To make more uniform builds we now turn FreeRTOS into a submodule. This also makes for one less thing to download.