### PR TITLE
fix firefly optical power commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ PL_MEM_CM_rev2.xml
 projects/cm_mcu/MonI2C_addresses.c
 projects/cm_mcu/MonI2C_addresses.h
 CornellCM_MCU.tgz
+CornellCM_MCU.tar.gz

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -319,7 +319,7 @@ float getFFoptpow(const uint8_t i, const uint8_t ch)
       val = -999.f;
       break;
   }
-  return val * 10.f; // LSB is 0.1 uW, we return uW
+  return val * 0.1f; // LSB is 0.1 uW, we return uW
 }
 #undef SWAP_BYTES
 

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -138,7 +138,6 @@ void MonitorTask(void *parameters)
         // loop over commands
         for (int c = 0; c < args->n_commands; ++c) {
           int index = ps * (args->n_commands * args->n_pages) + page * args->n_commands + c;
-          args->pm_values[index] = __builtin_nanf("");
 
           data[0] = 0x0U;
           data[1] = 0x0U;
@@ -147,6 +146,7 @@ void MonitorTask(void *parameters)
           if (r != SMBUS_OK) {
             log_warn(LOG_MON, "%s: SMBUS failed (master/bus busy, (ps=%d,c=%d,p=%d)\r\n", args->name,
                      ps, c, page);
+            args->pm_values[index] = __builtin_nanf("");
             continue; // abort reading this register
           }
           tries = 0;
@@ -162,6 +162,7 @@ void MonitorTask(void *parameters)
             log_warn(LOG_MON, "%s: Error %d, break out of loop (ps=%d,c=%d,p=%d) ...\r\n", args->name,
                      *args->smbus_status, ps, c, page);
             // abort reading this device
+            args->pm_values[index] = __builtin_nanf("");
             if (log)
               errbuffer_put(EBUF_I2C, (uint16_t)args->name[0]);
             release_break();

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -977,7 +977,7 @@ BaseType_t ff_optpow(int argc, char **argv, char *m)
     else {
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
     }
-    if ((SCRATCH_SIZE - copied) < 20) {
+    if ((SCRATCH_SIZE - copied) < 40) {
       ++i;
       return pdTRUE;
     }


### PR DESCRIPTION
- wrong value which does not fit into 16 bit int for Zynq transmission
- also fix printout of `ff_optpow`