### PR TITLE
Various clean-ups

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -95,10 +95,10 @@ jobs:
           **/LICENSE 
     - name: Format changed files
       if: steps.changed-files.outputs.any_changed == 'true'
-      uses: DoozyX/clang-format-lint-action@v0.14
+      uses: DoozyX/clang-format-lint-action@v0.17
       with:
         source: ${{ steps.changed-files.outputs.all_changed_files }}
         extensions: 'h,c'
-        clangFormatVersion: 11
+        clangFormatVersion: 17
         inplace: false
         style: file

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,13 +61,6 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        # Override the default behavior so that the action doesn't attempt
-        # to auto-install Python dependencies
-        setup-python-dependencies: false
 
     - name: Install Embedded Arm Toolchain arm-none-eabi-gcc
       uses: carlosperate/arm-none-eabi-gcc-action@v1.8.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,14 +47,13 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
           pip install pyyaml
-          # Set the `CODEQL-PYTHON` environment variable to the Python executable
-          # that includes the dependencies
-          echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
+          # tell the CodeQL tool which version of the Python analysis to use
+          echo "CODEQL_EXTRACTOR_PYTHON_ANALYSIS_VERSION=3.11" >> $GITHUB_ENV
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/format-commit.yml
+++ b/.github/workflows/format-commit.yml
@@ -39,7 +39,8 @@ jobs:
         clangFormatVersion: 17
         inplace: true
         style: file
-    - name: Commit clang-formatted files
-      uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: EndBug/add-and-commit@v9
       with:
-        commit_message: Apply clang-format changes
+        message: 'Committing clang-format changes'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format-commit.yml
+++ b/.github/workflows/format-commit.yml
@@ -31,12 +31,12 @@ jobs:
           makedefs
           **/*.md
     - name: Format changed files
-      uses: DoozyX/clang-format-lint-action@v0.14
+      uses: DoozyX/clang-format-lint-action@v0.17
       if: steps.changed-files.outputs.any_changed == 'true'
       with:
         source: ${{ steps.changed-files.outputs.all_changed_files }}
         extensions: 'h,c'
-        clangFormatVersion: 11
+        clangFormatVersion: 17
         inplace: true
         style: file
     - name: Commit clang-formatted files

--- a/.github/workflows/format-commit.yml
+++ b/.github/workflows/format-commit.yml
@@ -30,6 +30,11 @@ jobs:
           **/Makefile
           makedefs
           **/*.md
+          **/*.txt
+          **/.pylintrc
+          **/.gitignore
+          **/.git*
+          **/LICENSE 
     - name: Format changed files
       uses: DoozyX/clang-format-lint-action@v0.17
       if: steps.changed-files.outputs.any_changed == 'true'

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -298,12 +298,12 @@ static struct command_t commands[] = {
         "Show FF CDR loss of lock alarms\r\n",
         0,
     },
