### PR TITLE
choose bash explicitly in release generation sh script

### DIFF
--- a/make_release_xml_tgz.sh
+++ b/make_release_xml_tgz.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # exit on error
 set -e


### PR DESCRIPTION
with just `#! /bin/sh` I get 
```
  SH    make_release_xml_tgz.sh
trap: DEBUG: bad trap
make: *** [Makefile:41: release] Error 1
```
which the [internets suggest](https://stackoverflow.com/questions/11280240/why-my-trap-doesnt-work-when-the-signal-set-as-debug-fake-signal) is from ash not bash being what is invoked as /bin/sh in the github CI runner.