### PR TITLE
Use RGB LED on MCU for status info

### DIFF
--- a/projects/cm_mcu/AlarmUtilities.c
+++ b/projects/cm_mcu/AlarmUtilities.c
@@ -171,6 +171,9 @@ struct GenericAlarmParams_t tempAlarmTask = {
     .errorlog_registererror = &TempErrorLog,
     .errorlog_clearerror = &TempClearErrorLog,
     .stack_size = 4096,
+    .led_warn_msg = LED_STATUS_WARN,
+    .led_alarm_msg = LED_STATUS_ALARM,
+    .led_normal_msg = LED_STATUS_NORMAL,
 };
 
 ///////////////////////////////////////////////////////////

--- a/projects/cm_mcu/AlarmUtilities.c
+++ b/projects/cm_mcu/AlarmUtilities.c
@@ -171,9 +171,9 @@ struct GenericAlarmParams_t tempAlarmTask = {
     .errorlog_registererror = &TempErrorLog,
     .errorlog_clearerror = &TempClearErrorLog,
     .stack_size = 4096,
-    .led_warn_msg = LED_STATUS_WARN,
-    .led_alarm_msg = LED_STATUS_ALARM,
-    .led_normal_msg = LED_STATUS_NORMAL,
+    .led_warn_msg = &LED_STATUS_WARN,
+    .led_alarm_msg = &LED_STATUS_ALARM,
+    .led_normal_msg = &LED_STATUS_NORMAL,
 };
 
 ///////////////////////////////////////////////////////////

--- a/projects/cm_mcu/AlarmUtilities.h
+++ b/projects/cm_mcu/AlarmUtilities.h
@@ -14,7 +14,10 @@ struct GenericAlarmParams_t {
   void (*errorlog_registererror)(void);
   void (*errorlog_clearerror)(void);
   QueueHandle_t xAlmQueue;
-  UBaseType_t stack_size; // stack size of task
+  UBaseType_t stack_size;  // stack size of task
+  uint32_t led_warn_msg;   // LED message on WARN entry (0 = none)
+  uint32_t led_alarm_msg;  // LED message on FAULT_ERRORING entry (0 = none)
+  uint32_t led_normal_msg; // LED message on return to NORMAL (0 = none)
 };
 
 extern struct GenericAlarmParams_t tempAlarmTask;

--- a/projects/cm_mcu/AlarmUtilities.h
+++ b/projects/cm_mcu/AlarmUtilities.h
@@ -14,10 +14,10 @@ struct GenericAlarmParams_t {
   void (*errorlog_registererror)(void);
   void (*errorlog_clearerror)(void);
   QueueHandle_t xAlmQueue;
-  UBaseType_t stack_size;  // stack size of task
-  uint32_t led_warn_msg;   // LED message on WARN entry (0 = none)
-  uint32_t led_alarm_msg;  // LED message on FAULT_ERRORING entry (0 = none)
-  uint32_t led_normal_msg; // LED message on return to NORMAL (0 = none)
+  UBaseType_t stack_size;         // stack size of task
+  const LedMsg_t *led_warn_msg;   // LED state on WARN entry (NULL = no update)
+  const LedMsg_t *led_alarm_msg;  // LED state on FAULT_ERRORING entry (NULL = no update)
+  const LedMsg_t *led_normal_msg; // LED state on return to NORMAL (NULL = no update)
 };
 
 extern struct GenericAlarmParams_t tempAlarmTask;

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -204,7 +204,7 @@ static struct command_t commands[] = {
         "args: (<fac> FTL|ERR|WRN|INF|DBG|TRC)|dump|status|quiet\r\nConfigure log\r\n",
         -1,
     },