-#ifdef REV2  
+#ifdef REV2
     {
-      "ff_mux_reset", 
-      ff_mux_reset, 
-      "reset ff muxes, 1 or 2 for F1 or F2\r\n",
-      1,
+        "ff_mux_reset",
+        ff_mux_reset,
+        "reset ff muxes, 1 or 2 for F1 or F2\r\n",
+        1,
     },
 #endif // REV2
     {

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -300,7 +300,7 @@ static struct command_t commands[] = {
       "ff_mux_reset", 
       ff_mux_reset, 
       "reset ff muxes, 1 or 2 for F1 or F2\r\n",
-      1
+      1,
     },
     {
         "ff_optpow",

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -272,12 +272,14 @@ static struct command_t commands[] = {
      "args: (xmit|cdr on/off (0-23|all)) | regw reg# val (0-23|all) | regr reg# (0-23)\r\n"
      " Firefly controlling and monitoring commands\r\n",
      -1},
+#ifdef REV2
     {
         "ff_reset",
         ff_reset,
         "Reset FF, args: 1 or 2 for F1 or F2\r\n",
         1,
     },
+#endif // REV2
     {
         "ff_status",
         ff_status,
@@ -296,12 +298,14 @@ static struct command_t commands[] = {
         "Show FF CDR loss of lock alarms\r\n",
         0,
     },
+#ifdef REV2  
     {
       "ff_mux_reset", 
       ff_mux_reset, 
       "reset ff muxes, 1 or 2 for F1 or F2\r\n",
       1,
     },
+#endif // REV2
     {
         "ff_optpow",
         ff_optpow,

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -272,12 +272,12 @@ static struct command_t commands[] = {
      "args: (xmit|cdr on/off (0-23|all)) | regw reg# val (0-23|all) | regr reg# (0-23)\r\n"
      " Firefly controlling and monitoring commands\r\n",
      -1},
-     {
-      "ff_reset",
-      ff_reset,
-      "Reset FF, args: 1 or 2 for F1 or F2\r\n",
-      1,
-     },
+    {
+        "ff_reset",
+        ff_reset,
+        "Reset FF, args: 1 or 2 for F1 or F2\r\n",
+        1,
+    },
     {
         "ff_status",
         ff_status,
@@ -295,6 +295,12 @@ static struct command_t commands[] = {
         ff_cdr_lol_alarm,
         "Show FF CDR loss of lock alarms\r\n",
         0,
+    },
+    {
+      "ff_mux_reset", 
+      ff_mux_reset, 
+      "reset ff muxes, 1 or 2 for F1 or F2\r\n",
+      1
     },
     {
         "ff_optpow",

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -272,6 +272,12 @@ static struct command_t commands[] = {
      "args: (xmit|cdr on/off (0-23|all)) | regw reg# val (0-23|all) | regr reg# (0-23)\r\n"
      " Firefly controlling and monitoring commands\r\n",
      -1},
+     {
+      "ff_reset",
+      ff_reset,
+      "Reset FF, args: 1 or 2 for F1 or F2\r\n",
+      1,
+     },
     {
         "ff_status",
         ff_status,

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -157,6 +157,7 @@ header file. */
     APOLLO_ASSERT_RECORD();   \
     for (;;)                  \
       ;                       \
+    __builtin_unreachable();  \
   }
 #else
 #define APOLLO_ASSERT(exp)    \
@@ -164,6 +165,7 @@ header file. */
     taskDISABLE_INTERRUPTS(); \
     APOLLO_ASSERT_RECORD();   \
     ROM_SysCtlReset();        \
+    __builtin_unreachable();  \
   }
 #endif
 

--- a/projects/cm_mcu/I2CCommunication.h
+++ b/projects/cm_mcu/I2CCommunication.h
@@ -19,15 +19,19 @@
 #include "MonitorTask.h"
 
 // Command line interface
-//int apollo_i2c_ctl_set_dev(uint8_t base);
+// read an I2C device, without restart
 int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t data[4]);
+// read a register from an I2C device, with restart
 int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
                          uint16_t packed_reg_address, uint8_t nbytes,
                          uint32_t *packed_data);
+// write an I2C device, without restart
 int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned int value);
+// write a register to an I2C device, with restart
 int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr,
                          uint16_t packed_reg_address, uint8_t nbytes,
                          uint32_t packed_data);
+// read/write a register using the PMBUS protocol
 int apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *smbus_status, bool read,
                     struct dev_i2c_addr_t *add, struct pm_command_t *cmd, uint8_t *value);
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -399,23 +399,7 @@ struct dev_moni2c_addr_t ffl12_f2_moni2c_addrs[NFIREFLIES_IT_F2] = {
 #else
 #error "Define either Rev1 or Rev2"
 #endif
-uint16_t before_guard[6] = {
-    0xbeef,
-    0xbeef,
-    0xbeef,
-    0xbeef,
-    0xbeef,
-    0xbeef,
-};
 uint16_t ffl12_f2_values[NSUPPLIES_FFL12_F2 * NCOMMANDS_FFL12_F2];
-uint16_t after_guard[6] = {
-    0xbeef,
-    0xbeef,
-    0xbeef,
-    0xbeef,
-    0xbeef,
-    0xbeef,
-};
 
 struct MonitorI2CTaskArgs_t ffl12_f2_args = {
     .name = "F2_12",
@@ -632,9 +616,6 @@ void readFFpresent(void)
   present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;                     // bottom 6 bits
   present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU;             // bits 4-7
   present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU;             // bits 4-7
-  // remember these are active low signals.
-  log_info(LOG_SERVICE, "\r\nF1_12: 0x%x\r\nF1_4 : 0x%x\r\nF2_12: 0x%x\r\n, F2_4 : 0x%x\r\n", 
-    ~present_FFL12_F1_bar, ~present_FFLDAQ_F1_bar, ~present_FFL12_F2_bar, ~present_FFLDAQ_F2_bar);
 
   uint32_t ff_combined_present = ((present_FFLDAQ_F2_bar) << 16) | // 4 bits
                                  ((present_FFL12_F2_bar) << 10) |  // 6 bits

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -771,7 +771,7 @@ void getFFpart(void)
     acquireI2CSemaphoreBlock(semaphores[f]);
     uint32_t tmp_ffpart_bit_mask = 0U;
     bool detect_ff = false;
-    for (uint8_t n = 0; n < ndevices[f]; n++) {
+    for (uint32_t n = 0; n < ndevices[f]; n++) {
       uint8_t vendor_data_rxch[4];
       int8_t vendor_part_rxch[17];
 

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -612,10 +612,10 @@ void readFFpresent(void)
                                  ((present_FFL12_BOTTOM_F1));       // 6 bits
 
 #elif defined(REV2)
-  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;                     // bottom 6 bits
-  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;                     // bottom 6 bits
-  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU;             // bits 4-7
-  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU;             // bits 4-7
+  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;         // bottom 6 bits
+  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;         // bottom 6 bits
+  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU; // bits 4-7
+  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU; // bits 4-7
 
   uint32_t ff_combined_present = ((present_FFLDAQ_F2_bar) << 16) | // 4 bits
                                  ((present_FFL12_F2_bar) << 10) |  // 6 bits

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -12,7 +12,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h> // memset
-#include <sys/_types.h>
 #include <time.h> // struct tm
 
 // ROM header must come before MAP header
@@ -1718,7 +1717,7 @@ int enable_3v8(UBaseType_t ffmask[2], bool turnOff)
     // grab the semaphore to ensure unique access to I2C controller
     if (acquireI2CSemaphore(semaphores[i]) == pdFAIL) {
       log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-      return 5;
+      return SEM_ACCESS_ERROR;
     }
     // mux setting
     int result = apollo_i2c_ctl_w(i2c_device[i], muxaddr, 1, muxbit);

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -541,8 +541,6 @@ void readFFpresent(void)
   // otherwise, block its operations indefinitely until it's available
   acquireI2CSemaphoreBlock(i2c4_sem);
 
-  uint32_t present_FFL12_F1_bar, present_FFLDAQ_F1_bar; // active low signals
-
 #ifdef REV1
   // to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
@@ -551,6 +549,7 @@ void readFFpresent(void)
   apollo_i2c_ctl_w(4, 0x71, 1, 0x40);
   apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFLDAQ_F1);
 #elif defined(REV2)
+  uint32_t present_FFL12_F1_bar, present_FFLDAQ_F1_bar; // active low signals
   // to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
   apollo_i2c_ctl_reg_r(4, 0x20, 1, 0x01, 1, &present_FFL12_F1_bar); // active low!!
@@ -569,8 +568,6 @@ void readFFpresent(void)
   // otherwise, block its operations indefinitely until it's available
   acquireI2CSemaphoreBlock(i2c3_sem);
 
-  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar; // active low signals
-
 #ifdef REV1
   // to port 0
   apollo_i2c_ctl_w(3, 0x72, 1, 0x01);
@@ -579,6 +576,7 @@ void readFFpresent(void)
   apollo_i2c_ctl_w(3, 0x72, 1, 0x02);
   apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &present_0X21_F2);
 #elif defined(REV2)
+  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar; // active low signals
   // to port 7
   apollo_i2c_ctl_w(3, 0x70, 1, 0x80);
   apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2_bar); // active low!!

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h> // memset
-#include <time.h> // struct tm
+#include <time.h>   // struct tm
 
 // ROM header must come before MAP header
 #include "driverlib/rom.h"
@@ -576,7 +576,7 @@ void readFFpresent(void)
   apollo_i2c_ctl_w(3, 0x72, 1, 0x02);
   apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &present_0X21_F2);
 #elif defined(REV2)
-  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar; // active low signals
+  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar;            // active low signals
   // to port 7
   apollo_i2c_ctl_w(3, 0x70, 1, 0x80);
   apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2_bar); // active low!!
