### PR TITLE
Clean up CLI help comments to reduce memory usage

### DIFF
--- a/projects/boot_loader/bl_userhooks.c
+++ b/projects/boot_loader/bl_userhooks.c
@@ -244,7 +244,7 @@ bl_user_init_hw_fn(void)
 
 // Flash green LED 3 times
 
-void bl_user_end_hook()
+void bl_user_end_hook(void)
 {
   MAP_GPIOPinWrite(RED_LED_BASE, RED_LED_PIN, RED_LED_PIN);
   Delay(LONG_DELAY);
@@ -261,7 +261,7 @@ void bl_user_end_hook()
 
 void bl_user_progress_hook(unsigned long ulCompleted, unsigned long ulTotal)
 {
-  int tens = (10*ulCompleted/ulTotal);
+  unsigned int tens = (10*ulCompleted/ulTotal);
   MAP_GPIOPinWrite(RED_LED_BASE, RED_LED_PIN, tens%2);
   return;
 }

--- a/projects/boot_loader/bl_userhooks.c
+++ b/projects/boot_loader/bl_userhooks.c
@@ -31,9 +31,7 @@
 
 #include "common/LocalUart.h"
 
-
 #define LONG_DELAY 2500000
-
 
 #ifdef REV1
 #define RED_LED_BASE   GPIO_PORTP_BASE
@@ -60,42 +58,35 @@
 //*****************************************************************************
 extern void Delay(uint32_t ui32Count);
 
-
 void toggleLed(enum color rgb)
 {
   int gpio_port, gpio_pin;
   switch (rgb) {
-  case red: // red
-    gpio_port = RED_LED_BASE;
-    gpio_pin  = RED_LED_PIN;
-    break;
-  case green: // green
-    gpio_port = GREEN_LED_BASE;
-    gpio_pin  = GREEN_LED_PIN;
-    break;
-  case blue: // blue
-  default:
-    gpio_port = BLUE_LED_BASE;
-    gpio_pin  = BLUE_LED_PIN;
-    break;
+    case red: // red
+      gpio_port = RED_LED_BASE;
+      gpio_pin = RED_LED_PIN;
+      break;
+    case green: // green
+      gpio_port = GREEN_LED_BASE;
+      gpio_pin = GREEN_LED_PIN;
+      break;
+    case blue: // blue
+    default:
+      gpio_port = BLUE_LED_BASE;
+      gpio_pin = BLUE_LED_PIN;
+      break;
   }
 
-   
-  int val = MAP_GPIOPinRead(gpio_port,gpio_pin);
-  if ( val ) 
-    MAP_GPIOPinWrite(gpio_port,gpio_pin, 0);
+  int val = MAP_GPIOPinRead(gpio_port, gpio_pin);
+  if (val)
+    MAP_GPIOPinWrite(gpio_port, gpio_pin, 0);
   else
-    MAP_GPIOPinWrite(gpio_port,gpio_pin, gpio_pin);
+    MAP_GPIOPinWrite(gpio_port, gpio_pin, gpio_pin);
   return;
 }
 
-
-
-
-
 #ifdef BL_HW_INIT_FN_HOOK
-void
-bl_user_init_hw_fn(void)
+void bl_user_init_hw_fn(void)
 {
 #ifdef REV1
   // LEDs
@@ -141,12 +132,12 @@ bl_user_init_hw_fn(void)
 #endif // LEDs for Rev1
 
   // CLOCK
-  // Run from the PLL, internal oscillator, at the defined clock speed 
+  // Run from the PLL, internal oscillator, at the defined clock speed
   // CRYSTAL_FREQ
-  uint32_t ui32SysClock =   
-    MAP_SysCtlClockFreqSet((SYSCTL_OSC_INT|SYSCTL_USE_PLL |
-			    SYSCTL_CFG_VCO_320), CRYSTAL_FREQ);
-
+  uint32_t ui32SysClock =
+      MAP_SysCtlClockFreqSet((SYSCTL_OSC_INT | SYSCTL_USE_PLL |
+                              SYSCTL_CFG_VCO_320),
+                             CRYSTAL_FREQ);
 
   // UART
   // Turn on the UART peripheral
@@ -173,9 +164,8 @@ bl_user_init_hw_fn(void)
   // Configure the UART for 115,200, 8-N-1 operation.
   //
   MAP_UARTConfigSetExpClk(UART4_BASE, ui32SysClock, 115200,
-                         (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
-                          UART_CONFIG_PAR_NONE));
-
+                          (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
+                           UART_CONFIG_PAR_NONE));
 
   ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
 
@@ -195,17 +185,17 @@ bl_user_init_hw_fn(void)
   MAP_GPIOPinConfigure(GPIO_PB1_U1TX);
   MAP_GPIOPinTypeUART(GPIO_PORTB_BASE, GPIO_PIN_1);
 
-
   // Turn on the UART peripheral
   MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_UART1);
