### PR TITLE
add script to generate xml TGZ file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ PL_MEM_CM_rev1.xml
 PL_MEM_CM_rev2.xml
 projects/cm_mcu/MonI2C_addresses.c
 projects/cm_mcu/MonI2C_addresses.h
+CornellCM_MCU.tgz

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,19 @@ check-and-reinit-submodules:
 
 release:
 	@$(MAKE) -C projects/cm_mcu release
+	@if [ 'x${VERBOSE}' = x ]; then \
+		echo "  SH    make_release_xml_tgz.sh"; \
+	else \
+		echo "  ./make_release_xml_tgz.sh"; \
+	fi
+	@./make_release_xml_tgz.sh
 
 check-for-pr: format
+	@if [ 'x${VERBOSE}' = x ]; then \
+		echo "  SH buildall.sh"; \
+	else \
+		echo "  ./build_all.sh"; \
+	fi
 	@./buildall.sh
 
 

--- a/make_release_xml_tgz.sh
+++ b/make_release_xml_tgz.sh
@@ -1,0 +1,23 @@
+#! /bin/sh
+
+# exit on error
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command failed with exit code $?."' ERR
+
+
+[ -d tmp ] && rm -rf tmp
+
+mkdir -p tmp/CornellCM_MCU/address_table/modules_CM_MCU
+cd tmp
+cp ../PL_MEM*.xml CornellCM_MCU/address_table/modules_CM_MCU
+cp ../sm_cm_config/data/*.xml CornellCM_MCU/address_table
+cd CornellCM_MCU/address_table/modules_CM_MCU
+ln -s PL_MEM_CM_Rev2.xml PL_MEM_CM.xml
+cd ../../..
+tar -czf ../CornellCM_MCU.tgz CornellCM_MCU
+cd ..
+rm -rf tmp

--- a/make_release_xml_tgz.sh
+++ b/make_release_xml_tgz.sh
@@ -18,6 +18,6 @@ cp ../sm_cm_config/data/*.xml CornellCM_MCU/address_table
 cd CornellCM_MCU/address_table/modules_CM_MCU
 ln -s PL_MEM_CM_Rev2.xml PL_MEM_CM.xml
 cd ../../..
-tar -czf ../CornellCM_MCU.tgz CornellCM_MCU
+tar -czf ../CornellCM_MCU.tar.gz CornellCM_MCU
 cd ..
 rm -rf tmp

--- a/sm_cm_config/data/address_apollo.xml
+++ b/sm_cm_config/data/address_apollo.xml
@@ -1,0 +1,3 @@
+<node id="TOP">
+  <node id="PL_MEM_CM" address="0x23000000" fwinfo="uio_endpoint" module="file://modules_CM_MCU/PL_MEM_CM.xml" />
+</node>

--- a/sm_cm_config/data/connections.xml
+++ b/sm_cm_config/data/connections.xml
@@ -1,0 +1,3 @@
+<node id="TOP">
+  <node id="PL_MEM_CM" address="0x23000000" fwinfo="uio_endpoint" module="file://modules_CM_MCU/PL_MEM_CM.xml" />
+</node>


### PR DESCRIPTION
closes #222

when `make release` is called, this will cause a new tgz file to be created that has the right format so it can be installed in `/fw/CM` on the Zynq.

On the zynq:
```
[cms@cmsapollo214 ~]$ tree /fw/CM/CornellCM_MCU/
/fw/CM/CornellCM_MCU/
└── address_table
    ├── address_apollo.xml
    ├── address_apollo.xml~
    ├── connections.xml
    ├── connections.xml~
    └── modules_CM_MCU
        ├── modules_CM_MCU -> modules_CM_MCU
        ├── PL_MEM_CM_old.xml
        ├── PL_MEM_CM_rev2.xml
        └── PL_MEM_CM.xml -> PL_MEM_CM_rev2.xml

2 directories, 8 files
```

This PR generates a tgz file as follows:
```
(base) [tmp] tree CornellCM_MCU               11:23:42  ☁  xml_release ☂ ⚡ ✚ ✭
CornellCM_MCU
└── address_table
   ├── address_apollo.xml
   ├── connections.xml
   └── modules_CM_MCU
      ├── PL_MEM_CM.xml -> PL_MEM_CM_Rev2.xml
      ├── PL_MEM_CM_rev1.xml
      └── PL_MEM_CM_rev2.xml
```