-    {"led", led_ctl, "Manipulate red LED\r\n", 1},
+    {"led", led_ctl, "Set LED status: init|normal|load|warn|alarm|psfault|fwfault\r\n", 1},
     {"mem", mem_ctl, "Size of heap\r\n", 0},
     {
         "pwr",

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -204,7 +204,7 @@ static struct command_t commands[] = {
         "args: (<fac> FTL|ERR|WRN|INF|DBG|TRC)|dump|status|quiet\r\nConfigure log\r\n",
         -1,
     },
-    {"led", led_ctl, "Set LED status: init|normal|load|warn|alarm|psfault|fwfault\r\n", 1},
+    {"led", led_ctl, "Set LED status: init|idle|load|normal|warn|alarm|psfault|fwfault|white\r\n", 1},
     {"mem", mem_ctl, "Size of heap\r\n", 0},
     {
         "pwr",

--- a/projects/cm_mcu/GenericAlarmTask.c
+++ b/projects/cm_mcu/GenericAlarmTask.c
@@ -161,6 +161,15 @@ void GenericAlarmTask(void *parameters)
     if (currentState != nextState) {
       log_debug(LOG_ALM, "%s: change from state %s to %s\r\n", taskName,
                 alarm_task_state_names[currentState], alarm_task_state_names[nextState]);
+      uint32_t led_msg = 0;
+      if (nextState == ALM_WARN)
+        led_msg = params->led_warn_msg;
+      else if (nextState == ALM_FAULT_ERRORING)
+        led_msg = params->led_alarm_msg;
+      else if (nextState == ALM_NORMAL)
+        led_msg = params->led_normal_msg;
+      if (led_msg != 0)
+        xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
     }
 
     currentState = nextState;

--- a/projects/cm_mcu/GenericAlarmTask.c
+++ b/projects/cm_mcu/GenericAlarmTask.c
@@ -161,15 +161,15 @@ void GenericAlarmTask(void *parameters)
     if (currentState != nextState) {
       log_debug(LOG_ALM, "%s: change from state %s to %s\r\n", taskName,
                 alarm_task_state_names[currentState], alarm_task_state_names[nextState]);
-      uint32_t led_msg = 0;
+      const LedMsg_t *led_msg = NULL;
       if (nextState == ALM_WARN)
         led_msg = params->led_warn_msg;
       else if (nextState == ALM_FAULT_ERRORING)
         led_msg = params->led_alarm_msg;
       else if (nextState == ALM_NORMAL)
         led_msg = params->led_normal_msg;
-      if (led_msg != 0)
-        xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
+      if (led_msg != NULL)
+        xQueueSendToBack(xLedQueue, led_msg, pdMS_TO_TICKS(10));
     }
 
     currentState = nextState;

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -22,6 +22,9 @@
 
 void InitTask(void *parameters)
 {
+  uint32_t led_msg = LED_STATUS_INIT;
+  xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
+
   //  store the reboot into the error buffer, including the reason for the reset
   uint32_t r = ROM_SysCtlResetCauseGet();
   uint16_t restart_reason = (uint16_t)0xFFFFUL & r;
@@ -56,6 +59,9 @@ void InitTask(void *parameters)
     log_info(LOG_SERVICE, "Clock I/O expander failed\r\n");
     errbuffer_put(EBUF_CLKINIT_FAILURE, 0);
   }
+  led_msg = LED_STATUS_NORMAL;
+  xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
+
   vTaskSuspend(NULL);
   // Delete this task
   vTaskDelete(xTaskGetCurrentTaskHandle());

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -22,8 +22,7 @@
 
 void InitTask(void *parameters)
 {
-  uint32_t led_msg = LED_STATUS_INIT;
-  xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
+  xQueueSendToBack(xLedQueue, &LED_STATUS_INIT, pdMS_TO_TICKS(10));
 
   //  store the reboot into the error buffer, including the reason for the reset
   uint32_t r = ROM_SysCtlResetCauseGet();
@@ -59,8 +58,7 @@ void InitTask(void *parameters)
     log_info(LOG_SERVICE, "Clock I/O expander failed\r\n");
     errbuffer_put(EBUF_CLKINIT_FAILURE, 0);
   }
-  led_msg = LED_STATUS_NORMAL;
-  xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
+  xQueueSendToBack(xLedQueue, &LED_STATUS_NORMAL, pdMS_TO_TICKS(10));
 
   vTaskSuspend(NULL);
   // Delete this task

--- a/projects/cm_mcu/LedTask.c
+++ b/projects/cm_mcu/LedTask.c
@@ -23,7 +23,11 @@
 #include "FreeRTOSConfig.h"
 #include "queue.h"
 
-enum LEDpattern { OFF = 0, ON = 1, TOGGLE = 2, TOGGLE3, TOGGLE4 };
+enum LEDpattern { OFF = 0,
+                  ON = 1,
+                  TOGGLE = 2,
+                  TOGGLE3,
+                  TOGGLE4 };
 
 // Holds the handle of the created queue for the LED task.
 // gets initialized in main()
@@ -97,6 +101,41 @@ void LedTask(void *parameters)
           break;
         case GREEN_LED_TOGGLE4:
           greenLedPattern = TOGGLE4;
+          break;
+        case LED_STATUS_INIT:
+          redLedPattern = OFF;
+          greenLedPattern = OFF;
+          blueLedPattern = TOGGLE;
+          break;
+        case LED_STATUS_NORMAL:
+          redLedPattern = OFF;
+          greenLedPattern = ON;
+          blueLedPattern = OFF;
+          break;
+        case LED_STATUS_WARN:
+          redLedPattern = TOGGLE3;
+          greenLedPattern = TOGGLE3;
+          blueLedPattern = OFF;
+          break;
+        case LED_STATUS_ALARM:
+          redLedPattern = ON;
+          greenLedPattern = OFF;
+          blueLedPattern = OFF;
+          break;
+        case LED_STATUS_PS_FAULT:
+          redLedPattern = TOGGLE;
+          greenLedPattern = OFF;
+          blueLedPattern = OFF;
+          break;
+        case LED_STATUS_FW_FAULT:
+          redLedPattern = TOGGLE;
+          greenLedPattern = OFF;
+          blueLedPattern = TOGGLE;
+          break;
+        case LED_STATUS_BOOTLOADER:
+          redLedPattern = ON;
+          greenLedPattern = ON;
+          blueLedPattern = ON;
           break;
         default:
           blueLedPattern = TOGGLE4; // message I don't understand? Toggle blue LED

--- a/projects/cm_mcu/LedTask.c
+++ b/projects/cm_mcu/LedTask.c
@@ -22,10 +22,11 @@
 #include "queue.h"
 
 // Predefined LED status states
-const LedMsg_t LED_STATUS_INIT = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_TOGGLE};        // blue fast blink
+const LedMsg_t LED_STATUS_INIT = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_ON};             // blue solid
+const LedMsg_t LED_STATUS_PS_OFF = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_TOGGLE4};     // blue slow blink
 const LedMsg_t LED_STATUS_NORMAL = {LED_PAT_OFF, LED_PAT_ON, LED_PAT_OFF};          // green solid
-const LedMsg_t LED_STATUS_PS_LOADING = {LED_PAT_OFF, LED_PAT_TOGGLE4, LED_PAT_OFF}; // green slow blink
-const LedMsg_t LED_STATUS_WARN = {LED_PAT_TOGGLE3, LED_PAT_TOGGLE3, LED_PAT_OFF};   // yellow medium blink
+const LedMsg_t LED_STATUS_PS_LOADING = {LED_PAT_OFF, LED_PAT_TOGGLE4, LED_PAT_TOGGLE4}; // cyan slow blink (G+B)
+const LedMsg_t LED_STATUS_WARN = {LED_PAT_TOGGLE3, LED_PAT_OFF, LED_PAT_OFF};       // red medium blink (temperature warning)
 const LedMsg_t LED_STATUS_ALARM = {LED_PAT_ON, LED_PAT_OFF, LED_PAT_OFF};           // red solid
 const LedMsg_t LED_STATUS_PS_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_OFF};    // red fast blink
 const LedMsg_t LED_STATUS_FW_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_TOGGLE}; // magenta fast blink

--- a/projects/cm_mcu/LedTask.c
+++ b/projects/cm_mcu/LedTask.c
@@ -41,6 +41,8 @@ static void apply_pattern(enum LEDpattern pattern, uint32_t pin, uint32_t callcn
     write_gpio_pin(pin, 0x0);
   else if (pattern == LED_PAT_ON)
     write_gpio_pin(pin, 0x1);
+  else if (callcnt == 0)
+    write_gpio_pin(pin, 0x1); // start all blink channels HIGH so multi-channel states are in phase
   else if (callcnt % (uint32_t)pattern == 0)
     toggle_gpio_pin(pin);
 }