@@ -609,10 +609,10 @@ void readFFpresent(void)
                                  ((present_FFL12_BOTTOM_F1));       // 6 bits
 
 #elif defined(REV2)
-  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;         // bottom 6 bits
-  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;         // bottom 6 bits
-  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU; // bits 4-7
-  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU; // bits 4-7
+  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;             // bottom 6 bits
+  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;             // bottom 6 bits
+  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU;     // bits 4-7
+  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU;     // bits 4-7
 
   uint32_t ff_combined_present = ((present_FFLDAQ_F2_bar) << 16) | // 4 bits
                                  ((present_FFL12_F2_bar) << 10) |  // 6 bits

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -17,7 +17,6 @@
 
 // ROM header must come before MAP header
 #include "driverlib/rom.h"
-#include "driverlib/rom_map.h"
 #include "driverlib/hibernate.h"
 
 #include "Tasks.h"
@@ -31,8 +30,6 @@
 #include "common/smbus_helper.h"
 #include "I2CCommunication.h"
 #include "common/log.h"
-#include "common/printf.h"
-#include "inc/hw_memmap.h"
 
 convert_8_t tmp1;
 
@@ -45,7 +42,7 @@ uint32_t ff_USER_mask = 0;    // global variable of ff signals from user input
 uint32_t f1_ff12xmit_4v0_sel = 0; // global variable for FPGA1 12-ch xmit ff's power-supply physical selection
 uint32_t f2_ff12xmit_4v0_sel = 0; // global variable for FPGA2 12-ch xmit ff's power-supply physical selection
 
