### PR TITLE
Hotfix for two CLI Firefly commands

### DIFF
--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -157,7 +157,7 @@ static int disable_transmit(bool disable, int num_ff)
     }
 
     if (strstr(ff_moni2c_addrs[i].name, "XCVR") != NULL) {
-      value = 0xf;
+      value &= 0x000fU;
       ret += write_ff_register(ff_moni2c_addrs[i].name, ECU0_25G_XVCR_TX_DISABLE_REG, value, 1, i2c_dev);
     }
     else if (strstr(ff_moni2c_addrs[i].name, "Tx") != NULL) {

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -65,7 +65,7 @@ int read_ff_register(const char *name, uint16_t packed_reg_addr, uint8_t *value,
   if (!res) { // clear the mux
     muxmask = 0x0U;
     res = apollo_i2c_ctl_w(i2c_device, ff_moni2c_addrs[ff].mux_addr, 1, muxmask);
-    if (res !=0) {
+    if (res != 0) {
       log_warn(LOG_SERVICE, "%s: Mux clear error %d (%s) (ff=%s) ...\r\n", __func__, res,
                SMBUS_get_error(res), ff_moni2c_addrs[ff].name);
     }


### PR DESCRIPTION
Fix
* fix `ff xmit off all` and `ff recvr off all` commands
* add clearing of i2c mux on `read_ff_register` and `write_ff_register`