--- a/projects/cm_mcu/LedTask.c
+++ b/projects/cm_mcu/LedTask.c
@@ -41,10 +41,11 @@ static void apply_pattern(enum LEDpattern pattern, uint32_t pin, uint32_t callcn
     write_gpio_pin(pin, 0x0);
   else if (pattern == LED_PAT_ON)
     write_gpio_pin(pin, 0x1);
-  else if (callcnt == 0)
-    write_gpio_pin(pin, 0x1); // start all blink channels HIGH so multi-channel states are in phase
-  else if (callcnt % (uint32_t)pattern == 0)
-    toggle_gpio_pin(pin);
+  else
+    // Blink: first half-period ON, second half-period OFF.
+    // All channels with the same period and callcnt are written the same
+    // value, so multi-channel states (e.g. yellow = R+G) are always in phase.
+    write_gpio_pin(pin, ((callcnt / (uint32_t)pattern) % 2 == 0) ? 0x1 : 0x0);
 }
 
 void LedTask(void *parameters)

--- a/projects/cm_mcu/LedTask.c
+++ b/projects/cm_mcu/LedTask.c
@@ -22,15 +22,15 @@
 #include "queue.h"
 
 // Predefined LED status states
-const LedMsg_t LED_STATUS_INIT = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_ON};             // blue solid
-const LedMsg_t LED_STATUS_PS_OFF = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_TOGGLE4};     // blue slow blink
-const LedMsg_t LED_STATUS_NORMAL = {LED_PAT_OFF, LED_PAT_ON, LED_PAT_OFF};          // green solid
+const LedMsg_t LED_STATUS_INIT = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_ON};                // blue solid
+const LedMsg_t LED_STATUS_PS_OFF = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_TOGGLE4};         // blue slow blink
+const LedMsg_t LED_STATUS_NORMAL = {LED_PAT_OFF, LED_PAT_ON, LED_PAT_OFF};              // green solid
 const LedMsg_t LED_STATUS_PS_LOADING = {LED_PAT_OFF, LED_PAT_TOGGLE4, LED_PAT_TOGGLE4}; // cyan slow blink (G+B)
-const LedMsg_t LED_STATUS_WARN = {LED_PAT_TOGGLE3, LED_PAT_OFF, LED_PAT_OFF};       // red medium blink (temperature warning)
-const LedMsg_t LED_STATUS_ALARM = {LED_PAT_ON, LED_PAT_OFF, LED_PAT_OFF};           // red solid
-const LedMsg_t LED_STATUS_PS_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_OFF};    // red fast blink
-const LedMsg_t LED_STATUS_FW_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_TOGGLE}; // magenta fast blink
-const LedMsg_t LED_STATUS_BOOTLOADER = {LED_PAT_ON, LED_PAT_ON, LED_PAT_ON};        // white solid
+const LedMsg_t LED_STATUS_WARN = {LED_PAT_TOGGLE3, LED_PAT_OFF, LED_PAT_OFF};           // red medium blink (temperature warning)
+const LedMsg_t LED_STATUS_ALARM = {LED_PAT_ON, LED_PAT_OFF, LED_PAT_OFF};               // red solid
+const LedMsg_t LED_STATUS_PS_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_OFF};        // red fast blink
+const LedMsg_t LED_STATUS_FW_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_TOGGLE};     // magenta fast blink
+const LedMsg_t LED_STATUS_BOOTLOADER = {LED_PAT_ON, LED_PAT_ON, LED_PAT_ON};            // white solid
 
 // Holds the handle of the created queue for the LED task.
 // gets initialized in main()

--- a/projects/cm_mcu/LedTask.c
+++ b/projects/cm_mcu/LedTask.c
@@ -12,8 +12,6 @@
 
 // local includes
 #include "common/utils.h"
-#include "common/power_ctl.h"
-#include "common/pinout.h"
 #include "common/pinsel.h"
 #include "common/log.h"
 #include "Tasks.h"
@@ -23,146 +21,49 @@
 #include "FreeRTOSConfig.h"
 #include "queue.h"
 
-enum LEDpattern { OFF = 0,
-                  ON = 1,
-                  TOGGLE = 2,
-                  TOGGLE3,
-                  TOGGLE4 };
+// Predefined LED status states
+const LedMsg_t LED_STATUS_INIT = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_TOGGLE};        // blue fast blink
+const LedMsg_t LED_STATUS_NORMAL = {LED_PAT_OFF, LED_PAT_ON, LED_PAT_OFF};          // green solid
+const LedMsg_t LED_STATUS_PS_LOADING = {LED_PAT_OFF, LED_PAT_TOGGLE4, LED_PAT_OFF}; // green slow blink
+const LedMsg_t LED_STATUS_WARN = {LED_PAT_TOGGLE3, LED_PAT_TOGGLE3, LED_PAT_OFF};   // yellow medium blink
+const LedMsg_t LED_STATUS_ALARM = {LED_PAT_ON, LED_PAT_OFF, LED_PAT_OFF};           // red solid
+const LedMsg_t LED_STATUS_PS_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_OFF};    // red fast blink
+const LedMsg_t LED_STATUS_FW_FAULT = {LED_PAT_TOGGLE, LED_PAT_OFF, LED_PAT_TOGGLE}; // magenta fast blink
+const LedMsg_t LED_STATUS_BOOTLOADER = {LED_PAT_ON, LED_PAT_ON, LED_PAT_ON};        // white solid
 
 // Holds the handle of the created queue for the LED task.
 // gets initialized in main()
 QueueHandle_t xLedQueue = NULL;
 