-struct ff_bit_mask_t ff_bitmask_args[] = {
+struct ff_bit_mask_t ff_bitmask_args[4] = {
     {0U, 0U}, // {3, 6} bits correspond to ffl12_f1 devices
     {0U, 0U}, // {0, 4} and bits correspond to ffldaq_f1 devices
     {0U, 0U}, // {3, 6} bits correspond to ffl12_f2 devices
@@ -60,11 +57,6 @@ uint32_t present_FFLDAQ_F1, present_FFL12_F1,
     //      4.06 I2C VU7P OPTICS (the I/O expanders at 0x20 and 0x21 have mixed 4-ch (FFLDAQ) and 12-ch (FFL12) pins)
     present_0X20_F2, present_0X21_F2, present_FFLDAQ_0X20_F2, present_FFL12_0X20_F2,
     present_FFLDAQ_0X21_F2, present_FFL12_0X21_F2 = 0;
-#elif defined(REV2)
-//      4.05 I2C FPGA31 OPTICS
-uint32_t present_FFLDAQ_F1, present_FFL12_F1,
-    //      4.06 I2C FPGA2 OPTICS
-    present_FFLDAQ_F2, present_FFL12_F2 = 0;
 #endif // REV2
 
 #ifdef REV1
@@ -182,7 +174,7 @@ struct sm_command_t sm_command_ffldaq_f1[] = {
 uint16_t ffldaq_f1_values[NSUPPLIES_FFLDAQ_F1 * NCOMMANDS_FFLDAQ_F1];
 
 struct MonitorI2CTaskArgs_t ffldaq_f1_args = {
-    .name = "FFDAQ",
+    .name = "F1_4",
     .devices = ffldaq_f1_moni2c_addrs,
     .i2c_dev = I2C_DEVICE_F1,
     .n_devices = NSUPPLIES_FFLDAQ_F1,
@@ -273,7 +265,7 @@ struct dev_moni2c_addr_t ffl12_f1_moni2c_addrs[NFIREFLIES_IT_F1] = {
 uint16_t ffl12_f1_values[NSUPPLIES_FFL12_F1 * NCOMMANDS_FFL12_F1];
 
 struct MonitorI2CTaskArgs_t ffl12_f1_args = {
-    .name = "FF12",
+    .name = "F1_12",
     .devices = ffl12_f1_moni2c_addrs,
     .i2c_dev = I2C_DEVICE_F1,
     .n_devices = NSUPPLIES_FFL12_F1,
@@ -327,7 +319,7 @@ struct sm_command_t sm_command_ffldaq_f2[] = {
 uint16_t ffldaq_f2_values[NSUPPLIES_FFLDAQ_F2 * NCOMMANDS_FFLDAQ_F2];
 
 struct MonitorI2CTaskArgs_t ffldaq_f2_args = {
-    .name = "FFDAV",
+    .name = "F2_4",
     .devices = ffldaq_f2_moni2c_addrs,
     .i2c_dev = I2C_DEVICE_F2,
     .n_devices = NSUPPLIES_FFLDAQ_F2,
@@ -407,11 +399,26 @@ struct dev_moni2c_addr_t ffl12_f2_moni2c_addrs[NFIREFLIES_IT_F2] = {
 #else
 #error "Define either Rev1 or Rev2"
 #endif
-
+uint16_t before_guard[6] = {
+    0xbeef,
+    0xbeef,
+    0xbeef,
+    0xbeef,
+    0xbeef,
+    0xbeef,
+};
 uint16_t ffl12_f2_values[NSUPPLIES_FFL12_F2 * NCOMMANDS_FFL12_F2];
+uint16_t after_guard[6] = {
+    0xbeef,
+    0xbeef,
+    0xbeef,
+    0xbeef,
+    0xbeef,
+    0xbeef,
+};
 
 struct MonitorI2CTaskArgs_t ffl12_f2_args = {
-    .name = "FF12V",
+    .name = "F2_12",
     .devices = ffl12_f2_moni2c_addrs,
     .i2c_dev = I2C_DEVICE_F2,
     .n_devices = NSUPPLIES_FFL12_F2,
@@ -518,7 +525,7 @@ struct MonitorI2CTaskArgs_t clockr0a_args = {
 void setFFmask(uint32_t ff_combined_present)
 {
 
-  log_info(LOG_SERVICE, "Setting a bit mask of enabled Fireflys to 1 \r\n");
+  log_info(LOG_SERVICE, "Setting bit mask of enabled Fireflys\r\n");
 
   // int32_t data = (~ff_combined_present) & 0xFFFFFU; // the bit value for an FF mask is an inverted bit value of the PRESENT signals
 #ifdef REV1
@@ -542,11 +549,16 @@ void setFFmask(uint32_t ff_combined_present)
   return;
 }
 
+// this function reads out the I/O expanders to determine which Fireflys are present
+// and if they require 3.8V or not.
+// the code sets ff_bitmask_args[] and f[12]_ff12xmit_4v0_sel
 void readFFpresent(void)
 {
   // grab the semaphore to ensure unique access to I2C controller
   // otherwise, block its operations indefinitely until it's available
   acquireI2CSemaphoreBlock(i2c4_sem);
+
+  uint32_t present_FFL12_F1_bar, present_FFLDAQ_F1_bar; // active low signals
 
 #ifdef REV1
   // to port 7
@@ -558,10 +570,10 @@ void readFFpresent(void)
 #elif defined(REV2)
   // to port 7
   apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
-  apollo_i2c_ctl_reg_r(4, 0x20, 1, 0x01, 1, &present_FFL12_F1);
+  apollo_i2c_ctl_reg_r(4, 0x20, 1, 0x01, 1, &present_FFL12_F1_bar); // active low!!
   // to port 6
   apollo_i2c_ctl_w(4, 0x71, 1, 0x40);
-  apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFLDAQ_F1);
+  apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFLDAQ_F1_bar);
   apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x01, 1, &f1_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
 #endif
 
@@ -574,6 +586,8 @@ void readFFpresent(void)
   // otherwise, block its operations indefinitely until it's available
   acquireI2CSemaphoreBlock(i2c3_sem);
 
+  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar; // active low signals
+
 #ifdef REV1
   // to port 0
   apollo_i2c_ctl_w(3, 0x72, 1, 0x01);
@@ -584,10 +598,10 @@ void readFFpresent(void)
 #elif defined(REV2)
   // to port 7
   apollo_i2c_ctl_w(3, 0x70, 1, 0x80);
-  apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2);
+  apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2_bar); // active low!!
   // to port 6
   apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
-  apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFLDAQ_F2);
+  apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFLDAQ_F2_bar);
   apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &f2_ff12xmit_4v0_sel); // reading FPGA2 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
 
 #endif
@@ -614,20 +628,23 @@ void readFFpresent(void)
                                  ((present_FFL12_BOTTOM_F1));       // 6 bits
 
 #elif defined(REV2)
-  present_FFL12_F1 = present_FFL12_F1 & 0x3FU;                     // bottom 6 bits
-  present_FFL12_F2 = present_FFL12_F2 & 0x3FU;                     // bottom 6 bits
-  present_FFLDAQ_F1 = (present_FFLDAQ_F1 >> 4) & 0xFU;             // bits 4-7
-  present_FFLDAQ_F2 = (present_FFLDAQ_F2 >> 4) & 0xFU;             // bits 4-7
+  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;                     // bottom 6 bits
+  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;                     // bottom 6 bits
+  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU;             // bits 4-7
+  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU;             // bits 4-7
+  // remember these are active low signals.
+  log_info(LOG_SERVICE, "\r\nF1_12: 0x%x\r\nF1_4 : 0x%x\r\nF2_12: 0x%x\r\n, F2_4 : 0x%x\r\n", 
+    ~present_FFL12_F1_bar, ~present_FFLDAQ_F1_bar, ~present_FFL12_F2_bar, ~present_FFLDAQ_F2_bar);
 
-  uint32_t ff_combined_present = ((present_FFLDAQ_F2) << 16) | // 4 bits
-                                 ((present_FFL12_F2) << 10) |  // 6 bits
-                                 (present_FFLDAQ_F1) << 6 |    // 4 bits
-                                 ((present_FFL12_F1));         // 6 bits
+  uint32_t ff_combined_present = ((present_FFLDAQ_F2_bar) << 16) | // 4 bits
+                                 ((present_FFL12_F2_bar) << 10) |  // 6 bits
+                                 (present_FFLDAQ_F1_bar) << 6 |    // 4 bits
+                                 ((present_FFL12_F1_bar));         // 6 bits
 
-  ff_bitmask_args[1].present_bit_mask = (~present_FFLDAQ_F1) & 0xFU; // 4 bits
-  ff_bitmask_args[0].present_bit_mask = (~present_FFL12_F1) & 0x3FU; // 6 bits
-  ff_bitmask_args[3].present_bit_mask = (~present_FFLDAQ_F2) & 0xFU; // 4 bits
-  ff_bitmask_args[2].present_bit_mask = (~present_FFL12_F2) & 0x3FU; // 6 bits
+  ff_bitmask_args[0].present_bit_mask = (~present_FFL12_F1_bar) & 0x3FU; // 6 bits
+  ff_bitmask_args[1].present_bit_mask = (~present_FFLDAQ_F1_bar) & 0xFU; // 4 bits
+  ff_bitmask_args[2].present_bit_mask = (~present_FFL12_F2_bar) & 0x3FU; // 6 bits
+  ff_bitmask_args[3].present_bit_mask = (~present_FFLDAQ_F2_bar) & 0xFU; // 4 bits
 
   f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0x7; // bits 4-6
   f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0x7; // bits 4-6
@@ -749,17 +766,22 @@ uint16_t getFFpresentbit(const uint8_t i)
   return val;
 }
 
+// there is a lot of indirection here
+// this function modifies ffl12_f[12]_args to point to the appropriate command set
+// it also modifies ff_bitmask_args[]
+//
+#define NSTRING (VENDOR_STOP_BIT_FF12 - VENDOR_START_BIT_FF12 + 1)
 void getFFpart(void)
 {
   // Write device vendor part for identifying FF device
-  uint8_t nstring = VENDOR_STOP_BIT_FF12 - VENDOR_START_BIT_FF12 + 1;
-  char vendor_string[nstring];
-  uint8_t data;
+  char vendor_string[NSTRING];
 
   SemaphoreHandle_t semaphores[2] = {i2c4_sem, i2c3_sem};
   const int ff_ndev_offset[2] = {0, NFIREFLIES_IT_F1 + NFIREFLIES_DAQ_F1};
   const uint32_t ndevices[2] = {NSUPPLIES_FFL12_F1 / 2, NSUPPLIES_FFL12_F2 / 2};
-  const uint32_t dev_present_mask[2] = {present_FFL12_F1, present_FFL12_F2};
+  // why are these masks inverted? I am inverting them to preserve past behavior
+  const uint32_t dev_present_mask[2] = {~ff_bitmask_args[0].present_bit_mask,
+                                        ~ff_bitmask_args[2].present_bit_mask};
   const uint32_t dev_xmit_4v0_sel[2] = {f1_ff12xmit_4v0_sel, f2_ff12xmit_4v0_sel};
 
   struct MonitorI2CTaskArgs_t args_st[2] = {ffl12_f1_args, ffl12_f2_args};
@@ -775,7 +797,7 @@ void getFFpart(void)
       uint8_t vendor_data_rxch[4];
       int8_t vendor_part_rxch[17];
 
-      data = 0x1U << args_st[f].devices[(2 * n) + 1].mux_bit;
+      uint8_t data = 0x1U << args_st[f].devices[(2 * n) + 1].mux_bit;
       log_debug(LOG_SERVICE, "Mux set to 0x%02x\r\n", data);
       int rmux = apollo_i2c_ctl_w(args_st[f].i2c_dev, args_st[f].devices[(2 * n) + 1].mux_addr, 1, data);
       if (rmux != 0) {
@@ -813,14 +835,14 @@ void getFFpart(void)
               ffl12_f2_args.commands = sm_command_fflit_f2; // if the 14Gbsp 12-ch part is found, change the set of commands to sm_command_fflit_f2
           }
           log_info(LOG_SERVICE, "Getting Firefly 12-ch part (FPGA%d): %s \r\n:", f + 1, vendor_string_rxch);
-          strncpy(vendor_string, vendor_string_rxch, nstring);
+          strncpy(vendor_string, vendor_string_rxch, NSTRING);
         }
         else {
           if (strstr(vendor_string_rxch, "14") == NULL && strstr(vendor_string_rxch, "CRRNB") == NULL) {
             tmp_ffpart_bit_mask = tmp_ffpart_bit_mask | (0x1U << n); // bit 1 for a 25Gbs ch and assign to a Bit-mask of Firefly 12-ch part
           }
           else {
-            if (strncmp(vendor_string_rxch, vendor_string, nstring) != 0) {
+            if (strncmp(vendor_string_rxch, vendor_string, NSTRING) != 0) {
               log_info(LOG_SERVICE, "Different Firefly 12-ch part(FPGA%d) on %s \r\n:", f + 1, ff_moni2c_addrs[(2 * n) + 1 + ff_ndev_offset[f]].name);
               log_info(LOG_SERVICE, "with %s \r\n:", vendor_string_rxch);
             }

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -576,7 +576,7 @@ void readFFpresent(void)
   apollo_i2c_ctl_w(3, 0x72, 1, 0x02);
   apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &present_0X21_F2);
 #elif defined(REV2)
-  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar;            // active low signals
+  uint32_t present_FFL12_F2_bar, present_FFLDAQ_F2_bar; // active low signals
   // to port 7
   apollo_i2c_ctl_w(3, 0x70, 1, 0x80);
   apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2_bar); // active low!!
@@ -609,10 +609,10 @@ void readFFpresent(void)
                                  ((present_FFL12_BOTTOM_F1));       // 6 bits
 
 #elif defined(REV2)
-  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;             // bottom 6 bits
-  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;             // bottom 6 bits
-  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU;     // bits 4-7
-  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU;     // bits 4-7
+  present_FFL12_F1_bar = present_FFL12_F1_bar & 0x3FU;         // bottom 6 bits
+  present_FFL12_F2_bar = present_FFL12_F2_bar & 0x3FU;         // bottom 6 bits
+  present_FFLDAQ_F1_bar = (present_FFLDAQ_F1_bar >> 4) & 0xFU; // bits 4-7
+  present_FFLDAQ_F2_bar = (present_FFLDAQ_F2_bar >> 4) & 0xFU; // bits 4-7
 
   uint32_t ff_combined_present = ((present_FFLDAQ_F2_bar) << 16) | // 4 bits
                                  ((present_FFL12_F2_bar) << 10) |  // 6 bits

--- a/projects/cm_mcu/MonitorI2CTask.c
+++ b/projects/cm_mcu/MonitorI2CTask.c
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <string.h>
 
-
 // FreeRTOS
 #include "FreeRTOS.h"
 #include "FreeRTOSConfig.h"
@@ -49,7 +48,6 @@ bool getFFch_high(uint8_t val, int channel)
   return true;
 }
 
-
 // Monitor registers of FF temperatures, voltages, currents, and ClK statuses via I2C
 void MonitorI2CTask(void *parameters)
 {
@@ -61,12 +59,11 @@ void MonitorI2CTask(void *parameters)
   // watchdog info
   task_watchdog_register_task(kWatchdogTaskID_MonitorI2CTask);
 
-
   // wait for the power to come up
   vTaskDelayUntil(&(args->updateTick), pdMS_TO_TICKS(5000));
 
-  int IsCLK = (strstr(args->name, "CLK") != NULL);    // the instance is of CLK-device type
-  int IsFF12 = (strstr(args->name, "_12") != NULL);  // the instance is of FF 12-ch part type
+  int IsCLK = (strstr(args->name, "CLK") != NULL);  // the instance is of CLK-device type
+  int IsFF12 = (strstr(args->name, "_12") != NULL); // the instance is of FF 12-ch part type
   int IsFFDAQ = (strstr(args->name, "_4") != NULL); // the instance is of FF 4-ch part type
 
   // initialize to the current tick time
@@ -176,7 +173,7 @@ void MonitorI2CTask(void *parameters)
         uint8_t page_reg_value = args->commands[c].page;
         int r = apollo_i2c_ctl_reg_w(args->i2c_dev, args->devices[ps].dev_addr, 1, args->selpage_reg, 1, page_reg_value);
         if (r != 0) {
-          log_error(LOG_MONI2C, "%s : page fail %s\r\n", args->devices[ps].name, SMBUS_get_error(r));
+          log_error(LOG_MONI2C, "%s: %s : page fail %s\r\n", args->name, args->devices[ps].name, SMBUS_get_error(r));
           break;
         }
 

--- a/projects/cm_mcu/Semaphore.h
+++ b/projects/cm_mcu/Semaphore.h
@@ -25,6 +25,8 @@ void initSemaphores(void);
 
 SemaphoreHandle_t getSemaphore(int number);
 
+#define SEM_ACCESS_ERROR (-5)
+
 int acquireI2CSemaphoreTime(SemaphoreHandle_t s, TickType_t tickWaits);
 
 #define acquireI2CSemaphore(s) \

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -216,7 +216,7 @@ extern uint32_t ff_USER_mask;
 extern uint32_t f1_ff12xmit_4v0_sel;
 extern uint32_t f2_ff12xmit_4v0_sel;
 struct ff_bit_mask_t {
-  uint8_t ffpart_bit_mask;   // this mask is only used for detecting 12-ch 25Gbps on the REV2 board
+  uint8_t ffpart_bit_mask;  // this mask is only used for detecting 12-ch 25Gbps on the REV2 board
   uint8_t present_bit_mask; // this mask is used for all ffs to detect if it is mounted or not
 };
 extern struct ff_bit_mask_t ff_bitmask_args[NFIREFLY_ARG];
@@ -316,7 +316,7 @@ uint64_t EPRMMessage(uint64_t action, uint64_t addr, uint64_t data);
 void EEPROMTask(void *parameters);
 
 // -- ZynqMon
-//#define ZYNQMON_TEST_MODE
+// #define ZYNQMON_TEST_MODE
 // ZynqMon queue messages
 #define ZYNQMON_ENABLE_TRANSMIT  0x1
 #define ZYNQMON_DISABLE_TRANSMIT 0x2

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -217,15 +217,13 @@ extern uint32_t f1_ff12xmit_4v0_sel;
 extern uint32_t f2_ff12xmit_4v0_sel;
 struct ff_bit_mask_t {
   uint8_t ffpart_bit_mask;   // this mask is only used for detecting 12-ch 25Gbps on the REV2 board
-  uint32_t present_bit_mask; // this mask is used for all ffs to detect if it is mounted or not
+  uint8_t present_bit_mask; // this mask is used for all ffs to detect if it is mounted or not
 };
 extern struct ff_bit_mask_t ff_bitmask_args[NFIREFLY_ARG];
 #endif
 
 #ifdef REV1
 extern uint32_t present_0X20_F2, present_0X21_F2, present_FFLDAQ_F1, present_FFL12_F1, present_FFLDAQ_0X20_F2, present_FFL12_0X20_F2, present_FFLDAQ_0X21_F2, present_FFL12_0X21_F2;
-#elif defined(REV2)
-extern uint32_t present_FFLDAQ_F1, present_FFL12_F1, present_FFLDAQ_F2, present_FFL12_F2;
 #endif               // REV2
 #define ADDR_ID 0x40 // internal eeprom block for board number & rev
 #define ADDR_FF 0x44 // internal eeprom block for ff mask

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -433,7 +433,7 @@ void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName)
 }
 #endif
 /*-----------------------------------------------------------*/
-
+extern uint16_t  after_guard[6], before_guard[6];
 #if (configUSE_IDLE_HOOK == 1)
 void vApplicationIdleHook(void)
 {
@@ -455,6 +455,10 @@ void vApplicationIdleHook(void)
     }
     Print("\r\n");
 #endif // DUMP_STACK
+  }
+  for (int i = 0; i< 6; ++i ) {
+    if ( (after_guard[i] != 0xbeef ) || (before_guard[i] != 0xbeef) )
+      Print("bad beef\r\n");
   }
 }
 #endif

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -144,7 +144,7 @@ void SystemInitInterrupts(void)
 #if defined(REV1)
   initI2C6(g_ui32SysClock); // controller for FPGAs
 #elif defined(REV2)
-  initI2C5(g_ui32SysClock);  // controller for FPGAs
+  initI2C5(g_ui32SysClock); // controller for FPGAs
 #endif
 
   // smbus
@@ -411,8 +411,7 @@ int SystemStackWaterHighWaterMark(void)
 
 /*-----------------------------------------------------------*/
 #if (configCHECK_FOR_STACK_OVERFLOW != 0)
-__attribute__((noreturn))
-void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName)
+__attribute__((noreturn)) void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName)
 {
   /* If configCHECK_FOR_STACK_OVERFLOW is set to either 1 or 2 then this
      function will automatically get called if a task overflows its stack. */

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -299,20 +299,20 @@ int main(void)
 #endif // REV1
   xTaskCreate(ADCMonitorTask, "ADC", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
 
-  xTaskCreate(MonitorI2CTask, "FF12", 2 * configMINIMAL_STACK_SIZE, &ffl12_f1_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorI2CTask, ffl12_f1_args.name, 2 * configMINIMAL_STACK_SIZE, &ffl12_f1_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorI2CTask, "FFDAQ", 2 * configMINIMAL_STACK_SIZE, &ffldaq_f1_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorI2CTask, ffldaq_f1_args.name, 2 * configMINIMAL_STACK_SIZE, &ffldaq_f1_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorI2CTask, "FF12V", 2 * configMINIMAL_STACK_SIZE, &ffl12_f2_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorI2CTask, ffl12_f2_args.name, 2 * configMINIMAL_STACK_SIZE, &ffl12_f2_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorI2CTask, "FFDAV", 2 * configMINIMAL_STACK_SIZE, &ffldaq_f2_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorI2CTask, ffldaq_f2_args.name, 2 * configMINIMAL_STACK_SIZE, &ffldaq_f2_args, tskIDLE_PRIORITY + 4,
               NULL);
 
 #ifdef REV2
-  xTaskCreate(MonitorI2CTask, "CLKSI", 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,
-              NULL);
-  xTaskCreate(MonitorI2CTask, "CLKR0", 2 * configMINIMAL_STACK_SIZE, &clockr0a_args, tskIDLE_PRIORITY + 4,
-              NULL);
+  // xTaskCreate(MonitorI2CTask, clock_args.name, 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,
+  //             NULL);
+  // xTaskCreate(MonitorI2CTask, clockr0a_args.name, 2 * configMINIMAL_STACK_SIZE, &clockr0a_args, tskIDLE_PRIORITY + 4,
+  //             NULL);
 #endif // REV2
   xTaskCreate(MonitorTask, "PSMON", 2 * configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
               NULL);

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -309,10 +309,10 @@ __attribute__((noreturn)) int main(void)
               NULL);
 
 #ifdef REV2
-  // xTaskCreate(MonitorI2CTask, clock_args.name, 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,
-  //             NULL);
-  // xTaskCreate(MonitorI2CTask, clockr0a_args.name, 2 * configMINIMAL_STACK_SIZE, &clockr0a_args, tskIDLE_PRIORITY + 4,
-  //             NULL);
+  xTaskCreate(MonitorI2CTask, clock_args.name, 2 * configMINIMAL_STACK_SIZE, &clock_args, tskIDLE_PRIORITY + 4,
+              NULL);
+  xTaskCreate(MonitorI2CTask, clockr0a_args.name, 2 * configMINIMAL_STACK_SIZE, &clockr0a_args, tskIDLE_PRIORITY + 4,
+              NULL);
 #endif // REV2
   xTaskCreate(MonitorTask, dcdc_args.name, 2 * configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
               NULL);

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -314,9 +314,9 @@ __attribute__((noreturn)) int main(void)
   // xTaskCreate(MonitorI2CTask, clockr0a_args.name, 2 * configMINIMAL_STACK_SIZE, &clockr0a_args, tskIDLE_PRIORITY + 4,
   //             NULL);
 #endif // REV2
-  xTaskCreate(MonitorTask, "PSMON", 2 * configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTask, dcdc_args.name, 2 * configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorTask, "XIMON", 2 * configMINIMAL_STACK_SIZE, &fpga_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTask, fpga_args.name, 2 * configMINIMAL_STACK_SIZE, &fpga_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(I2CSlaveTask, "I2CS0", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(EEPROMTask, "EPRM", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -9,15 +9,16 @@
 #include <stdbool.h>
 
 #include <stdlib.h>
-#include "FreeRTOSConfig.h"
+//#include "FreeRTOSConfig.h"
 #include "commands/parameters.h"
 #include "common/utils.h"
 #include "driverlib/gpio.h"
 #include "BoardCommands.h"
 #include "common/pinsel.h"
 #include "inc/hw_hibernate.h"
-#include "driverlib/hibernate.h"
+//#include "driverlib/hibernate.h"
 #include "Tasks.h"
+#include "Semaphore.h"
 
 // This command takes no arguments
 BaseType_t restart_mcu(int argc, char **argv, char *m)
@@ -349,7 +350,7 @@ BaseType_t v38_ctl(int argc, char **argv, char *m)
   int ret = enable_3v8(ffmask, !turnOn);
   if (ret != 0) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "enable 3v8 failed with %d\r\n", ret);
-    if (ret == 5)
+    if (ret == SEM_ACCESS_ERROR)
       snprintf(m + copied, SCRATCH_SIZE - copied, "please release semaphore \r\n");
     return pdFALSE;
   }

--- a/projects/cm_mcu/commands/BoardCommands.c
+++ b/projects/cm_mcu/commands/BoardCommands.c
@@ -9,14 +9,12 @@
 #include <stdbool.h>
 
 #include <stdlib.h>
-//#include "FreeRTOSConfig.h"
 #include "commands/parameters.h"
 #include "common/utils.h"
 #include "driverlib/gpio.h"
 #include "BoardCommands.h"
 #include "common/pinsel.h"
 #include "inc/hw_hibernate.h"
-//#include "driverlib/hibernate.h"
 #include "Tasks.h"
 #include "Semaphore.h"
 

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -656,7 +656,6 @@ BaseType_t ff_status(int argc, char **argv, char *m)
   int i1 = 0; // 0 for status
 #ifdef REV2
   int nTx = -1; // order of Tx ch
-#endif          // REV2
   // print out the "present" bits on first pass
   if (whichff == 0) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "PRESENT:\r\n");
@@ -667,6 +666,7 @@ BaseType_t ff_status(int argc, char **argv, char *m)
                          ff_bitmask_args[i].present_bit_mask);
     }
   }