-  while ( ! ROM_SysCtlPeripheralReady(SYSCTL_PERIPH_UART1));
+  while (!ROM_SysCtlPeripheralReady(SYSCTL_PERIPH_UART1))
+    ;
 
   //
   // Configure the UART for 115,200, 8-N-1 operation.
   //
   MAP_UARTConfigSetExpClk(UART1_BASE, ui32SysClock, 115200,
-                         (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
-                          UART_CONFIG_PAR_NONE));
+                          (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
+                           UART_CONFIG_PAR_NONE));
 #elif UARTx_BASE == UART0_BASE
   ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
   //
@@ -261,20 +251,19 @@ void bl_user_end_hook(void)
 
 void bl_user_progress_hook(unsigned long ulCompleted, unsigned long ulTotal)
 {
-  unsigned int tens = (10*ulCompleted/ulTotal);
-  MAP_GPIOPinWrite(RED_LED_BASE, RED_LED_PIN, tens%2);
+  unsigned int tens = (10 * ulCompleted / ulTotal);
+  MAP_GPIOPinWrite(RED_LED_BASE, RED_LED_PIN, tens % 2);
   return;
 }
 #endif // BL_PROGRESS_FN_HOOK
 
-
 #ifdef BL_CHECK_UPDATE_FN_HOOK
 // User hook to force an update
 // print helper for CLI