-// control the LED
-// Todo: expand beyond just controlling the red LED, if needed, for the command line interface.
-// Probably not needed.
+static void apply_pattern(enum LEDpattern pattern, uint32_t pin, uint32_t callcnt)
+{
+  if (pattern == LED_PAT_OFF)
+    write_gpio_pin(pin, 0x0);
+  else if (pattern == LED_PAT_ON)
+    write_gpio_pin(pin, 0x1);
+  else if (callcnt % (uint32_t)pattern == 0)
+    toggle_gpio_pin(pin);
+}
+
 void LedTask(void *parameters)
 {
   TickType_t xLastWakeTime = xTaskGetTickCount();
   uint32_t callcnt = 0;
-  enum LEDpattern greenLedPattern = OFF;
-  enum LEDpattern blueLedPattern = OFF;
-  enum LEDpattern redLedPattern = OFF;
+  LedMsg_t cur = {LED_PAT_OFF, LED_PAT_OFF, LED_PAT_OFF};
 
   // this function never returns. Loop here forever.
   for (;;) {
-    uint32_t message;
-    // check for a new item in the queue but don't wait
-    if (xQueueReceive(xLedQueue, &message, 0)) {
-      switch (message) {
-        case PS_BAD:
-          write_gpio_pin(BLADE_POWER_OK, 0); // this should not be here
-          break;
-        case PS_GOOD:
-          write_gpio_pin(BLADE_POWER_OK, 1); // this should not be here
-          break;
-        case RED_LED_ON:
-          redLedPattern = ON;
-          break;
-        case RED_LED_OFF:
-          redLedPattern = OFF;
-          break;
-        case RED_LED_TOGGLE:
-          redLedPattern = TOGGLE;
-          break;
-        case RED_LED_TOGGLE3:
-          redLedPattern = TOGGLE3;
-          break;
-        case RED_LED_TOGGLE4:
-          redLedPattern = TOGGLE4;
-          break;
-        case BLUE_LED_ON:
-          blueLedPattern = ON;
-          break;
-        case BLUE_LED_OFF:
-          blueLedPattern = OFF;
-          break;
-        case BLUE_LED_TOGGLE:
-          blueLedPattern = TOGGLE;
-          break;
-        case BLUE_LED_TOGGLE3:
-          blueLedPattern = TOGGLE3;
-          break;
-        case BLUE_LED_TOGGLE4:
-          blueLedPattern = TOGGLE4;
-          break;
-          // GREEN
-        case GREEN_LED_ON:
-          greenLedPattern = ON;
-          break;
-        case GREEN_LED_OFF:
-          greenLedPattern = OFF;
-          break;
-        case GREEN_LED_TOGGLE:
-          greenLedPattern = TOGGLE;
-          break;
-        case GREEN_LED_TOGGLE3:
-          greenLedPattern = TOGGLE3;
-          break;
-        case GREEN_LED_TOGGLE4:
-          greenLedPattern = TOGGLE4;
-          break;
-        case LED_STATUS_INIT:
-          redLedPattern = OFF;
-          greenLedPattern = OFF;
-          blueLedPattern = TOGGLE;
-          break;
-        case LED_STATUS_NORMAL:
-          redLedPattern = OFF;
-          greenLedPattern = ON;
-          blueLedPattern = OFF;
-          break;
-        case LED_STATUS_WARN:
-          redLedPattern = TOGGLE3;
-          greenLedPattern = TOGGLE3;
-          blueLedPattern = OFF;
-          break;
-        case LED_STATUS_ALARM:
-          redLedPattern = ON;
-          greenLedPattern = OFF;
-          blueLedPattern = OFF;
-          break;
-        case LED_STATUS_PS_FAULT:
-          redLedPattern = TOGGLE;
-          greenLedPattern = OFF;
-          blueLedPattern = OFF;
-          break;
-        case LED_STATUS_FW_FAULT:
-          redLedPattern = TOGGLE;
-          greenLedPattern = OFF;
-          blueLedPattern = TOGGLE;
-          break;
-        case LED_STATUS_BOOTLOADER:
-          redLedPattern = ON;
-          greenLedPattern = ON;
-          blueLedPattern = ON;
-          break;
-        default:
-          blueLedPattern = TOGGLE4; // message I don't understand? Toggle blue LED
-          break;
+    LedMsg_t msg;
+    if (xQueueReceive(xLedQueue, &msg, 0)) {
+      if (msg.red != cur.red || msg.green != cur.green || msg.blue != cur.blue) {
+        cur = msg;
+        callcnt = 0; // reset so toggling channels start in phase
       }
     }
-    // Greed LED
-    if (greenLedPattern == OFF)
-      write_gpio_pin(MCU_LED_GREEN, 0x0);
-    else if (greenLedPattern == ON)
-      write_gpio_pin(MCU_LED_GREEN, 0x1);
-    else if (callcnt % greenLedPattern == 0) // toggle patterns
-      toggle_gpio_pin(MCU_LED_GREEN);
-    // Red LED
-    if (redLedPattern == OFF)
-      write_gpio_pin(MCU_LED_RED, 0x0);
-    else if (redLedPattern == ON)
-      write_gpio_pin(MCU_LED_RED, 0x1);
-    else if (callcnt % redLedPattern == 0) // toggle patterns
-      toggle_gpio_pin(MCU_LED_RED);
-    // Blue LED
-    if (blueLedPattern == OFF)
-      write_gpio_pin(MCU_LED_BLUE, 0x0);
-    else if (blueLedPattern == ON)
-      write_gpio_pin(MCU_LED_BLUE, 0x1);
-    else if (callcnt % blueLedPattern == 0) // toggle patterns
-      toggle_gpio_pin(MCU_LED_BLUE);
+
+    apply_pattern(cur.red, MCU_LED_RED, callcnt);
+    apply_pattern(cur.green, MCU_LED_GREEN, callcnt);
+    apply_pattern(cur.blue, MCU_LED_BLUE, callcnt);
     ++callcnt;
 
     // monitor stack usage for this task

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -511,6 +511,15 @@ void PowerSupplyTask(void *parameters)
     if (currentState != nextState) {
       log_debug(LOG_PWRCTL, "%s: change from state %s to %s\r\n", pcTaskGetName(NULL),
                 power_system_state_names[currentState], power_system_state_names[nextState]);
+      uint32_t led_msg = 0;
+      if (nextState == POWER_ON)
+        led_msg = LED_STATUS_NORMAL;
+      else if (nextState == POWER_FAILURE && !external_alarm)
+        led_msg = LED_STATUS_PS_FAULT;
+      else if (currentState == POWER_FAILURE && nextState == POWER_OFF)
+        led_msg = LED_STATUS_NORMAL;
+      if (led_msg != 0)
+        xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
     }
     currentState = nextState;
 

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -512,7 +512,9 @@ void PowerSupplyTask(void *parameters)
       log_debug(LOG_PWRCTL, "%s: change from state %s to %s\r\n", pcTaskGetName(NULL),
                 power_system_state_names[currentState], power_system_state_names[nextState]);
       const LedMsg_t *led_msg = NULL;
-      if (nextState == POWER_L1ON)
+      if (nextState == POWER_OFF)
+        led_msg = &LED_STATUS_PS_OFF;
+      else if (nextState == POWER_L1ON)
         led_msg = &LED_STATUS_PS_LOADING;
       else if (nextState == POWER_ON)
         led_msg = &LED_STATUS_NORMAL;

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -511,15 +511,15 @@ void PowerSupplyTask(void *parameters)
     if (currentState != nextState) {
       log_debug(LOG_PWRCTL, "%s: change from state %s to %s\r\n", pcTaskGetName(NULL),
                 power_system_state_names[currentState], power_system_state_names[nextState]);
-      uint32_t led_msg = 0;
-      if (nextState == POWER_ON)
-        led_msg = LED_STATUS_NORMAL;
+      const LedMsg_t *led_msg = NULL;
+      if (nextState == POWER_L1ON)
+        led_msg = &LED_STATUS_PS_LOADING;
+      else if (nextState == POWER_ON)
+        led_msg = &LED_STATUS_NORMAL;
       else if (nextState == POWER_FAILURE && !external_alarm)
-        led_msg = LED_STATUS_PS_FAULT;
-      else if (currentState == POWER_FAILURE && nextState == POWER_OFF)
-        led_msg = LED_STATUS_NORMAL;
-      if (led_msg != 0)
-        xQueueSendToBack(xLedQueue, &led_msg, pdMS_TO_TICKS(10));
+        led_msg = &LED_STATUS_PS_FAULT;
+      if (led_msg != NULL)
+        xQueueSendToBack(xLedQueue, led_msg, pdMS_TO_TICKS(10));
     }
     currentState = nextState;
 

--- a/projects/cm_mcu/README.md
+++ b/projects/cm_mcu/README.md
@@ -75,6 +75,33 @@ The vector table is defined in `startup_gcc.c`. Interrupt handlers are either in
 | PowerSupplyTask.c | Turns non-management power on and off on the board in proper order. Uses GPIOs. |
 | ZynqMonTask.c | Sends monitoring data to the Zynq SoC on the Apollo SM. Acts as a soft UART, with only the Tx function implemented. Uses a hardware timer and GPIOs.|  
 
+## LED Status Signals
+
+The board has a single RGB LED that communicates system state. The LED task runs every 250 ms; blink rates are expressed in multiples of that tick.
+
+| State | Color | Pattern | Condition |
+|-------|-------|---------|-----------|
+| INIT | Blue | Fast blink (~1 Hz) | MCU running, peripherals starting up |
+| NORMAL | Green | Solid | Fully operational |
+| PS_LOADING | Green | Slow blink (~0.5 Hz) | Power supplies ramping up (L1–L6 sequence) |
+| WARN | Yellow (R+G) | Medium blink (~0.67 Hz) | Temperature above warning threshold |
+| ALARM | Red | Solid | Temperature alarm triggered, power shut off |
+| PS_FAULT | Red | Fast blink (~1 Hz) | Power supply hardware failure |
+| FW_FAULT | Magenta (R+B) | Fast blink (~1 Hz) | Firmware / watchdog fault |
+| BOOTLOADER | White (R+G+B) | Solid | Bootloader mode |
+
+Normal power-up progression: **Blue blink → Green slow blink → Green solid**
+
+To set the LED from code, send a `LedMsg_t` to `xLedQueue`:
+```c
+xQueueSendToBack(xLedQueue, &LED_STATUS_NORMAL, pdMS_TO_TICKS(10));
+```
+
+The `led` CLI command can force a state for debugging:
+```
+led init | normal | load | warn | alarm | psfault | fwfault
+```
+
 ## Building FreeRTOS
 
 FreeRTOS is now included as a git submodule. 

--- a/projects/cm_mcu/README.md
+++ b/projects/cm_mcu/README.md
@@ -81,16 +81,17 @@ The board has a single RGB LED that communicates system state. The LED task runs
 
 | State | Color | Pattern | Condition |
 |-------|-------|---------|-----------|
-| INIT | Blue | Fast blink (~1 Hz) | MCU running, peripherals starting up |
+| INIT | Blue | Solid | MCU startup, peripherals initializing |
+| PS_OFF (idle) | Blue | Slow blink (~0.5 Hz) | MCU running, waiting for blade power enable |
+| PS_LOADING | Cyan (G+B) | Slow blink (~0.5 Hz) | Power supplies ramping up (L1–L6 sequence) |
 | NORMAL | Green | Solid | Fully operational |
-| PS_LOADING | Green | Slow blink (~0.5 Hz) | Power supplies ramping up (L1–L6 sequence) |
-| WARN | Yellow (R+G) | Medium blink (~0.67 Hz) | Temperature above warning threshold |
+| WARN | Red | Medium blink (~0.67 Hz) | Temperature above warning threshold |
 | ALARM | Red | Solid | Temperature alarm triggered, power shut off |
 | PS_FAULT | Red | Fast blink (~1 Hz) | Power supply hardware failure |
 | FW_FAULT | Magenta (R+B) | Fast blink (~1 Hz) | Firmware / watchdog fault |
 | BOOTLOADER | White (R+G+B) | Solid | Bootloader mode |
 
-Normal power-up progression: **Blue blink → Green slow blink → Green solid**
+Normal power-up progression: **Blue solid → Blue slow blink → Cyan slow blink → Green solid**
 
 To set the LED from code, send a `LedMsg_t` to `xLedQueue`:
 ```c
@@ -99,7 +100,7 @@ xQueueSendToBack(xLedQueue, &LED_STATUS_NORMAL, pdMS_TO_TICKS(10));
 
 The `led` CLI command can force a state for debugging:
 ```
-led init | normal | load | warn | alarm | psfault | fwfault
+led init | idle | load | normal | warn | alarm | psfault | fwfault | white
 ```
 
 ## Building FreeRTOS

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -83,6 +83,14 @@ void LedTask(void *parameters);
 #define GREEN_LED_TOGGLE  (32)
 #define GREEN_LED_TOGGLE3 (33)
 #define GREEN_LED_TOGGLE4 (34)
+// LED status modes — set all three channels atomically
+#define LED_STATUS_INIT       (40) // blue blink (startup / initializing)
+#define LED_STATUS_NORMAL     (41) // green solid (normal operation)
+#define LED_STATUS_WARN       (42) // yellow (R+G) slow blink (temperature warning)
+#define LED_STATUS_ALARM      (43) // red solid (temperature alarm / shutdown)
+#define LED_STATUS_PS_FAULT   (44) // red fast blink (power supply fault)
+#define LED_STATUS_FW_FAULT   (45) // magenta (R+B) fast blink (firmware / watchdog fault)
+#define LED_STATUS_BOOTLOADER (46) // white (R+G+B) solid (bootloader mode)
 // Holds the handle of the created queue for the power supply task.
 
 // --- Power Supply management task

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -90,10 +90,11 @@ typedef struct {
 //
 //   State           Color        Pattern         Condition
 //   --------------- ------------ --------------- ----------------------------------
-//   INIT            Blue         Fast blink      MCU running, peripherals starting
+//   INIT            Blue         Solid           MCU startup, peripherals initializing
+//   PS_OFF          Blue         Slow blink      MCU running, waiting for blade power enable
+//   PS_LOADING      Cyan (G+B)   Slow blink      Power supplies ramping up (L1–L6)
 //   NORMAL          Green        Solid           Fully operational
-//   PS_LOADING      Green        Slow blink      Power supplies ramping up (L1–L6)
-//   WARN            Yellow (R+G) Medium blink    Temperature above warning threshold
+//   WARN            Red          Medium blink    Temperature above warning threshold
 //   ALARM           Red          Solid           Temperature alarm, power shut off
 //   PS_FAULT        Red          Fast blink      Power supply hardware failure
 //   FW_FAULT        Magenta(R+B) Fast blink      Firmware / watchdog fault
@@ -102,10 +103,11 @@ typedef struct {
 // To send a state from any task:
 //   xQueueSendToBack(xLedQueue, &LED_STATUS_NORMAL, pdMS_TO_TICKS(10));
 //
-extern const LedMsg_t LED_STATUS_INIT;       // blue fast blink (startup / initializing)
+extern const LedMsg_t LED_STATUS_INIT;       // blue solid (startup / initializing)
+extern const LedMsg_t LED_STATUS_PS_OFF;     // blue slow blink (waiting for blade power enable)
 extern const LedMsg_t LED_STATUS_NORMAL;     // green solid (normal operation)
-extern const LedMsg_t LED_STATUS_PS_LOADING; // green slow blink (power supplies ramping up)
-extern const LedMsg_t LED_STATUS_WARN;       // yellow (R+G) medium blink (temperature warning)
+extern const LedMsg_t LED_STATUS_PS_LOADING; // cyan (G+B) slow blink (power supplies ramping up)
+extern const LedMsg_t LED_STATUS_WARN;       // red medium blink (temperature warning)
 extern const LedMsg_t LED_STATUS_ALARM;      // red solid (temperature alarm / shutdown)
 extern const LedMsg_t LED_STATUS_PS_FAULT;   // red fast blink (power supply fault)
 extern const LedMsg_t LED_STATUS_FW_FAULT;   // magenta (R+B) fast blink (firmware / watchdog fault)

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -68,29 +68,32 @@ extern QueueHandle_t xLedQueue;
 // control the LED
 void LedTask(void *parameters);
 
-#define RED_LED_OFF       (10)
-#define RED_LED_ON        (11)
-#define RED_LED_TOGGLE    (12)
-#define RED_LED_TOGGLE3   (13)
-#define RED_LED_TOGGLE4   (14)
-#define BLUE_LED_OFF      (20)
-#define BLUE_LED_ON       (21)
-#define BLUE_LED_TOGGLE   (22)
-#define BLUE_LED_TOGGLE3  (23)
-#define BLUE_LED_TOGGLE4  (24)
-#define GREEN_LED_OFF     (30)
-#define GREEN_LED_ON      (31)
-#define GREEN_LED_TOGGLE  (32)
-#define GREEN_LED_TOGGLE3 (33)
-#define GREEN_LED_TOGGLE4 (34)
-// LED status modes — set all three channels atomically
-#define LED_STATUS_INIT       (40) // blue blink (startup / initializing)
-#define LED_STATUS_NORMAL     (41) // green solid (normal operation)
-#define LED_STATUS_WARN       (42) // yellow (R+G) slow blink (temperature warning)
-#define LED_STATUS_ALARM      (43) // red solid (temperature alarm / shutdown)
-#define LED_STATUS_PS_FAULT   (44) // red fast blink (power supply fault)
-#define LED_STATUS_FW_FAULT   (45) // magenta (R+B) fast blink (firmware / watchdog fault)
-#define LED_STATUS_BOOTLOADER (46) // white (R+G+B) solid (bootloader mode)
+// LED channel pattern — value is the toggle period in ticks (250 ms/tick)
+enum LEDpattern {
+  LED_PAT_OFF = 0,
+  LED_PAT_ON = 1,
+  LED_PAT_TOGGLE = 2,  // toggle every 2 ticks (~500 ms half-period)
+  LED_PAT_TOGGLE3 = 3, // toggle every 3 ticks (~750 ms half-period)
+  LED_PAT_TOGGLE4 = 4, // toggle every 4 ticks (~1 s half-period, slow)
+};
+
+// LED message: sets all three channels atomically in a single queue send
+typedef struct {
+  enum LEDpattern red;
+  enum LEDpattern green;
+  enum LEDpattern blue;
+} LedMsg_t;
+
+// Predefined LED status states (defined in LedTask.c)
+extern const LedMsg_t LED_STATUS_INIT;       // blue fast blink (startup / initializing)
+extern const LedMsg_t LED_STATUS_NORMAL;     // green solid (normal operation)
+extern const LedMsg_t LED_STATUS_PS_LOADING; // green slow blink (power supplies ramping up)
+extern const LedMsg_t LED_STATUS_WARN;       // yellow (R+G) blink (temperature warning)
+extern const LedMsg_t LED_STATUS_ALARM;      // red solid (temperature alarm / shutdown)
+extern const LedMsg_t LED_STATUS_PS_FAULT;   // red fast blink (power supply fault)
+extern const LedMsg_t LED_STATUS_FW_FAULT;   // magenta (R+B) fast blink (firmware / watchdog fault)
+extern const LedMsg_t LED_STATUS_BOOTLOADER; // white (R+G+B) solid (bootloader mode)
+
 // Holds the handle of the created queue for the power supply task.
 
 // --- Power Supply management task

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -85,10 +85,27 @@ typedef struct {
 } LedMsg_t;
 
 // Predefined LED status states (defined in LedTask.c)
+//
+// The RGB LED communicates system state at a glance. Tick period is 250 ms.
+//
+//   State           Color        Pattern         Condition
+//   --------------- ------------ --------------- ----------------------------------
+//   INIT            Blue         Fast blink      MCU running, peripherals starting
+//   NORMAL          Green        Solid           Fully operational
+//   PS_LOADING      Green        Slow blink      Power supplies ramping up (L1–L6)
+//   WARN            Yellow (R+G) Medium blink    Temperature above warning threshold
+//   ALARM           Red          Solid           Temperature alarm, power shut off
+//   PS_FAULT        Red          Fast blink      Power supply hardware failure
+//   FW_FAULT        Magenta(R+B) Fast blink      Firmware / watchdog fault
+//   BOOTLOADER      White (R+G+B)Solid           Bootloader mode
+//
+// To send a state from any task:
+//   xQueueSendToBack(xLedQueue, &LED_STATUS_NORMAL, pdMS_TO_TICKS(10));
+//
 extern const LedMsg_t LED_STATUS_INIT;       // blue fast blink (startup / initializing)
 extern const LedMsg_t LED_STATUS_NORMAL;     // green solid (normal operation)
 extern const LedMsg_t LED_STATUS_PS_LOADING; // green slow blink (power supplies ramping up)
-extern const LedMsg_t LED_STATUS_WARN;       // yellow (R+G) blink (temperature warning)
+extern const LedMsg_t LED_STATUS_WARN;       // yellow (R+G) medium blink (temperature warning)
 extern const LedMsg_t LED_STATUS_ALARM;      // red solid (temperature alarm / shutdown)
 extern const LedMsg_t LED_STATUS_PS_FAULT;   // red fast blink (power supply fault)
 extern const LedMsg_t LED_STATUS_FW_FAULT;   // magenta (R+B) fast blink (firmware / watchdog fault)

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -313,7 +313,7 @@ __attribute__((noreturn)) int main(void)
   // Initialize all the queues
   // queue for the LED
   xLedQueue = xQueueCreate(3,                 // The maximum number of items the queue can hold.
-                           sizeof(uint32_t)); // The size of each item.
+                           sizeof(LedMsg_t)); // The size of each item.
   configASSERT(xLedQueue != NULL);
 
   xPwrQueue = xQueueCreate(10, sizeof(uint32_t)); // PWR queue

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -5,29 +5,39 @@
  *      Author: fatimayousuf
  */
 
+#include <string.h>
+
 #include "commands/SensorControl.h"
 #include "commands/parameters.h"
 #include "common/utils.h"
 #include "Tasks.h"
 #include "projdefs.h"
 
-// send LED commands
+// send LED status commands
 BaseType_t led_ctl(int argc, char **argv, char *m)
 {
-
-  BaseType_t i1 = strtol(argv[1], NULL, 10);
-
-  BaseType_t ones = i1 % 10;
-  BaseType_t tens = i1 / 10; // integer truncation
-
-  uint32_t message = HUH; // default: message not understood
-  if (ones < 5 && tens > 0 && tens < 4) {
-    message = i1;
+  static const struct {
+    const char *name;
+    const LedMsg_t *msg;
+  } statuses[] = {
+      {"init", &LED_STATUS_INIT},
+      {"normal", &LED_STATUS_NORMAL},
+      {"load", &LED_STATUS_PS_LOADING},
+      {"warn", &LED_STATUS_WARN},
+      {"alarm", &LED_STATUS_ALARM},
+      {"psfault", &LED_STATUS_PS_FAULT},
+      {"fwfault", &LED_STATUS_FW_FAULT},
+  };
+  for (size_t i = 0; i < sizeof(statuses) / sizeof(statuses[0]); ++i) {
+    if (strcmp(argv[1], statuses[i].name) == 0) {
+      xQueueSendToBack(xLedQueue, statuses[i].msg, pdMS_TO_TICKS(10));
+      m[0] = '\0';
+      return pdFALSE;
+    }
   }
-  // Send a message to the LED task
-  xQueueSendToBack(xLedQueue, &message, pdMS_TO_TICKS(10));
-  m[0] = '\0'; // no output from this command
-
+  snprintf(m, SCRATCH_SIZE,
+           "Unknown LED status '%s'.\r\nOptions: init normal load warn alarm psfault fwfault\r\n",
+           argv[1]);
   return pdFALSE;
 }
 

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -20,13 +20,15 @@ BaseType_t led_ctl(int argc, char **argv, char *m)
     const char *name;
     const LedMsg_t *msg;
   } statuses[] = {
-      {"init", &LED_STATUS_INIT},
-      {"normal", &LED_STATUS_NORMAL},
-      {"load", &LED_STATUS_PS_LOADING},
-      {"warn", &LED_STATUS_WARN},
-      {"alarm", &LED_STATUS_ALARM},
+      {"init",    &LED_STATUS_INIT},
+      {"idle",    &LED_STATUS_PS_OFF},
+      {"load",    &LED_STATUS_PS_LOADING},
+      {"normal",  &LED_STATUS_NORMAL},
+      {"warn",    &LED_STATUS_WARN},
+      {"alarm",   &LED_STATUS_ALARM},
       {"psfault", &LED_STATUS_PS_FAULT},
       {"fwfault", &LED_STATUS_FW_FAULT},
+      {"white",   &LED_STATUS_BOOTLOADER},
   };
   for (size_t i = 0; i < sizeof(statuses) / sizeof(statuses[0]); ++i) {
     if (strcmp(argv[1], statuses[i].name) == 0) {
@@ -36,7 +38,7 @@ BaseType_t led_ctl(int argc, char **argv, char *m)
     }
   }
   snprintf(m, SCRATCH_SIZE,
-           "Unknown LED status '%s'.\r\nOptions: init normal load warn alarm psfault fwfault\r\n",
+           "Unknown LED status '%s'.\r\nOptions: init idle load normal warn alarm psfault fwfault white\r\n",
            argv[1]);
   return pdFALSE;
 }

--- a/projects/cm_mcu/commands/SensorControl.c
+++ b/projects/cm_mcu/commands/SensorControl.c
@@ -20,15 +20,15 @@ BaseType_t led_ctl(int argc, char **argv, char *m)
     const char *name;
     const LedMsg_t *msg;
   } statuses[] = {
-      {"init",    &LED_STATUS_INIT},
-      {"idle",    &LED_STATUS_PS_OFF},
-      {"load",    &LED_STATUS_PS_LOADING},
-      {"normal",  &LED_STATUS_NORMAL},
-      {"warn",    &LED_STATUS_WARN},
-      {"alarm",   &LED_STATUS_ALARM},
+      {"init", &LED_STATUS_INIT},
+      {"idle", &LED_STATUS_PS_OFF},
+      {"load", &LED_STATUS_PS_LOADING},
+      {"normal", &LED_STATUS_NORMAL},
+      {"warn", &LED_STATUS_WARN},
+      {"alarm", &LED_STATUS_ALARM},
       {"psfault", &LED_STATUS_PS_FAULT},
       {"fwfault", &LED_STATUS_FW_FAULT},
-      {"white",   &LED_STATUS_BOOTLOADER},
+      {"white", &LED_STATUS_BOOTLOADER},
   };
   for (size_t i = 0; i < sizeof(statuses) / sizeof(statuses[0]); ++i) {
     if (strcmp(argv[1], statuses[i].name) == 0) {

--- a/projects/cm_mcu/commands/SoftwareCommands.c
+++ b/projects/cm_mcu/commands/SoftwareCommands.c
@@ -6,11 +6,18 @@
 #include "portmacro.h"
 #include "Semaphore.h"
 #include "projdefs.h"
+#include "common/utils.h"
+#include "common/pinsel.h"
 
 // this command takes no arguments and never returns.
 __attribute__((noreturn)) BaseType_t bl_ctl(int argc, char **argv, char *m)
 {
   disable_ps();
+  // Set LED to white (all channels on) to indicate bootloader mode.
+  // Write GPIO directly since the scheduler will be stopped momentarily.
+  write_gpio_pin(MCU_LED_RED, 0x1);
+  write_gpio_pin(MCU_LED_GREEN, 0x1);
+  write_gpio_pin(MCU_LED_BLUE, 0x1);
   Print("Jumping to bootloader\r\n");
   ROM_SysCtlDelay(100000);
   // this code is copied from the JumpToBootLoader()


### PR DESCRIPTION
This pull request implements a unified and extensible RGB LED status signaling system for the MCU, replacing the old per-channel LED control with a message-based approach. It introduces a new `LedMsg_t` structure for atomic RGB LED state updates, defines a set of standard LED status patterns for key system states, and updates all relevant tasks and the CLI to use the new system. The documentation is also expanded to describe LED behavior and usage.

**Core LED System Refactor:**

* Introduced `LedMsg_t` struct and `enum LEDpattern` for atomic RGB LED control, replacing individual channel commands and constants. The LED task now receives full RGB state messages and applies patterns (solid, blink at various rates) via a queue (`xLedQueue`). Predefined status messages (e.g., `LED_STATUS_NORMAL`, `LED_STATUS_WARN`) are provided for common system states. (`projects/cm_mcu/Tasks.h`, `projects/cm_mcu/LedTask.c`, `projects/cm_mcu/cm_mcu.c`, [[1]](diffhunk://#diff-9ef4f53259d24af6b0eaed4ccac253510813da8734cfb8624bfcecc4cfe9d196L71-R115) [[2]](diffhunk://#diff-7b97669834b467123d7dc7dcc81932e2140a72916eb3e9a4211befdc86ecc105L26-R70) [[3]](diffhunk://#diff-c658e5f6b60b86345ea2dcce49ce6183ba7627c64557318fed2ea90bd7e3b397L316-R316)

* Refactored the LED task to use the new `LedMsg_t` message type, supporting atomic updates and consistent blinking patterns for all RGB channels. Legacy per-channel command handling is removed. (`projects/cm_mcu/LedTask.c`, [projects/cm_mcu/LedTask.cL26-R70](diffhunk://#diff-7b97669834b467123d7dc7dcc81932e2140a72916eb3e9a4211befdc86ecc105L26-R70))

**System State Integration:**

* Updated system tasks (`InitTask`, `PowerSupplyTask`, `GenericAlarmTask`) to send the appropriate predefined LED status message to `xLedQueue` when changing states, ensuring the LED always reflects the current system condition. (`projects/cm_mcu/InitTask.c`, `projects/cm_mcu/PowerSupplyTask.c`, `projects/cm_mcu/GenericAlarmTask.c`, [[1]](diffhunk://#diff-8af5c7d7354d1c15cedcb1ae2231118c23a78c7ea7b441d5e8e900da5126cc42R25-R26) [[2]](diffhunk://#diff-8af5c7d7354d1c15cedcb1ae2231118c23a78c7ea7b441d5e8e900da5126cc42R61-R62) [[3]](diffhunk://#diff-71fa23dbb3e161d509dce3a4814106ca619d75649eca73042648978804ac5499R514-R524) [[4]](diffhunk://#diff-d0be17d5d3b789d18f99518bf0cda762fca7fe6cfb47d807eefe2784235001b5R164-R172)

* Extended alarm task parameters (`GenericAlarmParams_t`) to include pointers to LED status messages for warning, alarm, and normal states, allowing flexible LED signaling for different alarm types. (`projects/cm_mcu/AlarmUtilities.h`, `projects/cm_mcu/AlarmUtilities.c`, [[1]](diffhunk://#diff-946f8c6276e08e800637d7c2dbbade19ca49936a27bff594febd54e9229d689dR18-R20) [[2]](diffhunk://#diff-bc94e11eae53157d64f214847ebcecf554cb078fda3024c9dddafc9e18d7b651R174-R176)

**CLI and Bootloader Support:**

* Reworked the `led` CLI command to accept symbolic state names (e.g., `normal`, `warn`) and send the corresponding `LedMsg_t` message for debugging and manual override. (`projects/cm_mcu/CommandLineTask.c`, `projects/cm_mcu/commands/SensorControl.c`, [[1]](diffhunk://#diff-9cb461e4d0d68a2faa7e67efb69c308c2d463228064bb42ac14abd5e01af4a5fL207-R207) [[2]](diffhunk://#diff-3a539259500d49f6fc09f3999c0427c2cf030740607f00faecfb68c259063409R8-R42)

* Updated the bootloader command to directly set the LED to white (all channels on) as a visual indicator before jumping to the bootloader. (`projects/cm_mcu/commands/SoftwareCommands.c`, [projects/cm_mcu/commands/SoftwareCommands.cR9-R20](diffhunk://#diff-4f85917b415c3e8588923d7c724268ebe07fc41bb9735e3a809fb14fff98e253R9-R20))

**Documentation:**

* Added a comprehensive "LED Status Signals" section to the README, detailing each LED pattern, its meaning, and usage instructions for developers. (`projects/cm_mcu/README.md`, [projects/cm_mcu/README.mdR78-R105](diffhunk://#diff-a267d9b401f45262ec572fcdcfe6e832d9ba457279c68a97fc365419634e7209R78-R105))

