### PR TITLE
bug fixes, new commands, for firefly monitoring

### DIFF
--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -141,6 +141,12 @@ static struct command_t commands[] = {
         "dump name registers\r\n",
         0,
     },
+    {        
+        "ff_fw_reg",
+        ff_fw_reg,
+        "Read FF firmware registers (12ch only, RO).\r\n",
+        0,
+    },
     {
         "ff_optpow",
         ff_optpow,

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -118,6 +118,12 @@ static struct command_t commands[] = {
         0,
     },
     {
+        "ff_pwr_alarm",
+        ff_power_alarm_status,
+        "Show FF optical power alarms\r\n",
+        0,
+    },
+    {
         "ff_ch_dis",
         ff_ch_disable_status,
         "Show FF ch disable status\r\n",

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -141,7 +141,7 @@ static struct command_t commands[] = {
         "dump name registers\r\n",
         0,
     },
-    {        
+    {
         "ff_fw_reg",
         ff_fw_reg,
         "Read FF firmware registers (12ch only, RO).\r\n",

--- a/projects/cm_mcu/MonUtils.c
+++ b/projects/cm_mcu/MonUtils.c
@@ -176,6 +176,13 @@ bool isEnabledFF_F2(int device)
   return isEnabledFF(device + NFIREFLIES_F1);
 }
 
+int FireflyTypeF2(int device)
+{
+  // F2 monitor task passes local indices 0-(NFIREFLIES_F2-1); offset to global
+  // so FireflyType selects the F2 bitmask instead of the F1 bitmask.
+  return FireflyType(device + NFIREFLIES_F1);
+}
+
 struct MonitorTaskI2CArgs_t ff_f1_args = {
     .name = "FF_F1",
     .devices = ff_moni2c_addrs_f1,
@@ -200,7 +207,7 @@ struct MonitorTaskI2CArgs_t ff_f2_args = {
     .selpage_reg = FF_SELPAGE_REG,
     .xSem = NULL,
     .stack_size = 4096U,
-    .typeCallback = FireflyType,
+    .typeCallback = FireflyTypeF2,
     .presentCallback = isEnabledFF_F2,
 };
 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -312,6 +312,7 @@ void zm_set_fpga(struct zynqmon_data_t data[], int start);
 void zm_set_allclk(struct zynqmon_data_t data[], int start);
 void zm_set_firefly_optpow12(struct zynqmon_data_t data[], int start);
 void zm_set_firefly_optpow4(struct zynqmon_data_t data[], int start);
+void zm_set_firefly_power_alarm(struct zynqmon_data_t data[], int start);
 
 #ifdef ZYNQMON_TEST_MODE
 void setZYNQMonTestData(uint8_t sensor, uint16_t value);

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -507,6 +507,32 @@ void zm_set_firefly_optpow4(struct zynqmon_data_t data[], int start)
   }   // loop over Tx firefly devices
 }
 
+void zm_set_firefly_power_alarm(struct zynqmon_data_t data[], int start)
+{
+  int ll = 0;
+  for (int j = 0; j < NFIREFLIES; ++j) {
+    if (isFFStale()) {
+      data[ll].data.us = 0xff;
+    }
+    else {
+      data[ll].data.us = get_FF_POWER_ALARM_0_data(j);
+      log_debug(LOG_SERVICE, "POWER_ALARM_0 for ff %d: 0x%04x\r\n", j, data[ll].data.us);
+    }
+    data[ll].sensor = ll + start;
+    ++ll;
+
+    if (isFFStale()) {
+      data[ll].data.us = 0xff;
+    }
+    else {
+      data[ll].data.us = get_FF_POWER_ALARM_1_data(j);
+      log_debug(LOG_SERVICE, "POWER_ALARM_1 for ff %d: 0x%04x\r\n", j, data[ll].data.us);
+    }
+    data[ll].sensor = ll + start;
+    ++ll;
+  }
+}
+
 #endif // REV2 or 3
 
 // store the zynqmon ADCMon data

--- a/projects/cm_mcu/commands/FireflyCommands.c
+++ b/projects/cm_mcu/commands/FireflyCommands.c
@@ -1103,3 +1103,43 @@ BaseType_t ff_dump_names(int argc, char **argv, char *m)
   i = 0;
   return pdFALSE;
 }
+
+// read the Firefly firmware register at address 111-113 on page 0. This
+// register exists on the CERN-B and 12x25G parts, but does not exist
+// on the 4x25G part.
+#define FF_FW_REG_ADDR 111
+#define FF_FW_REG_SIZE 3
+BaseType_t ff_fw_reg(int argc, char **argv, char *m)
+{
+  int copied = 0;
+  static int whichff = 0;
+  if (whichff == 0) { // title only on first iteration
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: Firmware registers\r\n", argv[0]);
+  }
+  for (; whichff < NFIREFLIES; ++whichff) { // loop over all fireflies
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: ", ff_moni2c_addrs[whichff].name);
+    if (isEnabledFF(whichff) && FireflyType(whichff) != DEVICE_25G4) { // only read if enabled and if not 4x25G
+      uint8_t fw_reg[FF_FW_REG_SIZE];
+      int ret = read_arbitrary_ff_register(FF_FW_REG_ADDR, whichff, fw_reg, FF_FW_REG_SIZE);
+      if (ret != 0) {
+        copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: read failed\r\n", argv[0]);
+        return pdFALSE;
+      }
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "0x%02x%02x%02x", fw_reg[0], fw_reg[1], fw_reg[2]);
+    }
+    else {
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "   ---   ");
+    }
+    bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL); // newline for Tx vs Rx formatting
+    if (isTx)
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+    else
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+    if ((SCRATCH_SIZE - copied) < 30) {
+      ++whichff;
+      return pdTRUE;
+    }
+  }
+  whichff = 0;
+  return pdFALSE;
+}

