### PR TITLE
Implement and test a new ff_laser_fault

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -289,6 +289,12 @@ static struct command_t commands[] = {
         0,
     },
     {
+        "ff_laser_fault",
+        ff_laser_fault,
+        "Displays a table showing the laser fault of the fireflies via Tx channels.\r\n",
+        0,
+    },
+    {
         "ff_optpow",
         ff_optpow,
         "Displays a table showing the per-ch optical power of the I2C fireflies.\r\n",

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -173,6 +173,7 @@ struct sm_command_t sm_command_ffldaq_f1[] = {
     {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {1, 0x00, 0x03, 1, "FF_LOS_ALARM", 0xff, "", PM_STATUS},
     {1, 0x00, 0x05, 1, "FF_CDR_LOL_ALARM", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x04, 1, "FF_LASER_FAULT", 0xff, "", PM_STATUS},
     {2, 0x00, 0x22, 1, "FF_CH01_OPT_POW", 0xff, "mw", PM_STATUS}, // read 4 Rx-ch registers with increasing addresses
     {2, 0x00, 0x24, 1, "FF_CH02_OPT_POW", 0xff, "mw", PM_STATUS},
     {2, 0x00, 0x26, 1, "FF_CH03_OPT_POW", 0xff, "mw", PM_STATUS},
@@ -206,6 +207,7 @@ struct sm_command_t sm_command_fflit_f1[] = {
     {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x09, 1, "FF_LASER_FAULT", 0xffff, "", PM_STATUS},
     // there are no registers to read optical power for 14Gbps ECUO.
     // registers below are a placeholder with a reading equal to zero
     // the reason we need them because n_commands is fixed
@@ -230,6 +232,7 @@ struct sm_command_t sm_command_fflot_f1[] = {
     {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x09, 1, "FF_LASER_FAULT", 0xffff, "", PM_STATUS},
     {2, 0x01, 0xe4, 1, "FF_CH01_OPT_POW", 0xff, "mw", PM_STATUS}, // read 12 Rx-ch registers  with decreasing addresses
     {2, 0x01, 0xe2, 1, "FF_CH02_OPT_POW", 0xff, "mw", PM_STATUS},
     {2, 0x01, 0xe0, 1, "FF_CH03_OPT_POW", 0xff, "mw", PM_STATUS},
@@ -319,6 +322,7 @@ struct sm_command_t sm_command_ffldaq_f2[] = {
     {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {1, 0x00, 0x03, 1, "FF_LOS_ALARM", 0xff, "", PM_STATUS},
     {1, 0x00, 0x05, 1, "FF_CDR_LOL_ALARM", 0xff, "", PM_STATUS},
+    {1, 0x00, 0x04, 1, "FF_LASER_FAULT", 0xff, "", PM_STATUS},
     {2, 0x00, 0x22, 1, "FF_CH01_OPT_POW", 0xff, "mw", PM_STATUS}, // read 4 Rx-ch registers with increasing addresses
     {2, 0x00, 0x24, 1, "FF_CH02_OPT_POW", 0xff, "mw", PM_STATUS},
     {2, 0x00, 0x26, 1, "FF_CH03_OPT_POW", 0xff, "mw", PM_STATUS},
@@ -351,6 +355,7 @@ struct sm_command_t sm_command_fflit_f2[] = {
     {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x09, 1, "FF_LASER_FAULT", 0xffff, "", PM_STATUS},
     // there are no registers to read optical power for 14Gbps ECUO.
     // registers below are a placeholder with a reading equal to zero
     // the reason we need them because n_commands is fixed
@@ -374,6 +379,7 @@ struct sm_command_t sm_command_fflot_f2[] = {
     {1, 0x00, 0x16, 2, "FF_TEMPERATURE", 0xff, "C", PM_STATUS},
     {2, 0x00, 0x07, 1, "FF_LOS_ALARM", 0xffff, "", PM_STATUS},
     {2, 0x00, 0x14, 1, "FF_CDR_LOL_ALARM", 0xffff, "", PM_STATUS},
+    {2, 0x00, 0x09, 1, "FF_LASER_FAULT", 0xffff, "", PM_STATUS},
     {2, 0x01, 0xe4, 1, "FF_CH01_OPT_POW", 0xff, "mw", PM_STATUS}, // read 12 Rx-ch registers  with decreasing addresses
     {2, 0x01, 0xe2, 1, "FF_CH02_OPT_POW", 0xff, "mw", PM_STATUS},
     {2, 0x01, 0xe0, 1, "FF_CH03_OPT_POW", 0xff, "mw", PM_STATUS},
@@ -728,12 +734,12 @@ uint16_t getFFoptpow(const uint8_t i)
 
   for (int n = 0; n < 4; ++n) {
     if (ff_moni2c_arg[n].int_idx <= i && i < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev) {
-      for (int i1 = 4; i1 < ff_moni2c_arg[n].arg->n_commands; ++i1) {
+      for (int i1 = 5; i1 < ff_moni2c_arg[n].arg->n_commands; ++i1) {
         int dev = i - ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].dev_int_idx;
         int index = dev * (ff_moni2c_arg[n].arg->n_commands * ff_moni2c_arg[n].arg->n_pages) + i1;
         sum_val += ff_moni2c_arg[n].arg->sm_values[index];
       }
-      avg_val = sum_val / (ff_moni2c_arg[n].arg->n_commands - 4);
+      avg_val = sum_val / (ff_moni2c_arg[n].arg->n_commands - 5);
     }
   }
 

--- a/projects/cm_mcu/MonitorI2CTask.h
+++ b/projects/cm_mcu/MonitorI2CTask.h
@@ -52,7 +52,7 @@ struct MonitorI2CTaskArgs_t {
 #else // REV2
 #define NSUPPLIES_FFLDAQ_F1 (4)
 #endif                        // REV 2
-#define NCOMMANDS_FFLDAQ_F1 8 // number of commands
+#define NCOMMANDS_FFLDAQ_F1 9 // number of commands
 #define NPAGES_FFLDAQ_F1    1 // number of pages on the 4-channel firefly ports
 
 #ifndef REV2
@@ -60,7 +60,7 @@ struct MonitorI2CTaskArgs_t {
 #else // REV1
 #define NSUPPLIES_FFL12_F1 (6)
 #endif                        // REV 2
-#define NCOMMANDS_FFL12_F1 16 // number of commands
+#define NCOMMANDS_FFL12_F1 17 // number of commands
 #define NPAGES_FFL12_F1    1  // number of pages on the 12-channel firefly ports
 
 #ifndef REV2
@@ -68,7 +68,7 @@ struct MonitorI2CTaskArgs_t {
 #else // REV1
 #define NSUPPLIES_FFLDAQ_F2 (4)
 #endif                        // REV 2
-#define NCOMMANDS_FFLDAQ_F2 8 // number of commands
+#define NCOMMANDS_FFLDAQ_F2 9 // number of commands
 #define NPAGES_FFLDAQ_F2    1 // number of pages on the 4-channel firefly ports
 
 #ifndef REV2
@@ -76,7 +76,7 @@ struct MonitorI2CTaskArgs_t {
 #else // REV1
 #define NSUPPLIES_FFL12_F2 (6)
 #endif                        // REV 2
-#define NCOMMANDS_FFL12_F2 16 // number of commands
+#define NCOMMANDS_FFL12_F2 17 // number of commands
 #define NPAGES_FFL12_F2    1  // number of pages on the 12-channel firefly ports
 
 extern struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1];

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -34,6 +34,7 @@ BaseType_t ff_temp(int argc, char **argv, char *m);
 BaseType_t ff_status(int argc, char **argv, char *m);
 BaseType_t ff_los_alarm(int argc, char **argv, char *m);
 BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m);
+BaseType_t ff_laser_fault(int argc, char **argv, char *m);
 
 // Clocks
 BaseType_t clkmon_ctl(int argc, char **argv, char *m);


### PR DESCRIPTION
This PR adds a new `ff_laser_fault,` which is one of FF information necessary to monitor and send to Zynq. It only reads tx channels of 12-ch FFs and transmit fault alarm of 4-ch FFs. 