### PR TITLE
Add CLI command to program FPGA from flash (implement issue #187)

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -261,6 +261,10 @@ static struct command_t commands[] = {
     {"errorlog_reset", errbuff_reset,
      "Resets the eeprom error logger.\r\n", 0},
     {"first_mcu", first_mcu_ctl, "args: <board #> <revision #>\r\n Detect first-time setup of MCU and prompt loading internal EEPROM configuration\r\n", 4},
+#ifdef REV2
+    {"fpga_flash", fpga_flash, "args # (1|2):  Program FPGA 1(2) via a programmed flash.\r\n",
+     1},
+#endif // REV2
     {"fpga_reset", fpga_reset, "Reset Kintex (k) or Virtex (V) FPGA\r\n", 1},
     {"ff", ff_ctl,
      "args: (xmit|cdr on/off (0-23|all)) | regw reg# val (0-23|all) | regr reg# (0-23)\r\n"

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1280,6 +1280,33 @@ BaseType_t fpga_ctl(int argc, char **argv, char *m)
 }
 
 // This command takes 1 argument, either k or v
+BaseType_t fpga_flash(int argc, char **argv, char *m)
+{
+  int copied = 0;
+  const TickType_t delay = 1 / portTICK_PERIOD_MS; // 1 ms delay
+
+  if (strcmp(argv[1], "f2") == 0) {
+    write_gpio_pin(FPGA_CFG_FROM_FLASH, 0x1);
+    write_gpio_pin(F2_FPGA_PROGRAM, 0x0);
+    vTaskDelay(delay);
+    write_gpio_pin(F2_FPGA_PROGRAM, 0x1);
+    vTaskDelay(delay);
+    write_gpio_pin(F2_FPGA_PROGRAM, 0x0);
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA2 has been programmed\r\n");
+  }
+  if (strcmp(argv[1], "f1") == 0) {
+    write_gpio_pin(FPGA_CFG_FROM_FLASH, 0x1);
+    write_gpio_pin(F1_FPGA_PROGRAM, 0x0);
+    vTaskDelay(delay);
+    write_gpio_pin(F1_FPGA_PROGRAM, 0x1);
+    vTaskDelay(delay);
+    write_gpio_pin(F1_FPGA_PROGRAM, 0x0);
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA1 has been programmed\r\n");
+  }
+  return pdFALSE;
+}
+
+// This command takes 1 argument, either k or v
 BaseType_t fpga_reset(int argc, char **argv, char *m)
 {
   int copied = 0;

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1279,7 +1279,8 @@ BaseType_t fpga_ctl(int argc, char **argv, char *m)
   }
 }
 
-// This command takes 1 argument, either k or v
+// This command takes 1 argument, either f1 or f2
+#ifdef REV2
 BaseType_t fpga_flash(int argc, char **argv, char *m)
 {
   int copied = 0;
@@ -1305,8 +1306,9 @@ BaseType_t fpga_flash(int argc, char **argv, char *m)
   }
   return pdFALSE;
 }
+#endif
 
-// This command takes 1 argument, either k or v
+// This command takes 1 argument, either f1 or f2
 BaseType_t fpga_reset(int argc, char **argv, char *m)
 {
   int copied = 0;

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1304,6 +1304,7 @@ BaseType_t fpga_flash(int argc, char **argv, char *m)
     write_gpio_pin(F1_FPGA_PROGRAM, 0x0);
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FPGA1 has been programmed\r\n");
   }
+  snprintf(m + copied, SCRATCH_SIZE - copied, "via flash\r\n");
   return pdFALSE;
 }
 #endif

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -42,5 +42,6 @@ BaseType_t clkr0amon_ctl(int argc, char **argv, char *m);
 // FPGA
 BaseType_t fpga_ctl(int argc, char **argv, char *m);
 BaseType_t fpga_reset(int argc, char **argv, char *m);
+BaseType_t fpga_flash(int argc, char **argv, char *m);
 
 #endif


### PR DESCRIPTION
implement issue #187  by adding `fpga_flash f1(f2)` to CLI commands for programming FPGA1(2) from flash. 