--- a/projects/cm_mcu/commands/FireflyCommands.c
+++ b/projects/cm_mcu/commands/FireflyCommands.c
@@ -672,6 +672,54 @@ BaseType_t ff_cdr_enable_status(int argc, char **argv, char *m)
   return pdFALSE;
 }
 
+BaseType_t ff_power_alarm_status(int argc, char **argv, char *m)
+{
+  int copied = 0;
+
+  static int whichff = 0;
+
+  if (whichff == 0) {
+    // check for stale data
+    if (isFFStale()) {
+      TickType_t now = pdTICKS_TO_S(xTaskGetTickCount());
+      TickType_t last = pdTICKS_TO_S(getFFupdateTick(isFFStale()));
+      int mins = (now - last) / 60;
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                         "%s: stale data, last update %d minutes ago\r\n", argv[0], mins);
+    }
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "FIREFLY POWER ALARM:\r\n");
+  }
+
+  for (; whichff < NFIREFLIES; ++whichff) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%17s: ", ff_moni2c_addrs[whichff].name);
+    if (isEnabledFF(whichff) && (FireflyType(whichff) == DEVICE_25G12 || FireflyType(whichff) == DEVICE_25G4)) {
+      uint16_t val0 = get_FF_POWER_ALARM_0_data(whichff);
+      uint16_t val1 = get_FF_POWER_ALARM_1_data(whichff);
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "0x%04x 0x%04x", val0, val1);
+    }
+    else {
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "  --        --");
+    }
+    bool isTx = (strstr(ff_moni2c_addrs[whichff].name, "Tx") != NULL);
+    if (isTx)
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\t");
+    else
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "\r\n");
+    if ((SCRATCH_SIZE - copied) < 30) {
+      ++whichff;
+      return pdTRUE;
+    }
+  }
+  if (whichff % 2 == 1) {
+    m[copied++] = '\r';
+    m[copied++] = '\n';
+    m[copied] = '\0';
+  }
+  whichff = 0;
+
+  return pdFALSE;
+}
+
 BaseType_t ff_temp(int argc, char **argv, char *m)
 {
   // argument handling

--- a/projects/cm_mcu/commands/FireflyCommands.h
+++ b/projects/cm_mcu/commands/FireflyCommands.h
@@ -39,5 +39,6 @@ BaseType_t ff_dump_names(int argc, char **argv, char *m);
 BaseType_t ff_v3v3(int argc, char **argv, char *m);
 BaseType_t ff_ch_disable_status(int argc, char **argv, char *m);
 BaseType_t ff_cdr_enable_status(int argc, char **argv, char *m);
+BaseType_t ff_power_alarm_status(int argc, char **argv, char *m);
 
 #endif

--- a/projects/cm_mcu/commands/FireflyCommands.h
+++ b/projects/cm_mcu/commands/FireflyCommands.h
@@ -40,5 +40,6 @@ BaseType_t ff_v3v3(int argc, char **argv, char *m);
 BaseType_t ff_ch_disable_status(int argc, char **argv, char *m);
 BaseType_t ff_cdr_enable_status(int argc, char **argv, char *m);
 BaseType_t ff_power_alarm_status(int argc, char **argv, char *m);
+BaseType_t ff_fw_reg(int argc, char **argv, char *m);
 
 #endif

--- a/sm_cm_config/data/PL_MEM_CM_rev2.yml
+++ b/sm_cm_config/data/PL_MEM_CM_rev2.yml
@@ -274,8 +274,40 @@ config:
       - FF2_P5_XCVR4 
       - FF2_P6_XCVR4
       - FF2_P7_XCVR4
-    postfixes:  
+    postfixes:
       - CH0
       - CH1
       - CH2
       - CH3
+  - name: firefly_power_alarm
+    start: 420
+    count: 40
+    mcu_call: firefly_power_alarm
+    mcu_extra_call: null
+    type: uint16_t
+    extra: Table=CM_FF_MON;Status=1
+    default_col: null
+    names:
+      - F1_P1_Tx12
+      - F1_P1_Rx12
+      - F1_P2_Tx12
+      - F1_P2_Rx12
+      - F1_P3_Tx12
+      - F1_P3_Rx12
+      - F1_P4_XCVR4
+      - F1_P5_XCVR4
+      - F1_P6_XCVR4
+      - F1_P7_XCVR4
+      - F2_P1_Tx12
+      - F2_P1_Rx12
+      - F2_P2_Tx12
+      - F2_P2_Rx12
+      - F2_P3_Tx12
+      - F2_P3_Rx12
+      - F2_P4_XCVR4
+      - F2_P5_XCVR4
+      - F2_P6_XCVR4
+      - F2_P7_XCVR4
+    postfixes:
+      - POWER_ALARM_0
+      - POWER_ALARM_1

--- a/sm_cm_config/data/PL_MEM_CM_rev3.yml
+++ b/sm_cm_config/data/PL_MEM_CM_rev3.yml
@@ -273,8 +273,40 @@ config:
       - FF1_P6_XCVR4 
       - FF2_P5_XCVR4 
       - FF2_P6_XCVR4 
-    postfixes:  
+    postfixes:
       - CH0
       - CH1
       - CH2
       - CH3
+  - name: firefly_power_alarm
+    start: 424
+    count: 40
+    mcu_call: firefly_power_alarm
+    mcu_extra_call: null
+    type: uint16_t
+    extra: Table=CM_FF_MON;Status=1
+    default_col: null
+    names:
+      - F1_P1_Tx12
+      - F1_P1_Rx12
+      - F1_P2_Tx12
+      - F1_P2_Rx12
+      - F1_P3_Tx12
+      - F1_P3_Rx12
+      - F1_P4_Tx12
+      - F1_P4_Rx12
+      - F1_P5_XCVR4
+      - F1_P6_XCVR4
+      - F2_P1_Tx12
+      - F2_P1_Rx12
+      - F2_P2_Tx12
+      - F2_P2_Rx12
+      - F2_P3_Tx12
+      - F2_P3_Rx12
+      - F2_P4_Tx12
+      - F2_P4_Rx12
+      - F2_P5_XCVR4
+      - F2_P6_XCVR4
+    postfixes:
+      - POWER_ALARM_0
+      - POWER_ALARM_1

--- a/sm_cm_config/data/README.md
+++ b/sm_cm_config/data/README.md
@@ -1,0 +1,40 @@
+# Data Files for `sm_cm_config`
+
+This directory contains YAML inputs and XML artifacts used by the CM MCU/Zynq address-generation flow.
+
+## File Overview
+
+- `MON_I2C_rev2.yml`
+  - I2C monitor register map input for CM hardware revision 2.
+  - Used to generate MCU-side monitor address tables for REV2.
+
+- `MON_I2C_rev3.yml`
+  - I2C monitor register map input for CM hardware revision 3.
+  - Defines monitored devices, register layout, masks, units, and data types.
+
+- `PL_MEM_CM_rev1.yml`
+  - Main PL memory-map input for CM hardware revision 1.
+  - Used by generation scripts to produce MCU C tables and Zynq XML address mappings.
+
+- `PL_MEM_CM_rev2.yml`
+  - Main PL memory-map input for CM hardware revision 2.
+
+- `PL_MEM_CM_rev2.yml~`
+  - Editor backup file for `PL_MEM_CM_rev2.yml`.
+  - Not used by generation scripts; safe to ignore for normal builds.
+
+- `PL_MEM_CM_rev3.yml`
+  - Main PL memory-map input for CM hardware revision 3.
+
+- `address_apollo.xml`
+  - Generated XML address-table artifact used on the Zynq side.
+  - Included in the software stack that decodes CM MCU memory fields.
+
+- `connections.xml`
+  - XML file describing module connections used by the address-table hierarchy.
+
+## Notes
+
+- Revision-specific YAML files must stay in sync with firmware expectations for `REV1`/`REV2`/`REV3` builds.
+- If a YAML file changes, regenerate and commit the corresponding generated outputs consumed by firmware and Zynq software.
+- The canonical generation entry points are in `sm_cm_config/src` (see parent docs in `sm_cm_config/README.md`).


### PR DESCRIPTION
This pull request adds new support for monitoring and reporting Firefly optical power alarms and firmware registers in the CM MCU firmware and configuration. It introduces new CLI commands. Also fixes a bug in how some of the data was previously displayed in the CLI.

New commands are `ff_pwr_alarm` and `ff_fw_reg` to show the power alarms and firmware version register data. Note that the 4x25 parts do not appear

Send ff power_alarm data to the zynq.