+#endif // REV2
   for (; n < NFIREFLY_ARG; ++n) {
     struct MonitorI2CTaskArgs_t *ff_arg = ff_moni2c_arg[n].arg;
     for (; whichff < ff_moni2c_arg[n].int_idx + ff_moni2c_arg[n].num_dev; ++whichff) {

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -544,17 +544,17 @@ BaseType_t adc_ctl(int argc, char **argv, char *m)
 
 #ifdef REV2
 // reset firefly devices. The resets are ganged together,
-// so you can only reset all of them at once, for those 
+// so you can only reset all of them at once, for those
 // attached to F1 or F2
 #define FF_RESET_MUX_ADDR       0x71
-#define FF_RESET_MUX_BIT_MASK  (0x1<<6)
+#define FF_RESET_MUX_BIT_MASK   (0x1 << 6)
 #define FF_RESET_IOEXP_ADDR     0x21
 #define FF_RESET_IOEXP_REG_ADDR 0x3 // output port 1
 BaseType_t ff_reset(int argc, char **argv, char *m)
 {
   int copied = 0;
   BaseType_t which_fpga = strtol(argv[1], NULL, 10);
-  if ( which_fpga != 1 && which_fpga != 2 ) {
+  if (which_fpga != 1 && which_fpga != 2) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: arg must 1 or 2\r\n", argv[0]);
     return pdFALSE;
   }
@@ -563,7 +563,7 @@ BaseType_t ff_reset(int argc, char **argv, char *m)
   // otherwise, block its operations indefinitely until it's available
   SemaphoreHandle_t s = i2c4_sem;
   uint8_t i2c_dev = 4;
-  if ( which_fpga == 2 ) {
+  if (which_fpga == 2) {
     s = i2c3_sem;
     i2c_dev = 3;
   }
@@ -587,7 +587,7 @@ BaseType_t ff_reset(int argc, char **argv, char *m)
   // release the semaphore
   if (xSemaphoreGetMutexHolder(s) == xTaskGetCurrentTaskHandle())
     xSemaphoreGive(s);
-  if ( ret ) {
+  if (ret) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: error %d\r\n", argv[0], ret);
   }
   else {
@@ -600,7 +600,7 @@ BaseType_t ff_mux_reset(int argc, char **argv, char *m)
 {
   int copied = 0;
   BaseType_t which_fpga = strtol(argv[1], NULL, 10);
-  if ( which_fpga != 1 && which_fpga != 2 ) {
+  if (which_fpga != 1 && which_fpga != 2) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: arg must 1 or 2\r\n", argv[0]);
     return pdFALSE;
   }
@@ -608,7 +608,7 @@ BaseType_t ff_mux_reset(int argc, char **argv, char *m)
   // grab the semaphore to ensure unique access to I2C controller
   // otherwise, block its operations indefinitely until it's available
   SemaphoreHandle_t s = i2c4_sem;
-  if ( which_fpga == 2 ) {
+  if (which_fpga == 2) {
     s = i2c3_sem;
   }
   if (acquireI2CSemaphore(s) == pdFAIL) {
@@ -617,7 +617,7 @@ BaseType_t ff_mux_reset(int argc, char **argv, char *m)
   }
   // select the appropriate output for the mux
   int pin = _F1_OPTICS_I2C_RESET;
-  if ( which_fpga == 2 )
+  if (which_fpga == 2)
     pin = _F2_OPTICS_I2C_RESET;
   // toggle the pin
   write_gpio_pin(pin, 0); // active low signal
@@ -625,7 +625,7 @@ BaseType_t ff_mux_reset(int argc, char **argv, char *m)
   write_gpio_pin(pin, 1); // active low signal
 
   if (xSemaphoreGetMutexHolder(s) == xTaskGetCurrentTaskHandle())
-      xSemaphoreGive(s);
+    xSemaphoreGive(s);
   copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: mux reset complete F%d\r\n", argv[0], which_fpga);
   return pdFALSE;
 }
@@ -657,13 +657,13 @@ BaseType_t ff_status(int argc, char **argv, char *m)
   int nTx = -1; // order of Tx ch
 #endif          // REV2
   // print out the "present" bits on first pass
-  if ( whichff == 0 ) {
+  if (whichff == 0) {
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "PRESENT:\r\n");
     extern struct ff_bit_mask_t ff_bitmask_args[4];
     char *ff_bitmask_names[4] = {"1_12", "1_4 ", "2_12", "2_4 "};
-    for (int i = 0; i < 4; ++i ) {
+    for (int i = 0; i < 4; ++i) {
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "F%s: 0x%02x\r\n", ff_bitmask_names[i],
-                          ff_bitmask_args[i].present_bit_mask);
+                         ff_bitmask_args[i].present_bit_mask);
     }
   }
   for (; n < NFIREFLY_ARG; ++n) {

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -1055,8 +1055,9 @@ BaseType_t ff_ctl(int argc, char **argv, char *m)
         int ret = read_arbitrary_ff_register(regnum, channel, &value, 1);
         if (ret != 0) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "read_ff_reg failed with %d\r\n", ret);
-          if (ret == -5)
+          if (ret == SEM_ACCESS_ERROR) {
             snprintf(m + copied, SCRATCH_SIZE - copied, "please release semaphore \r\n");
+          }
           return pdFALSE;
         }
         copied += snprintf(m + copied, SCRATCH_SIZE - copied,
@@ -1087,8 +1088,9 @@ BaseType_t ff_ctl(int argc, char **argv, char *m)
         int ret = write_arbitrary_ff_register(regnum, value, channel);
         if (ret != 0) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "write_ff_reg failed with %d\r\n", ret);
-          if (ret == -5)
+          if (ret == SEM_ACCESS_ERROR) {
             snprintf(m + copied, SCRATCH_SIZE - copied, "please release semaphore \r\n");
+          }
           return pdFALSE;
         }
         snprintf(m + copied, SCRATCH_SIZE - copied,

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -16,7 +16,6 @@
 #include "Tasks.h"
 #include "projdefs.h"
 
-
 int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t *value, size_t size, int i2c_device)
 {
   memset(value, 0, size);

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -16,6 +16,7 @@
 #include "Tasks.h"
 #include "projdefs.h"
 
+
 int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t *value, size_t size, int i2c_device)
 {
   memset(value, 0, size);
@@ -37,7 +38,7 @@ int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t *value,
 
   if (acquireI2CSemaphore(s) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return 5;
+    return SEM_ACCESS_ERROR;
   }
 
   // write to the mux
@@ -90,7 +91,7 @@ static int write_ff_register(const char *name, uint8_t reg, uint16_t value, int 
 
   if (acquireI2CSemaphore(s) == pdFAIL) {
     log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return 5;
+    return SEM_ACCESS_ERROR;
   }
 
   // write to the mux
@@ -1055,7 +1056,7 @@ BaseType_t ff_ctl(int argc, char **argv, char *m)
         int ret = read_arbitrary_ff_register(regnum, channel, &value, 1);
         if (ret != 0) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "read_ff_reg failed with %d\r\n", ret);
-          if (ret == 5)
+          if (ret == -5)
             snprintf(m + copied, SCRATCH_SIZE - copied, "please release semaphore \r\n");
           return pdFALSE;
         }
@@ -1087,7 +1088,7 @@ BaseType_t ff_ctl(int argc, char **argv, char *m)
         int ret = write_arbitrary_ff_register(regnum, value, channel);
         if (ret != 0) {
           copied += snprintf(m + copied, SCRATCH_SIZE - copied, "write_ff_reg failed with %d\r\n", ret);
-          if (ret == 5)
+          if (ret == -5)
             snprintf(m + copied, SCRATCH_SIZE - copied, "please release semaphore \r\n");
           return pdFALSE;
         }

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -50,6 +50,7 @@ BaseType_t adc_ctl(int argc, char **argv, char *m);
 BaseType_t ff_ctl(int argc, char **argv, char *m);
 BaseType_t ff_optpow(int argc, char **argv, char *m);
 BaseType_t ff_temp(int argc, char **argv, char *m);
+BaseType_t ff_reset(int argc, char **argv, char *m);
 BaseType_t ff_status(int argc, char **argv, char *m);
 BaseType_t ff_los_alarm(int argc, char **argv, char *m);
 BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m);

--- a/projects/cm_mcu/commands/SensorControl.h
+++ b/projects/cm_mcu/commands/SensorControl.h
@@ -54,6 +54,7 @@ BaseType_t ff_reset(int argc, char **argv, char *m);
 BaseType_t ff_status(int argc, char **argv, char *m);
 BaseType_t ff_los_alarm(int argc, char **argv, char *m);
 BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m);
+BaseType_t ff_mux_reset(int argc, char **argv, char *m);
 
 // Clocks
 BaseType_t clkmon_ctl(int argc, char **argv, char *m);


### PR DESCRIPTION
This set of cleanups was done with in the context of debugging some I2C failures on the new Samtec 12 channel fireflies. That study was ultimately inconclusive. The changes here are 
* add two commands, `ff_reset` and `ff_mux_reset`
* add some documentary comments
* fix a bug where some ADDR_ACK_ERRORS were reported as a semaphore error 
* start removing some globals