-void bl_user_uart_print(const char* str)
+void bl_user_uart_print(const char *str)
 {
   UARTPrint(UARTx_BASE, str);
-  return ;
+  return;
 }
 
 struct bl_user_data_t {
@@ -284,43 +273,42 @@ struct bl_user_data_t {
 
 int bl_user_rl_execute(void *d, int argc, char **argv)
 {
-  const char * helpstr =
-    "h\r\n This help.\r\n"
-    "b\r\n Start normal boot process\r\n"
-    "r\r\n Restart MCU\r\n"
-    "f\r\n Force update\r\n"
-    ;
+  const char *helpstr =
+      "h\r\n This help.\r\n"
+      "b\r\n Start normal boot process\r\n"
+      "r\r\n Restart MCU\r\n"
+      "f\r\n Force update\r\n";
 
-  struct bl_user_data_t *data = d; // cast pointer to void 
+  struct bl_user_data_t *data = d; // cast pointer to void
 
-  UARTPrint(UARTx_BASE, "\r\n"); 
+  UARTPrint(UARTx_BASE, "\r\n");
 
-  if ( argc > 1 )  {
+  if (argc > 1) {
     UARTPrint(UARTx_BASE, helpstr);
     data->done = false;
     return 0;
   }
 
   switch (argv[0][0]) {
-  case 'b':
-    UARTPrint(UARTx_BASE, "Booting application.\r\n");
-    data->done = true;
-    data->retval = 0;
-    break;
-  case 'f':
-    UARTPrint(UARTx_BASE, "Force update\r\n");
-    data->done = true;
-    data->retval = 1;
-    break;
-  case 'r':
-    UARTPrint(UARTx_BASE, "Hard reboot\r\n");
-    ROM_SysCtlReset(); // this function never returns
-    break;
-  case 'h':
-  default:
-    UARTPrint(UARTx_BASE, helpstr);
-    data->done = false;
-    break;
+    case 'b':
+      UARTPrint(UARTx_BASE, "Booting application.\r\n");
+      data->done = true;
+      data->retval = 0;
+      break;
+    case 'f':
+      UARTPrint(UARTx_BASE, "Force update\r\n");
+      data->done = true;
+      data->retval = 1;
+      break;
+    case 'r':
+      UARTPrint(UARTx_BASE, "Hard reboot\r\n");
+      ROM_SysCtlReset(); // this function never returns
+      break;
+    case 'h':
+    default:
+      UARTPrint(UARTx_BASE, helpstr);
+      data->done = false;
+      break;
   }
   while (ROM_UARTBusy(UARTx_BASE))
     ;
@@ -329,9 +317,8 @@ int bl_user_rl_execute(void *d, int argc, char **argv)
   return 0;
 }
 
-
 // return non-zero to force an update
-#define BL_USER_BUFFSZ  1
+#define BL_USER_BUFFSZ 1
 unsigned long bl_user_checkupdate_hook(void)
 {
   UARTPrint(UARTx_BASE, "\r\n***** CM MCU BOOTLOADER *****\r\n");
@@ -340,13 +327,12 @@ unsigned long bl_user_checkupdate_hook(void)
     ;
   toggleLed(blue);
 
-
   struct bl_user_data_t rl_userdata = {
       .done = false,
       .retval = 0,
   };
   struct microrl_config rl_config = {
-      .print = bl_user_uart_print, 
+      .print = bl_user_uart_print,
       // set callback for execute
       .execute = bl_user_rl_execute,
       .prompt_str = "$ ",
@@ -358,33 +344,31 @@ unsigned long bl_user_checkupdate_hook(void)
   microrl_set_execute_callback(&rl, bl_user_rl_execute);
   microrl_insert_char(&rl, ' '); // this seems to be necessary?
 
-
   int cRxedChar;
-  for( ;; ) {
+  for (;;) {
     int timeleft = 20;
     cRxedChar = -1;
 
-    while ( timeleft ) {
-      if ( MAP_UARTCharsAvail(UARTx_BASE)) {
+    while (timeleft) {
+      if (MAP_UARTCharsAvail(UARTx_BASE)) {
         cRxedChar = MAP_UARTCharGetNonBlocking(UARTx_BASE);
         break;
       }
       else {
-        ROM_SysCtlDelay(CRYSTAL_FREQ/20);
+        ROM_SysCtlDelay(CRYSTAL_FREQ / 20);
       }
       timeleft--;
     }
-    if ( cRxedChar > 0 )
+    if (cRxedChar > 0)
       microrl_insert_char(&rl, cRxedChar);
-    if ( timeleft == 0 ) {
+    if (timeleft == 0) {
       UARTPrint(UARTx_BASE, "CLI timed out\r\n");
       break;
     }
-    if ( rl_userdata.done == true ) {
+    if (rl_userdata.done == true) {
       toggleLed(blue);
       return rl_userdata.retval;
     }
-
   }
   toggleLed(blue);
 

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -23,7 +23,7 @@ static char m[SCRATCH_SIZE];
 // this command takes no arguments and never returns.
 static BaseType_t bl_ctl(int argc, char **argv, char *m)
 {
-  Print("Jumping to boot loader.\r\n");
+  Print("Jumping to bootloader\r\n");
   ROM_SysCtlDelay(100000);
   // this code is copied from the JumpToBootLoader()
   // stack from the boot_demo1 application in the
@@ -235,37 +235,37 @@ struct command_t {
 
 #define NUM_COMMANDS (sizeof(commands) / sizeof(commands[0]))
 static struct command_t commands[] = {
-    {"adc", adc_ctl, "Displays a table showing the state of ADC inputs.\r\n", 0},
-    {"alm", alarm_ctl, "args: (clear|status|settemp|setvoltthres|#)\r\nGet or clear status of alarm task.\r\n",
+    {"adc", adc_ctl, "Display ADC measurements\r\n", 0},
+    {"alm", alarm_ctl, "args: (clear|status|settemp|setvoltthres|#)\r\nGet or clear status of alarm task\r\n",
      -1},
-    {"bootloader", bl_ctl, "Call the boot loader\r\n", 0},
+    {"bootloader", bl_ctl, "Call bootloader\r\n", 0},
 #ifdef REV2
     {"clearclk", clearclk_ctl,
-     "Reset clock sticky bits.\r\n", 0},
-    {"clkmon", clkmon_ctl, "Displays a table showing the clock chips' statuses given the clock chip id option\r\n", 1},
+     "Reset clk sticky bits\r\n", 0},
+    {"clkmon", clkmon_ctl, "CLK chips' status, id:0-4\r\n", 1},
 #endif // REV2
-    {"eeprom_info", eeprom_info, "Prints information about the EEPROM.\r\n", 0},
+    {"eeprom_info", eeprom_info, "Prints information about the EEPROM\r\n", 0},
     {"eeprom_read", eeprom_read,
-     "args: <address>\r\nReads 4 bytes from EEPROM. Address should be a multiple of 4.\r\n",
+     "args: <address>\r\nReads 4 bytes from EEPROM. Address should be a multiple of 4\r\n",
      1},
     {"eeprom_write", eeprom_write,
      "args: <address> <data>\r\nWrites <data> to <address> in EEPROM. <address> should be "
-     "a multiple of 4.\r\n",
+     "a multiple of 4\r\n",
      2},
     {"errorlog_entry", errbuff_in,
-     "args: <data>\r\nManual entry of 2-byte code into the eeprom error logger.\r\n", 1},
+     "args: <data>\r\nManual entry of 2-byte code into the eeprom error logger\r\n", 1},
     {"errorlog", errbuff_out,
-     "args: <n>\r\nPrints last n entries in the eeprom error logger.\r\n", 1},
+     "args: <n>\r\nPrints last n entries in the eeprom error logger\r\n", 1},
     {"errorlog_info", errbuff_info,
-     "Prints information about the eeprom error logger.\r\n", 0},
+     "Prints information about the eeprom error logger\r\n", 0},
     {"errorlog_reset", errbuff_reset,
-     "Resets the eeprom error logger.\r\n", 0},
+     "Resets the eeprom error logger\r\n", 0},
     {"first_mcu", first_mcu_ctl, "args: <board #> <revision #>\r\n Detect first-time setup of MCU and prompt loading internal EEPROM configuration\r\n", 4},
 #ifdef REV2
-    {"fpga_flash", fpga_flash, "args # (1|2):  Program FPGA 1(2) via a programmed flash.\r\n",
+    {"fpga_flash", fpga_flash, "args # (1|2):  Program FPGA 1(2) via a programmed flash\r\n",
      1},
 #endif // REV2
-    {"fpga_reset", fpga_reset, "Reset Kintex (k) or Virtex (V) FPGA\r\n", 1},
+    {"fpga_reset", fpga_reset, "Reset F1 (f1) or F2 (f2) FPGA\r\n", 1},
     {"ff", ff_ctl,
      "args: (xmit|cdr on/off (0-23|all)) | regw reg# val (0-23|all) | regr reg# (0-23)\r\n"
      " Firefly controlling and monitoring commands\r\n",
@@ -273,55 +273,55 @@ static struct command_t commands[] = {
     {
         "ff_status",
         ff_status,
-        "Displays a table showing the status of the fireflies.\r\n",
+        "Show FF status\r\n",
         0,
     },
     {
         "ff_los",
         ff_los_alarm,
-        "Displays a table showing the loss of signal alarms of the fireflies.\r\n",
+        "Show FF loss of signal alarms\r\n",
         0,
     },
     {
         "ff_cdr_lol",
         ff_cdr_lol_alarm,
-        "Displays a table showing the CDR loss of lock alarms of the fireflies.\r\n",
+        "Show FF CDR loss of lock alarms\r\n",
         0,
     },
     {
         "ff_optpow",
         ff_optpow,
-        "Displays a table showing the per-ch optical power of the I2C fireflies.\r\n",
+        "Showing the FF per-ch optical power \r\n",
         0,
     },
     {
         "ff_temp",
         ff_temp,
-        "Displays a table showing the temperature of the I2C fireflies.\r\n",
+        "Showing FF temperatures\r\n",
         0,
     },
-    {"fpga", fpga_ctl, "Displays a table showing the state of FPGAs.\r\n",
+    {"fpga", fpga_ctl, "Show state of FPGAs\r\n",
      -1},
     {
         "gpio",
         gpio_ctl,
-        "Get or set any GPIO pin.\r\n",
+        "Get or set GPIO pin\r\n",
         -1,
     },
     {"help", help_command_fcn, "This help command\r\n", -1},
-    {"id", board_id_info, "Prints board ID information.\r\n", 0},
+    {"id", board_id_info, "Print board ID info\r\n", 0},
     {"i2cr", i2c_ctl_r,
-     "args: <dev> <address> <number of bytes>\r\nRead I2C controller. Addr in hex.\r\n", 3},
+     "args: <dev> <address> <number of bytes>\r\nRead I2C controller. Addr in hex\r\n", 3},
     {"i2crr", i2c_ctl_reg_r,
      "i2crr <dev> <address> <n reg addr bytes> <reg addr> <n data bytes> \r\n Read I2C controller. Addr in hex\r\n", 5},
-    {"i2cw", i2c_ctl_w, "i2cw <dev> <address> <number of bytes> <value>\r\n Write I2C controller.\r\n",
+    {"i2cw", i2c_ctl_w, "i2cw <dev> <address> <number of bytes> <value>\r\n Write I2C controller\r\n",
      4},
     {"i2cwr", i2c_ctl_reg_w,
-     "args: <dev> <address> <number of reg bytes> <reg> <number of bytes>\r\nWrite I2C controller.\r\n", 6},
+     "args: <dev> <address> <number of reg bytes> <reg> <number of bytes>\r\nWrite I2C controller\r\n", 6},
     {
         "i2c_scan",
         i2c_scan,
-        "Scan current I2C bus.\r\n",
+        "Scan current I2C bus\r\n",
         1,
     },
 #ifdef REV2
@@ -334,57 +334,50 @@ static struct command_t commands[] = {
     {
         "loadclock",
         init_load_clock_ctl,
-        "args: the clock id options to program are r0a:0, r0b:1, r1a:2, r1b:3 and r1c:4.\r\n",
+        "args: 0-4\r\n",
         1,
     },
 #endif // REV2
     {
         "log",
         log_ctl,
-        "args: (<fac> debug|toggle|info|warn|fatal|trace)(status|quiet)\r\nManipulate logger levels\r\n",
+        "args: (<fac> debug|toggle|info|warn|fatal|trace)(status|quiet)\r\nChange levels\r\n",
         -1,
     },
-    {"led", led_ctl, "Manipulate red LED.\r\n", 1},
-    {"mem", mem_ctl, "Size of heap.\r\n", 0},
+    {"led", led_ctl, "Manipulate red LED\r\n", 1},
+    {"mem", mem_ctl, "Size of heap\r\n", 0},
     {
         "pwr",
         power_ctl,
         "args: (on|off|status|clearfail)\r\nTurn on or off all power, get status or clear "
-        "failures.\r\n",
+        "failures\r\n",
         1,
     },
-    {"psmon", psmon_ctl, "Displays a table showing the state of power supplies.\r\n", 1},
+    {"psmon", psmon_ctl, "Show state of power supplies\r\n", 1},
     {"psreg", psmon_reg, "<which> <reg>. which: LGA80D (10*dev+page), reg: reg address in hex\r\n", 2},
     {"restart_mcu", restart_mcu, "Restart the microcontroller\r\n", 0},
     {"semaphore", sem_ctl, "args: (none)|<i2cdev 1-6> <take|release>\r\nTake or release a semaphore\r\n", -1},
     {"snapshot", snapshot,
-     "args:# (0|1)\r\nDump snapshot register. #: which of 5 LGA80D (10*dev+page). 0|1 decide "
-     "if to reset snapshot.\r\n",
+     "args:# (0|1)\r\nDump snapshot register. #: which LGA80D (10*dev+page). 0|1 reset bool\r\n",
      2},
-    {"sn_all", sn_all, "reset all LGA80Ds snapshot registers\r\n", 0},
+    {"sn_all", sn_all, "reset all LGA80D snapshots\r\n", 0},
     {
         "set_id",
         set_board_id,
         "args: <passwd> <addr> <data>\r\nAllows the user to set the board id "
-        "information.\r\n",
+        "information\r\n",
         3,
     },
     {
         "set_id_password",
         set_board_id_password,
-        "One-time use: sets password for ID block.\r\n",
-        0,
-    },
-    {
-        "simple_sensor",
-        sensor_summary,
-        "Displays a table showing the state of temps.\r\n",
+        "One-time use: sets password for ID block\r\n",
         0,
     },
     {
         "stack_usage",
         stack_ctl,
-        "Print out system stack high water mark.\r\n",
+        "Print out system stack high water mark\r\n",
         0,
     },
     {
@@ -395,7 +388,7 @@ static struct command_t commands[] = {
     },
     {"taskstats",
      TaskStatsCommand,
-     "Displays a table showing the state of each FreeRTOS task\r\n", 0},
+     "Show state of each FreeRTOS task\r\n", 0},
 #ifdef REV2
     {
         "time",
@@ -404,12 +397,14 @@ static struct command_t commands[] = {
         -1,
     },
 #endif // REV2
-    {"uptime", uptime, "Display uptime in minutes\r\n", 0},
-    {"version", ver_ctl, "Display information about MCU firmware version\r\n", 0},
+    {"uptime", uptime, "Uptime in minutes\r\n", 0},
+    {"version", ver_ctl, "MCU firmware version\r\n", 0},
 #ifdef REV2
-    {"v38", v38_ctl, "Control 3V8 FF supply args: on|off 1|2\r\n", 2},
+    {"v38", v38_ctl, "Control 3V8 supply. Args: on|off 1|2\r\n", 2},
 #endif // REV2
+#if 0
     {"watchdog", watchdog_ctl, "Display status of the watchdog task\r\n", 0},
+#endif
     {
         "zmon",
         zmon_ctl,
@@ -418,7 +413,7 @@ static struct command_t commands[] = {
 #else
         "args:(on|off)\r\n"
 #endif // ZYNQMON_TEST_MODE
-        " Control ZynqMon task.\r\n",
+        " Control ZynqMon task\r\n",
         -1,
     },
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -749,7 +749,7 @@ uint16_t getFFpresentbit(const uint8_t i)
   return val;
 }
 
-void getFFpart()
+void getFFpart(void)
 {
   // Write device vendor part for identifying FF device
   uint8_t nstring = VENDOR_STOP_BIT_FF12 - VENDOR_START_BIT_FF12 + 1;

--- a/projects/cm_mcu/WatchdogTask.c
+++ b/projects/cm_mcu/WatchdogTask.c
@@ -73,7 +73,7 @@ void task_watchdog_feed_task(uint16_t task_id)
   taskENABLE_INTERRUPTS();
 }
 
-uint16_t task_watchdog_get_status()
+uint16_t task_watchdog_get_status(void)
 {
   return s_fed_tasks & s_registered_tasks;
 }

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -258,7 +258,6 @@ static uint16_t read_arbitrary_ff_register(uint16_t regnumber, int num_ff, uint8
   return ret;
 }
 
-
 // dump monitor information
 BaseType_t psmon_ctl(int argc, char **argv, char *m)
 {

--- a/projects/cm_mcu/commands/SoftwareCommands.c
+++ b/projects/cm_mcu/commands/SoftwareCommands.c
@@ -126,12 +126,14 @@ BaseType_t TaskStatsCommand(int argc, char **argv, char *m)
   return pdFALSE;
 }
 
+#if 0
 BaseType_t watchdog_ctl(int argc, char **argv, char *m)
 {
   uint16_t stat = task_watchdog_get_status();
   snprintf(m, SCRATCH_SIZE, "%s: status 0x%08x\r\n", argv[0], stat);
   return pdFALSE;
 }
+#endif 
 
 BaseType_t zmon_ctl(int argc, char **argv, char *m)
 {

--- a/projects/cm_mcu/commands/SoftwareCommands.c
+++ b/projects/cm_mcu/commands/SoftwareCommands.c
@@ -133,7 +133,7 @@ BaseType_t watchdog_ctl(int argc, char **argv, char *m)
   snprintf(m, SCRATCH_SIZE, "%s: status 0x%08x\r\n", argv[0], stat);
   return pdFALSE;
 }
-#endif 
+#endif
 
 BaseType_t zmon_ctl(int argc, char **argv, char *m)
 {


### PR DESCRIPTION
also get rid of some duplication
removed
- simple_sensor (removed code)
- watchdog task (commented out by `#if 0`)

Before:
```sh
(base) ➜  apollo_cm_mcu git:(master) make -j8  
  CC    cm_mcu.c
  LD    gcc/cm_mcu.axf 
  SZ    gcc/cm_mcu.axf
   text	   data	    bss	    dec	    hex	filename
  86989	   4628	  45856	 137473	  21901	gcc/cm_mcu.axf
```

After:
```sh
(base) ➜  apollo_cm_mcu git:(cli_help) make -j8 
  CC    cm_mcu.c
  LD    gcc/cm_mcu.axf 
  SZ    gcc/cm_mcu.axf
   text	   data	    bss	    dec	    hex	filename
  85789	   4628	  45856	 136273	  21451	gcc/cm_mcu.axf
```
text segment reduced by 1200 bytes.