### PR TITLE
Fix incomplete handling of 4v, new peripheral documentation for MCU, bug fix in ZMON power alarm (c and yaml)

### DIFF
--- a/common/LocalUart.c
+++ b/common/LocalUart.c
@@ -35,14 +35,17 @@ void UART4Init(uint32_t ui32SysClock)
   MAP_UARTConfigSetExpClk(UART4_BASE, ui32SysClock, 115200,
                           (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE | UART_CONFIG_PAR_NONE));
 
-  //
-  // Enable the UART interrupt.
-  //
+  // In REV1, UART4 is the front-panel CLI and needs RX interrupts.
+  // In REV2/3, UART4 is TX-only (ZynqMon); no handler is installed in the
+  // vector table, so enabling RX/RT interrupts would call IntDefaultHandler
+  // on any received character or noise. Only enable interrupts in REV1.
+#ifdef REV1
 #ifdef USE_FREERTOS
   MAP_IntPrioritySet(INT_UART4, configKERNEL_INTERRUPT_PRIORITY);
 #endif // USE_FREERTOS
   MAP_IntEnable(INT_UART4);
   MAP_UARTIntEnable(UART4_BASE, UART_INT_RX | UART_INT_RT);
+#endif // REV1
 
   return;
 }

--- a/common/LocalUart.c
+++ b/common/LocalUart.c
@@ -97,8 +97,6 @@ void UART0Init(uint32_t ui32SysClock)
   return;
 }
 
-
-
 //*****************************************************************************
 //
 // Send a string to the UART4

--- a/mcu_peripherals.md
+++ b/mcu_peripherals.md
@@ -1,0 +1,350 @@
+# Apollo CM MCU Hardware Pin and Peripheral Assignments
+
+**MCU**: TI TM4C1290NCPDT (ARM Cortex-M4F, 80 MHz)  
+**Sources**: `common/`pinout_rev1`.c`, `common/`pinout_rev2`.c`, `common/`gpio_pins_rev2`.def`, `common/pinsel.h`, `projects/`cm_mcu`/ADCMonitorTask.c`, `common/LocalUart.c`, `common/`i2c_reg`.c`
+
+---
+
+## Dedicated Peripherals
+
+### UART
+
+| Peripheral | TX Pin | RX Pin | Baud | REV1 Function | REV2/3 Function |
+|------------|--------|--------|------|---------------|-----------------|
+| UART0 | PA1 (U0TX) | PA0 (U0RX) | 115200 | (unused / debug) | `ZQ_UART` — Zynq-facing CLI |
+| UART1 | PB1 (U1TX) | PB0 (U1RX) | 115200 | `ZQ_UART` — Zynq-facing CLI | — (PB0/1 reassigned to I2C5) |
+| UART3 | PA5 (U3TX) | PA4 (U3RX) | — | — (PA4/5 are GPIO outputs) | pins muxed in `pinout_rev2.c` but peripheral **not initialized** |
+| UART4 | PA3 (U4TX) | PA2 (U4RX) | 115200 | `FP_UART` — front-panel CLI | `ZynqMonTask` TX-only output to Zynq (hardware UART, no soft-UART) |
+
+UART0, UART1 (REV1), and UART4 have RX+RT interrupts enabled with handlers in `InterruptHandlers.c`. In REV2/3, `FP_UART` is not defined — there is no separate front-panel CLI UART.
+
+---
+
+### I2C
+
+| Peripheral | SCL Pin | SDA Pin | Mode | Function |
+|------------|---------|---------|------|----------|
+| I2C0 | PB2 | PB3 | **Slave** (addr 0x40) | I2C slave interface to external master (`I2CSlaveTask`) |
+| I2C1 | PG0 | PG1 | SMBus Master | DCDC / power supply monitoring |
+| I2C2 | PG2 | PG3 | SMBus Master | Clock synthesizers (Si5395) |
+| I2C3 | PG4 | PG5 | SMBus Master | F2 Firefly optics |
+| I2C4 | PG6 | PG7 | SMBus Master | F1 Firefly optics |
+| I2C5 | PB0 | PB1 | SMBus Master | FPGA monitoring (REV2/3 only) |
+| I2C6 | PA6 | PA7 | SMBus Master | FPGA monitoring (REV1 only) |
+
+All I2C masters use interrupts at `configKERNEL_INTERRUPT_PRIORITY`; I2C0 slave uses `I2C0SlaveIntHandler`.
+
+---
+
+### ADC
+
+| Peripheral | Sequence | Reference | Interrupt | Usage |
+|------------|----------|-----------|-----------|-------|
+| ADC0 | Seq 1 | External 3 V | `INT_ADC0SS1` | Voltage monitoring (first 4–8 channels) |
+| ADC1 | Seq 0 | External 3 V | `INT_ADC1SS0` | Voltage / current / temperature monitoring |
+
+Internal TM4C temperature sensor sampled via `ADC_CTL_TS`.
+
+---
+
+### Timer
+
+| Peripheral | Sub-timer | Priority | REV1 Usage | REV2/3 Usage |
+|------------|-----------|----------|------------|--------------|
+| TIMER0A | Timer A (periodic) | 0x80 (high) | Bit-time counter for ZynqMon **software UART** (`ZynqMonTask.c`) | not used (ZynqMon uses hardware UART4 instead) |
+
+**Note**: Timer 0A priority (REV1) must not be changed — it is deliberately higher than FreeRTOS-managed interrupts.
+
+---
+
+### Internal Peripherals
+
+| Peripheral | Usage |
+|------------|-------|
+| EEPROM0 | Non-volatile storage: board identity, alarm thresholds, power-supply ignore mask, error log ring buffer |
+| Hibernate module | RTC (`InitRTC()`) — REV2/3 only |
+
+---
+
+## ADC Channel Signal Assignments
+
+The ADC channel numbers are fixed by the TM4C silicon; signals differ between board revisions.
+
+### GPIO → ADC Channel Map (all revisions, from `pinout_rev1.c` / `pinout_rev2.c`)
+
+| GPIO Pin | ADC Channel | Hex |
+|----------|------------|-----|
+| PE3 | `AIN0_1` | CH0 |
+| PE2 | `AIN1_1` | CH1 |
+| PE1 | `AIN2_1` | CH2 |
+| PE0 | `AIN3_1` | CH3 |
+| PD7 | AIN4 | CH4 |
+| PD6 | AIN5 | CH5 |
+| PD5 | AIN6 | CH6 |
+| PD4 | AIN7 | CH7 |
+| PE5 | AIN8 | CH8 |
+| PE4 | AIN9 | CH9 |
+| PB4 | AIN10 | CH10 |
+| PB5 | AIN11 | CH11 |
+| PD3 | `AIN12_1` | CH12 |
+| PD2 | `AIN13_1` | CH13 |
+| PD1 | `AIN14_1` | CH14 |
+| PD0 | `AIN15_1` | CH15 |
+| PK0 | `AIN16_1` | CH16 |
+| PK1 | `AIN17_1` | CH17 |
+| PK2 | `AIN18_1` | CH18 |
+| PK3 | `AIN19_1` | CH19 |
+
+### ADC Signal Names by Revision (`ADCMonitorTask.c`)
+
+| GPIO Pin | ADC Ch | REV1 Signal | REV2/3 Signal |
+|----------|--------|-------------|---------------|
+| PE3 | CH0 | `F2_MGTY1_AVTT` | `VCC_12V` |
+| PE2 | CH1 | `F2_MGTY1_AVCC` | `VCC_M3V3` |
+| PE1 | CH2 | `F2_MGTY1_VCCAUX` | `VCC_3V3` |
+| PE0 | CH3 | `F2_VCCINT` | `VCC_4V0` |
+| PD7 | CH4 | `F1_MGTY_AVTT` | `VCC_1V8` |
+| PD6 | CH5 | `F1_MGTY_AVCC` | `F1_VCCINT` |
+| PD5 | CH6 | `F1_MGTY_VCCAUX` | `F1_AVCC` |
+| PD4 | CH7 | `VCC_1V8` | `F1_AVTT` |
+| PE5 | CH8 | `F1_VCCINT` | `F1_VCCAUX` |
+| PE4 | CH9 | `F1_MGTH_VCCAUX` | `F2_VCCINT` |
+| PB4 | CH10 | `F1_MGTH_AVCC` | `F2_AVCC` |
+| PB5 | CH11 | `F1_MGTH_AVTT` | `F2_AVTT` |
+| PD3 | CH12 | `VCC_12V` | `F2_VCCAUX` |
+| PD2 | CH13 | `VCC_2V5` | `CUR_V_12V` |
+| PD1 | CH14 | `VCC_M3V3` | `CUR_V_M3V3` |
+| PD0 | CH15 | `VCC_M1V8` | `CUR_V_4V0` |
+| PK0 | CH16 | `VCC_3V3` | `CUR_V_F1VCCAUX` |
+| PK1 | CH17 | `F2_MGTY2_VCCAUX` | `CUR_V_F2VCCAUX` |
+| PK2 | CH18 | `F2_MGTY2_AVCC` | `F1_TEMP` (°C) |
+| PK3 | CH19 | `F2_MGTY2_AVTT` | `F2_TEMP` (°C) |
+| (internal) | TS | `TM4C_TEMP` (°C) | `TM4C_TEMP` (°C) |
+
+---
+
+## GPIO Pin Assignments
+
+`Dir` abbreviations: **In** = input, **Out** = push-pull output, **OD** = open-drain output.
+
+Pin numbers are 128-pin TQFP package pin numbers. Numbers marked with † come directly from `gpio_pins_rev1.def` / `gpio_pins_rev2.def` (generated by TI PinMux); others are derived from the package pinout.
+
+### Port A
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PA0 | 33 | UART | UART0 RX (U0RX) | UART | UART0 RX (U0RX) |
+| PA1 | 34 | UART | UART0 TX (U0TX) | UART | UART0 TX (U0TX) |
+| PA2 | 35 | UART | UART4 RX (U4RX) | UART | UART4 RX (U4RX) |
+| PA3 | 36 | UART | UART4 TX (U4TX) | UART | UART4 TX (U4TX) |
+| PA4 | 37† | Out | `CTRL_V_VCCINT_PWR_EN` | UART | UART3 RX (U3RX) |
+| PA5 | 38† | Out | `CTRL_VCC_1V8_PWR_EN` | UART | UART3 TX (U3TX) |
+| PA6 | 39 | I2C | I2C6 SCL (FPGA I2C, REV1) | — | not used |
+| PA7 | 40 | I2C | I2C6 SDA (FPGA I2C, REV1) | — | not used |
+
+### Port B
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PB0 | 18 | UART | UART1 RX (U1RX) | I2C | I2C5 SCL (FPGA I2C) |
+| PB1 | 19 | UART | UART1 TX (U1TX) | I2C | I2C5 SDA (FPGA I2C) |
+| PB2 | 20 | I2C | I2C0 SCL (slave) | I2C | I2C0 SCL (slave) |
+| PB3 | 21 | I2C | I2C0 SDA (slave) | I2C | I2C0 SDA (slave) |
+| PB4 | 16 | ADC | AIN10 → `F1_MGTH_AVCC` | ADC | AIN10 → `F2_AVCC` |
+| PB5 | 17 | ADC | AIN11 → `F1_MGTH_AVTT` | ADC | AIN11 → `F2_AVTT` |
+
+Note: PB4/PB5 (ADC-capable) have lower pin numbers than PB0–PB3 because they are placed adjacent to the ADC input bank on the package.
+
+### Port C
+
+PC0–PC3 are reserved for JTAG (SWDIO/SWDCLK/TDI/TDO) and must not be reconfigured.
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PC4 | 25† | In | `V_MGTY2_AVTT_OK` | — | not used |
+| PC5 | 24† | In | `V_MGTY2_AVCC_OK` | — | not used |
+| PC6 | 23† | In | `V_MGTY1_AVCC_OK` | Out | `F2_FPGA_PROGRAM` |
+| PC7 | 22† | In | `V_MGTY1_AVTT_OK` | In | `PG_4V0` (4 V power-good) |
+
+### Port D (ADC — same pin mux both revisions)
+
+| Pin | MCU Pin | ADC Ch | REV1 Signal | REV2/3 Signal |
+|-----|---------|--------|-------------|---------------|
+| PD0 | 1 | CH15 | `VCC_M1V8` | `CUR_V_4V0` |
+| PD1 | 2 | CH14 | `VCC_M3V3` | `CUR_V_M3V3` |
+| PD2 | 3 | CH13 | `VCC_2V5` | `CUR_V_12V` |
+| PD3 | 4 | CH12 | `VCC_12V` | `F2_VCCAUX` |
+| PD4 | 91 | CH7 | `VCC_1V8` | `F1_AVTT` |
+| PD5 | 90 | CH6 | `F1_MGTY_VCCAUX` | `F1_AVCC` |
+| PD6 | 89 | CH5 | `F1_MGTY_AVCC` | `F1_VCCINT` |
+| PD7 | 88 | CH4 | `F1_MGTY_AVTT` | `VCC_1V8` |
+
+PD7 requires LOCK/COMMIT register unlock before pin-mux configuration (shared NMI function).  
+PD0–PD3 (AIN alternate-bank) and PD4–PD7 (AIN primary-bank) are in different quadrants of the package.
+
+### Port E (ADC — same pin mux both revisions)
+
+| Pin | MCU Pin | ADC Ch | REV1 Signal | REV2/3 Signal |
+|-----|---------|--------|-------------|---------------|
+| PE0 | 7 | CH3 | `F2_VCCINT` | `VCC_4V0` |
+| PE1 | 8 | CH2 | `F2_MGTY1_VCCAUX` | `VCC_3V3` |
+| PE2 | 9 | CH1 | `F2_MGTY1_AVCC` | `VCC_M3V3` |
+| PE3 | 10 | CH0 | `F2_MGTY1_AVTT` | `VCC_12V` |
+| PE4 | 12 | CH9 | `F1_MGTH_VCCAUX` | `F2_VCCINT` |
+| PE5 | 13 | CH8 | `F1_VCCINT` | `F1_VCCAUX` |
+
+### Port F
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PF0 | 42† | OD | `_FPGA_I2C_RESET` | In | `PG_F1_INT_A` (F1 FPGA power-good: INT rail A) |
+| PF1 | 43† | Out | `CTRL_VCC_3V3_PWR_EN` | In | `PG_F1_INT_B` (F1 FPGA power-good: INT rail B) |
+| PF2 | 44† | Out | `CTRL_K_VCCINT_PWR_EN` | In | `PG_F1_AVCC` (F1 FPGA power-good: AVCC) |
+| PF3 | 45† | OD | `_PWR_I2C_RESET` | In | `PG_F1_AVTT` (F1 FPGA power-good: AVTT) |
+| PF4 | 46† | In | `TM4C_TP1` (test point) | In | `PG_F1_VCCAUX` (F1 FPGA power-good: VCCAUX) |
+
+### Port G (I2C — identical both revisions)
+
+| Pin | MCU Pin | Function |
+|-----|---------|----------|
+| PG0 | 48 | I2C1 SCL → DCDC power supplies |
+| PG1 | 49 | I2C1 SDA → DCDC power supplies |
+| PG2 | 50 | I2C2 SCL → clock synthesizers |
+| PG3 | 51 | I2C2 SDA → clock synthesizers |
+| PG4 | 52 | I2C3 SCL → F2 Firefly optics |
+| PG5 | 53 | I2C3 SDA → F2 Firefly optics |
+| PG6 | 54 | I2C4 SCL → F1 Firefly optics |
+| PG7 | 55 | I2C4 SDA → F1 Firefly optics |
+
+PG0–PG7 pins (48–55) are derived: they occupy the consecutive block between PF4 (46) and PQ5 (57), with supply pins at 47 and 56.
+
+### Port H
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PH0 | 29† | In | `VCC_1V8_PG` (1.8 V power-good) | OD | `_FPGA_I2C_RESET` |
+| PH1 | 30† | In | `VCC_3V3_PG` (3.3 V power-good) | In (WPU) | `BLADE_POWER_EN` |
+| PH2 | 31† | In | `F2_VCCINT_PG_B` | In | `PG_3V3` (3.3 V power-good) |
+| PH3 | 32† | In | `F2_VCCINT_PG_A` | In | `PG_1V8` (1.8 V power-good) |
+
+### Port J
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PJ0 | 116† | Out | `MCU_LED_BLUE` | In | `F1_C2C_OK` (F1 FPGA chip-to-chip link OK) |
+| PJ1 | 117† | Out | `MCU_LED_GREEN` | In | `F2_C2C_OK` (F2 FPGA chip-to-chip link OK) |
+
+### Port K
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PK0 | 68 | ADC | CH16 → `VCC_3V3` | ADC | CH16 → `CUR_V_F1VCCAUX` |
+| PK1 | 67 | ADC | CH17 → `F2_MGTY2_VCCAUX` | ADC | CH17 → `CUR_V_F2VCCAUX` |
+| PK2 | 66 | ADC | CH18 → `F2_MGTY2_AVCC` | ADC | CH18 → `F1_TEMP` |
+| PK3 | 65 | ADC | CH19 → `F2_MGTY2_AVTT` | ADC | CH19 → `F2_TEMP` |
+| PK4 | 62† | Out | `BLADE_POWER_OK` | In | `_F1_FPGA_DONE` |
+| PK5 | 61† | In | `K_VCCINT_PG_A` | In | `PG_F2_VCCAUX` (F2 FPGA power-good: VCCAUX) |
+| PK6 | 60† | In | `K_VCCINT_PG_B` | In | `PG_F2_AVTT` (F2 FPGA power-good: AVTT) |
+| PK7 | 59† | OD | `_K_OPTICS_I2C_RESET` | In | `PG_F2_AVCC` (F2 FPGA power-good: AVCC) |
+
+### Port L
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PL0 | 81† | Out | `K_FPGA_PROGRAM` | Out | `EN_F1_INT` (enable F1 INT supply) |
+| PL1 | 82† | In | `TM4C_DIP_SW_1` (F1 installed?) | Out | `EN_F1_AVCC` (enable F1 AVCC) |
+| PL2 | 83† | Out | `CTRL_K_MGTY_VCCAUX_PWR_EN` | Out | `EN_F1_AVTT` (enable F1 AVTT) |
+| PL3 | 84† | Out | `CTRL_K_MGTH_VCCAUX_PWR_EN` | Out | `EN_F1_VCCAUX` (enable F1 VCCAUX) |
+| PL4 | 85† | Out | `CTRL_K_MGTY_AVCC_PWR_EN` | Out | `EN_F2_INT` (enable F2 INT supply) |
+| PL5 | 86† | Out | `CTRL_K_MGTH_AVCC_PWR_EN` | Out | `EN_F2_AVCC` (enable F2 AVCC) |
+| PL6 | 94† | Out | `TM4C_TO_KU15P_0` | Out | `EN_F2_VCCAUX` (enable F2 VCCAUX) |
+| PL7 | 93† | In | `TM4C_FROM_KU15P_0` | Out | `EN_F2_AVTT` (enable F2 AVTT) |
+
+### Port M
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PM0 | 78† | In | `_K_FPGA_DONE` | Out | `EN_1V8` (enable 1.8 V supply) |
+| PM1 | 77† | In | `K_MGTY_AVTT_OK` | Out | `EN_3V3` (enable 3.3 V supply) |
+| PM2 | 76† | In | `K_MGTY_AVCC_OK` | Out | `BLADE_POWER_OK` |
+| PM3 | 75† | In | `K_MGTH_AVCC_OK` | Out | `MCU_TO_F2` (MCU→F2 FPGA GPIO) |
+| PM4 | 74† | In | `K_MGTH_AVTT_OK` | Out | `MCU_TO_F1` (MCU→F1 FPGA GPIO) |
+| PM5 | 73† | In | `BLADE_ZYNQ_GPIO2` | In | `F2_TO_MCU` (F2 FPGA→MCU GPIO) |
+| PM6 | 72† | In | `BLADE_ZYNQ_GPIO1` / soft-UART TX (REV1) | In | `F1_TO_MCU` (F1 FPGA→MCU GPIO) |
+| PM7 | 71† | In (WPU) | `BLADE_POWER_EN` | In | `_F2_FPGA_DONE` |
+
+### Port N
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PN0 | 107† | Out | `CTRL_V_MGTY2_AVTT_PWR_EN` | Out | `ID_EEPROM_WP` (EEPROM write-protect) |
+| PN1 | 108† | Out | `CTRL_V_MGTY1_AVTT_PWR_EN` | Out | `JTAG_FROM_SM` |
+| PN2 | 109† | Out | `CTRL_V_MGTY2_AVCC_PWR_EN` | Out | `_F1_JTAG_BYPASS` |
+| PN3 | 110† | Out | `CTRL_V_MGTY1_AVCC_PWR_EN` | Out | `_F2_JTAG_BYPASS` |
+| PN4 | 111† | Out | `CTRL_V_MGTY2_VCCAUX_PWR_EN` | In | `SPARE_GPIO0` |
+| PN5 | 112† | Out | `CTRL_V_MGTY1_VCCAUX_PWR_EN` | In | `SPARE_GPIO1` |
+
+### Port P
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PP0 | 118† | Out | `TM4C_LED_RED` | In | `_F1_INSTALLED` (DIP switch: F1 FPGA present) |
+| PP1 | 119† | In | `_V_FPGA_DONE` | In | `_F2_INSTALLED` (DIP switch: F2 FPGA present) |
+| PP2 | 103† | Out | `CTRL_K_MGTH_AVTT_PWR_EN` | Out | `F1_FPGA_PROGRAM` |
+| PP3 | 104† | In | `TM4C_TP2` (test point) | Out | `MCU_LED_RED` |
+| PP4 | 105† | In | `TM4C_TP3` (test point) | Out | `MCU_LED_GREEN` |
+| PP5 | 106† | Out | `ID_EEPROM_WP` | Out | `MCU_LED_BLUE` |
+
+### Port Q
+
+| Pin | MCU Pin | REV1 Dir | REV1 Signal / Function | REV2/3 Dir | REV2/3 Signal / Function |
+|-----|---------|----------|------------------------|------------|--------------------------|
+| PQ0 | 5† | Out | `TM4C_TO_VU7P_0` | OD | `_PWR_I2C_RESET` |
+| PQ1 | 6† | In | `TM4C_FROM_VU7P_0` | OD | `_CLOCKS_I2C_RESET` |
+| PQ2 | 11† | In | `TM4C_DIP_SW_2` (F2 installed?) | OD | `_F2_OPTICS_I2C_RESET` |
+| PQ3 | 27† | Out | `V_FPGA_PROGRAM` | OD | `_F1_OPTICS_I2C_RESET` |
+| PQ4 | 102† | Out | `CTRL_K_MGTY_AVTT_PWR_EN` | Out | `FPGA_CFG_FROM_FLASH` |
+| PQ5 | 57† | OD | `_CLOCKS_I2C_RESET` | In | `PG_F2_INT_A` (F2 FPGA power-good: INT rail A) |
+| PQ6 | 58† | OD | `_V_OPTICS_I2C_RESET` | In | `PG_F2_INT_B` (F2 FPGA power-good: INT rail B) |
+
+---
+
+## Unimplemented / Unused Peripherals
+
+### Unused UART
+
+| Peripheral | REV1 | REV2/3 | Pin options | Current use of those pins |
+|------------|------|--------|-------------|---------------------------|
+| UART0 | unused | **used** (`ZQ_UART`) | PA0 (RX), PA1 (TX) | Used by UART0 itself in REV2/3; idle in REV1 |
+| UART1 | **used** (`ZQ_UART`) | unused | PB0 (RX), PB1 (TX) | Reassigned to I2C5 in REV2/3 |
+| UART2 | unused | unused | PD6 (RX), PD7 (TX) **or** PG4 (RX), PG5 (TX) | PD6/PD7 → ADC (`AIN5`/`AIN4`); PG4/PG5 → I2C3 (F2 Firefly) |
+| UART3 | unused | unused | PA4 (RX), PA5 (TX) | REV1: GPIO (`CTRL_V_VCCINT_PWR_EN` / `CTRL_VCC_1V8_PWR_EN`); REV2/3: muxed in `pinout_rev2.c` but peripheral never initialized |
+| UART5 | unused | unused | PE4 (RX), PE5 (TX) | ADC (`AIN9` / `AIN8`) |
+| UART6 | unused | unused | PD4 (RX), PD5 (TX) | ADC (`AIN7` / `AIN6`) |
+| UART7 | unused | unused | PE0 (RX), PE1 (TX) | ADC (`AIN3_1` / `AIN2_1`) |
+
+### Unused I2C
+
+| Peripheral | REV1 | REV2/3 | Pin options | Current use of those pins |
+|------------|------|--------|-------------|---------------------------|
+| I2C5 | unused | **used** (FPGA monitoring) | PB0 (SCL), PB1 (SDA) | UART1 (`ZQ_UART`) in REV1 |
+| I2C6 | **used** (FPGA monitoring) | unused | PA6 (SCL), PA7 (SDA) | REV1: I2C6 itself; REV2/3: **pins unassigned** — I2C6 is available if PA6/PA7 are configured |
+| I2C7 | unused | unused | PA4 (SCL), PA5 (SDA) **or** PD0 (SCL), PD1 (SDA) | PA4/PA5 → UART3 (see above); PD0/PD1 → ADC (`AIN15_1` / `AIN14_1`) |
+| I2C8 | unused | unused | PA2 (SCL), PA3 (SDA) **or** PD2 (SCL), PD3 (SDA) | PA2/PA3 → UART4 (used); PD2/PD3 → ADC (`AIN13_1` / `AIN12_1`) |
+| I2C9 | unused | unused | PA0 (SCL), PA1 (SDA) **or** PE6 (SCL), PE7 (SDA) | PA0/PA1 → UART0 (used); PE6/PE7 → not bonded out on TM4C1290NCPDT |
+
+With the exception of I2C6 in REV2/3 (PA6/PA7 are unassigned and available), all other unused UART and I2C peripherals have every available pin option occupied by another function in this design.
+
+### Other Unused Peripherals
+
+| Peripheral | Notes |
+|------------|-------|
+| SSI0–SSI3 (SPI) | `IntDefaultHandler` in `startup_gcc.c`; never initialized |
+| PWM0 | Not used |
+| CAN0 / CAN1 | Not used |
+| USB | Not used |
+| EPI0 | Not used |
+
+---
+
+*Generated from firmware source. For authoritative pin assignments refer to `common/pinout_rev1.c` and `common/pinout_rev2.c` / `common/gpio_pins_rev2.def`.*

--- a/mcu_peripherals.md
+++ b/mcu_peripherals.md
@@ -1,7 +1,7 @@
 # Apollo CM MCU Hardware Pin and Peripheral Assignments
 
 **MCU**: TI TM4C1290NCPDT (ARM Cortex-M4F, 80 MHz)  
-**Sources**: `common/`pinout_rev1`.c`, `common/`pinout_rev2`.c`, `common/`gpio_pins_rev2`.def`, `common/pinsel.h`, `projects/`cm_mcu`/ADCMonitorTask.c`, `common/LocalUart.c`, `common/`i2c_reg`.c`
+**Sources**: `common/pinout_rev1.c`, `common/pinout_rev2.c`, `common/gpio_pins_rev2.def`, `common/pinsel.h`, `projects/cm_mcu/ADCMonitorTask.c`, `common/LocalUart.c`, `common/i2c_reg.c`
 
 ---
 
@@ -14,9 +14,9 @@
 | UART0 | PA1 (U0TX) | PA0 (U0RX) | 115200 | (unused / debug) | `ZQ_UART` — Zynq-facing CLI |
 | UART1 | PB1 (U1TX) | PB0 (U1RX) | 115200 | `ZQ_UART` — Zynq-facing CLI | — (PB0/1 reassigned to I2C5) |
 | UART3 | PA5 (U3TX) | PA4 (U3RX) | — | — (PA4/5 are GPIO outputs) | pins muxed in `pinout_rev2.c` but peripheral **not initialized** |
-| UART4 | PA3 (U4TX) | PA2 (U4RX) | 115200 | `FP_UART` — front-panel CLI | `ZynqMonTask` TX-only output to Zynq (hardware UART, no soft-UART) |
+| UART4 | PA3 (U4TX) | PA2 (U4RX) | 115200 | `FP_UART` — front-panel CLI (RX+RT interrupts, `UART4IntHandler`) | `ZynqMonTask` TX-only polling output to Zynq — **no RX interrupts enabled** (see note) |
 
-UART0, UART1 (REV1), and UART4 have RX+RT interrupts enabled with handlers in `InterruptHandlers.c`. In REV2/3, `FP_UART` is not defined — there is no separate front-panel CLI UART.
+UART0 (REV2/3), UART1 (REV1), and UART4 (REV1) have RX+RT interrupts enabled with handlers in `InterruptHandlers.c`. In REV2/3, `FP_UART` is not defined and UART4 RX+RT interrupts are **not** enabled — UART4 is TX-only via `ROM_UARTCharPut` (blocking poll), so no interrupt handler is needed. The vector table has `IntDefaultHandler` for UART4 in REV2/3; enabling RX interrupts there would cause a system hang on any received byte or line noise, since `IntDefaultHandler` loops forever. PA2 (U4RX) is physically unconnected in REV2/3, so the UART RX input sits idle-high and no interrupt is ever generated in practice.
 
 ---
 

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -507,4 +507,24 @@ uint16_t getFF12Ch25GTxMask(int device)
   return mask;
 }
 
+// get the physical presence mask for 12 channel Tx slots. Device is 0 for F1 and 1 for F2.
+// Returns a mask in the same bit space as getFF12Ch25GTxMask: any part present, not just 25G.
+// assumes that ff_map_25gb_parts has been called first
+uint16_t getFF12ChPresentTxMask(int device)
+{
+  // for historical reasons these are stored at indices 0 and 2, not 0 and 1
+  uint16_t mask = ff_bitmask_args[0].present_bit_mask;
+  if (device == 1) {
+    mask = ff_bitmask_args[2].present_bit_mask;
+  }
+  else if (device > 1 || device < 0) {
+    log_error(LOG_SERVICE, "Invalid device %d\r\n", device);
+    return 0x0U;
+  }
+  mask &= FF_12CH_TX_MASK; // Mask to select 12 channel tx indices
+  mask = pack_10bit(mask);
+
+  return mask;
+}
+
 #endif // end REV2 or REV3

--- a/projects/cm_mcu/FireflyUtils.h
+++ b/projects/cm_mcu/FireflyUtils.h
@@ -74,6 +74,7 @@ uint8_t getFFpartbit(const uint8_t i);
 void getFFpart(void);
 uint32_t ff_map_25gb_parts(void);
 uint16_t getFF12Ch25GTxMask(int device);
+uint16_t getFF12ChPresentTxMask(int device);
 #endif
 
 uint8_t getFFstatus(const uint8_t i);

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -8,7 +8,6 @@
 // includes for types
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <assert.h>
 
 // local includes
@@ -405,13 +404,23 @@ void PowerSupplyTask(void *parameters)
           // check 12-ch FF parts from vendors on FPGA1/2
           vTaskDelay(pdMS_TO_TICKS(1000));
           (void)ff_map_25gb_parts();
-          // FIXME when no FF are installed the code requires the 4V switch to be off for no good reason
-          uint32_t pair_mask_f1 = getFF12Ch25GTxMask(0); // F1
-          uint32_t pair_mask_f2 = getFF12Ch25GTxMask(1); // F2
+          uint32_t pair_mask_f1 = getFF12Ch25GTxMask(0);        // 25G TX parts, F1
+          uint32_t pair_mask_f2 = getFF12Ch25GTxMask(1);        // 25G TX parts, F2
+          uint32_t present_mask_f1 = getFF12ChPresentTxMask(0); // any part present, F1
+          uint32_t present_mask_f2 = getFF12ChPresentTxMask(1); // any part present, F2
 
-          UBaseType_t ffmask[2] = {f1_ff12xmit_4v0_sel, f2_ff12xmit_4v0_sel};
-          if ((f1_ff12xmit_4v0_sel == pair_mask_f1) && (f2_ff12xmit_4v0_sel == pair_mask_f2)) {
-            int ret = enable_3v8(ffmask, false); // enable v38
+          // Only enable 3.8V for slots that are both present (25G) and wired to 4V0.
+          // Fail if: (a) a 25G part has no 4V0 switch (would be underpowered), or
+          //          (b) a non-25G part (e.g. 14G) occupies a 4V0-switched slot (would be overpowered).
+          // Empty slots with 4V0 switch set are harmless and do not block power-on.
+          UBaseType_t ffmask[2] = {f1_ff12xmit_4v0_sel & pair_mask_f1,
+                                   f2_ff12xmit_4v0_sel & pair_mask_f2};
+          bool mismatch = ((pair_mask_f1 & ~f1_ff12xmit_4v0_sel) != 0) ||
+                          ((pair_mask_f2 & ~f2_ff12xmit_4v0_sel) != 0) ||
+                          ((present_mask_f1 & f1_ff12xmit_4v0_sel & ~pair_mask_f1) != 0) ||
+                          ((present_mask_f2 & f2_ff12xmit_4v0_sel & ~pair_mask_f2) != 0);
+          if (!mismatch) {
+            int ret = enable_3v8(ffmask, false); // enable v38 (no-op if ffmask is {0,0})
             if (ret != 0) {
               log_error(LOG_PWRCTL, "enable 3v8 failed with %d\r\n", ret);
               disable_ps(); // turn off power
@@ -425,7 +434,8 @@ void PowerSupplyTask(void *parameters)
             }
           }
           else {
-            log_error(LOG_PWRCTL, "FF 4V0 part check failed: %x!=%x||%x!=%x, power off\r\n",
+            log_error(LOG_PWRCTL, "FF 4V0 part check failed: part present without 4V0 switch"
+                                  " (f1: sel=%x parts=%x, f2: sel=%x parts=%x), power off\r\n",
                       f1_ff12xmit_4v0_sel, pair_mask_f1, f2_ff12xmit_4v0_sel, pair_mask_f2);
             int ret = enable_3v8(ffmask, true); // disable v38
             if (ret == 0)

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -312,7 +312,6 @@ void zm_set_fpga(struct zynqmon_data_t data[], int start);
 void zm_set_allclk(struct zynqmon_data_t data[], int start);
 void zm_set_firefly_optpow12(struct zynqmon_data_t data[], int start);
 void zm_set_firefly_optpow4(struct zynqmon_data_t data[], int start);
-void zm_set_firefly_power_alarm(struct zynqmon_data_t data[], int start);
 
 #ifdef ZYNQMON_TEST_MODE
 void setZYNQMonTestData(uint8_t sensor, uint16_t value);

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -440,6 +440,26 @@ void zm_set_firefly_info(struct zynqmon_data_t data[], int start)
     }
     data[ll].sensor = ll + start;
     ++ll;
+    // POWER_ALARM_0
+    if (isFFStale()) {
+      data[ll].data.us = 0xff; // special stale value
+    }
+    else {
+      data[ll].data.us = get_FF_POWER_ALARM_0_data(j); // sensor value and type
+      log_debug(LOG_SERVICE, "POWER_ALARM_0 for ff %d: 0x%04x\r\n", j, data[ll].data.us);
+    }
+    data[ll].sensor = ll + start;
+    ++ll;
+    // POWER_ALARM_1
+    if (isFFStale()) {
+      data[ll].data.us = 0xff; // special stale value
+    }
+    else {
+      data[ll].data.us = get_FF_POWER_ALARM_1_data(j); // sensor value and type
+      log_debug(LOG_SERVICE, "POWER_ALARM_1 for ff %d: 0x%04x\r\n", j, data[ll].data.us);
+    }
+    data[ll].sensor = ll + start;
+    ++ll;
   }
 }
 
@@ -505,32 +525,6 @@ void zm_set_firefly_optpow4(struct zynqmon_data_t data[], int start)
       ++ll;
     } // loop over channels
   }   // loop over Tx firefly devices
-}
-
-void zm_set_firefly_power_alarm(struct zynqmon_data_t data[], int start)
-{
-  int ll = 0;
-  for (int j = 0; j < NFIREFLIES; ++j) {
-    if (isFFStale()) {
-      data[ll].data.us = 0xff;
-    }
-    else {
-      data[ll].data.us = get_FF_POWER_ALARM_0_data(j);
-      log_debug(LOG_SERVICE, "POWER_ALARM_0 for ff %d: 0x%04x\r\n", j, data[ll].data.us);
-    }
-    data[ll].sensor = ll + start;
-    ++ll;
-
-    if (isFFStale()) {
-      data[ll].data.us = 0xff;
-    }
-    else {
-      data[ll].data.us = get_FF_POWER_ALARM_1_data(j);
-      log_debug(LOG_SERVICE, "POWER_ALARM_1 for ff %d: 0x%04x\r\n", j, data[ll].data.us);
-    }
-    data[ll].sensor = ll + start;
-    ++ll;
-  }
 }
 
 #endif // REV2 or 3

--- a/sm_cm_config/data/MON_I2C_rev2.yml
+++ b/sm_cm_config/data/MON_I2C_rev2.yml
@@ -9,7 +9,7 @@ define: &FF_SHARED_REGS
   - name: STATUS_REG # register name
     reg_size: 1 # size of register address in bytes
     page: 0 # page of register
-    reg_address: 0x2 # register address, if list: [ cernb, 14g, 25g4, 25g12]
+    reg_address: [0x6,0x6, 0x2, 0x6] # register address, if list: [ cernb, 14g, 25g4, 25g12]
     size: 2 # size of data in register in bytes, max 2 bytes
     mask: 0xFF # mask for valid bits
     units: "" # units for display

--- a/sm_cm_config/data/MON_I2C_rev2.yml
+++ b/sm_cm_config/data/MON_I2C_rev2.yml
@@ -191,7 +191,7 @@ define: &FF_SHARED_REGS
     page: 0
     reg_address: [-1, -1, 98, 74]
     size: 2
-    mask: 0xFFF
+    mask: 0xFFFF
     units: ""
     type: PM_STATUS
     devicetypes: [25G4, 25G12]

--- a/sm_cm_config/data/MON_I2C_rev3.yml
+++ b/sm_cm_config/data/MON_I2C_rev3.yml
@@ -9,7 +9,7 @@ define: &FF_SHARED_REGS
   - name: STATUS_REG # register name
     reg_size: 1 # size of register address in bytes
     page: 0 # page of register
-    reg_address: 0x6 # register address, if list: [ cernb, 14g, 25g4, 25g12]
+    reg_address: [0x6,0x6, 0x2, 0x6] # register address, if list: [ cernb, 14g, 25g4, 25g12]
     size: 1 # size of data in register in bytes, max 2 bytes
     mask: 0xFF # mask for valid bits
     units: "" # units for display

--- a/sm_cm_config/data/MON_I2C_rev3.yml
+++ b/sm_cm_config/data/MON_I2C_rev3.yml
@@ -9,8 +9,8 @@ define: &FF_SHARED_REGS
   - name: STATUS_REG # register name
     reg_size: 1 # size of register address in bytes
     page: 0 # page of register
-    reg_address: 0x2 # register address, if list: [ cernb, 14g, 25g4, 25g12]
-    size: 2 # size of data in register in bytes, max 2 bytes
+    reg_address: 0x6 # register address, if list: [ cernb, 14g, 25g4, 25g12]
+    size: 1 # size of data in register in bytes, max 2 bytes
     mask: 0xFF # mask for valid bits
     units: "" # units for display
     type: PM_STATUS # type of data
@@ -164,7 +164,7 @@ define: &FF_SHARED_REGS
     page: 0
     reg_address: [52, 52, 86, 52]
     size: 2
-    mask: 0xFFF
+    mask: 0xFFFF
     units: ""
     type: PM_STATUS
     devicetypes: [CERNB, 14G, 25G4, 25G12]
@@ -191,7 +191,7 @@ define: &FF_SHARED_REGS
     page: 0
     reg_address: [-1, -1, 98, 74]
     size: 2
-    mask: 0xFFF
+    mask: 0xFFFF
     units: ""
     type: PM_STATUS
     devicetypes: [25G4, 25G12]

--- a/sm_cm_config/data/PL_MEM_CM_rev2.yml
+++ b/sm_cm_config/data/PL_MEM_CM_rev2.yml
@@ -9,7 +9,7 @@ metadata:
 config:
   - name: firefly
     start: 2
-    count: 120
+    count: 160
     mcu_call: firefly_info
     mcu_extra_call: null
     type: uint16_t
@@ -43,8 +43,10 @@ config:
       - LOS_ALARM
       - CDR_LOL_ALARM
       - CDR_ENABLE
+      - POWER_ALARM_R0
+      - POWER_ALARM_R1
   - name: uptime
-    start: 122
+    start: 162
     count: 2
     type: uint32_t
     mcu_call: uptime
@@ -54,7 +56,7 @@ config:
     names:
       - MCU_UPTIME
   - name: psmon
-    start: 124
+    start: 164
     count: 84
     mcu_call: psmon
     mcu_extra_call: null
@@ -84,7 +86,7 @@ config:
       - IOUT
       - STATUS_WORD
   - name: gitversion
-    start: 208
+    start: 248
     count: 10
     type: char
     size: 5
@@ -94,7 +96,7 @@ config:
     names:
       - MCU_FW_VER
   - name: adcmon
-    start: 218
+    start: 258
     count: 21
     mcu_call: adcmon
     mcu_extra_call: null
@@ -124,7 +126,7 @@ config:
       - F2_TEMP
       - TM4C_TEMP
   - name: fpga
-    start: 240
+    start: 280
     count: 8
     type: fp16
     extra: Table=CM_MON;Status=2
@@ -141,7 +143,7 @@ config:
       - F2_TEMP_SLR2
       - F2_TEMP_SLR3
   - name: clkmon
-    start: 248
+    start: 288
     count: 40
     type: uint16_t
     extra: Table=CM_CLK_MON;Status=1
@@ -164,7 +166,7 @@ config:
       - LOSOOF_IN
       - STICKY_FLG
   - name: clkr0aconfigversion
-    start: 288
+    start: 328
     count: 4
     type: char
     size: 2
@@ -174,7 +176,7 @@ config:
     names:
       - MCU_CLKR0A_VER
   - name: clkr0bconfigversion
-    start: 292
+    start: 332
     count: 4
     type: char
     size: 2
@@ -184,7 +186,7 @@ config:
     names:
       - MCU_CLKR0B_VER
   - name: clkr1aconfigversion
-    start: 296
+    start: 336
     count: 4
     type: char
     size: 2
@@ -194,7 +196,7 @@ config:
     names:
       - MCU_CLKR1A_VER
   - name: clkr1bconfigversion
-    start: 300
+    start: 340
     count: 4
     type: char
     size: 2
@@ -204,7 +206,7 @@ config:
     names:
       - MCU_CLKR1B_VER
   - name: clkr1cconfigversion
-    start: 304
+    start: 344
     count: 4
     type: char
     size: 2
@@ -214,7 +216,7 @@ config:
     names:
       - MCU_CLKR1C_VER
   - name: firefly_bits
-    start: 308
+    start: 348
     count: 8
     type: uint16_t
     extra: Table=CM_FFARGV_MON;Status=1
@@ -230,7 +232,7 @@ config:
       - IS_FF25Gbs
       - IS_PRESENT
   - name: firefly_optpow_12
-    start: 316
+    start: 356
     count: 72
     mcu_call: firefly_optpow12
     mcu_extra_call: null
@@ -258,7 +260,7 @@ config:
       - CH10
       - CH11
   - name: firefly_optpow_4
-    start: 388
+    start: 428
     count: 32
     mcu_call: firefly_optpow4
     mcu_extra_call: null
@@ -279,35 +281,3 @@ config:
       - CH1
       - CH2
       - CH3
-  - name: firefly_power_alarm
-    start: 420
-    count: 40
-    mcu_call: firefly_power_alarm
-    mcu_extra_call: null
-    type: uint16_t
-    extra: Table=CM_FF_MON;Status=1
-    default_col: null
-    names:
-      - F1_P1_Tx12
-      - F1_P1_Rx12
-      - F1_P2_Tx12
-      - F1_P2_Rx12
-      - F1_P3_Tx12
-      - F1_P3_Rx12
-      - F1_P4_XCVR4
-      - F1_P5_XCVR4
-      - F1_P6_XCVR4
-      - F1_P7_XCVR4
-      - F2_P1_Tx12
-      - F2_P1_Rx12
-      - F2_P2_Tx12
-      - F2_P2_Rx12
-      - F2_P3_Tx12
-      - F2_P3_Rx12
-      - F2_P4_XCVR4
-      - F2_P5_XCVR4
-      - F2_P6_XCVR4
-      - F2_P7_XCVR4
-    postfixes:
-      - POWER_ALARM_0
-      - POWER_ALARM_1

--- a/sm_cm_config/data/PL_MEM_CM_rev3.yml
+++ b/sm_cm_config/data/PL_MEM_CM_rev3.yml
@@ -45,8 +45,10 @@ config:
       - LOS_ALARM
       - CDR_LOL_ALARM
       - CDR_ENABLE
+      - POWER_ALARM_R0
+      - POWER_ALARM_R1
   - name: uptime
-    start: 122
+    start: 162
     count: 2
     type: uint32_t
     mcu_call: uptime
@@ -56,7 +58,7 @@ config:
     names:
       - MCU_UPTIME
   - name: psmon
-    start: 124
+    start: 164
     count: 84
     mcu_call: psmon
     mcu_extra_call: null
@@ -86,7 +88,7 @@ config:
       - IOUT
       - STATUS_WORD
   - name: gitversion
-    start: 208
+    start: 248
     count: 10
     type: char
     size: 5
@@ -96,7 +98,7 @@ config:
     names:
       - MCU_FW_VER
   - name: adcmon
-    start: 218
+    start: 258
     count: 21
     mcu_call: adcmon
     mcu_extra_call: null
@@ -126,7 +128,7 @@ config:
       - F2_TEMP
       - TM4C_TEMP
   - name: fpga
-    start: 240
+    start: 280
     count: 8
     type: fp16
     extra: Table=CM_MON;Status=2
@@ -143,7 +145,7 @@ config:
       - F2_TEMP_SLR2
       - F2_TEMP_SLR3
   - name: clkmon
-    start: 248
+    start: 288
     count: 35
     type: uint16_t
     extra: Table=CM_CLK_MON;Status=1
@@ -165,7 +167,7 @@ config:
       - LOSOOF_IN
       - STICKY_FLG
   - name: clkr0aconfigversion
-    start: 284
+    start: 324
     count: 4
     type: char
     size: 2
@@ -175,7 +177,7 @@ config:
     names:
       - MCU_CLKR0A_VER
   - name: clkr0bconfigversion
-    start: 288
+    start: 328
     count: 4
     type: char
     size: 2
@@ -185,7 +187,7 @@ config:
     names:
       - MCU_CLKR0B_VER
   - name: clkr1aconfigversion
-    start: 292
+    start: 332
     count: 4
     type: char
     size: 2
@@ -195,7 +197,7 @@ config:
     names:
       - MCU_CLKR1A_VER
   - name: clkr1bconfigversion
-    start: 296
+    start: 336
     count: 4
     type: char
     size: 2
@@ -205,7 +207,7 @@ config:
     names:
       - MCU_CLKR1B_VER
   - name: clkr1cconfigversion
-    start: 300
+    start: 340
     count: 4
     type: char
     size: 2
@@ -215,7 +217,7 @@ config:
     names:
       - MCU_CLKR1C_VER
   - name: firefly_bits
-    start: 304
+    start: 344
     count: 8
     type: uint16_t
     extra: Table=CM_FFARGV_MON;Status=1
@@ -231,7 +233,7 @@ config:
       - IS_FF25Gbs
       - IS_PRESENT      
   - name: firefly_optpow_12
-    start: 312
+    start: 352
     count: 96
     mcu_call: firefly_optpow12
     mcu_extra_call: null
@@ -261,7 +263,7 @@ config:
       - CH10
       - CH11
   - name: firefly_optpow_4
-    start: 408
+    start: 448
     count: 16
     mcu_call: firefly_optpow4
     mcu_extra_call: null
@@ -278,35 +280,3 @@ config:
       - CH1
       - CH2
       - CH3
-  - name: firefly_power_alarm
-    start: 424
-    count: 40
-    mcu_call: firefly_power_alarm
-    mcu_extra_call: null
-    type: uint16_t
-    extra: Table=CM_FF_MON;Status=1
-    default_col: null
-    names:
-      - F1_P1_Tx12
-      - F1_P1_Rx12
-      - F1_P2_Tx12
-      - F1_P2_Rx12
-      - F1_P3_Tx12
-      - F1_P3_Rx12
-      - F1_P4_Tx12
-      - F1_P4_Rx12
-      - F1_P5_XCVR4
-      - F1_P6_XCVR4
-      - F2_P1_Tx12
-      - F2_P1_Rx12
-      - F2_P2_Tx12
-      - F2_P2_Rx12
-      - F2_P3_Tx12
-      - F2_P3_Rx12
-      - F2_P4_Tx12
-      - F2_P4_Rx12
-      - F2_P5_XCVR4
-      - F2_P6_XCVR4
-    postfixes:
-      - POWER_ALARM_0
-      - POWER_ALARM_1

--- a/sm_cm_config/data/PL_MEM_CM_rev3.yml
+++ b/sm_cm_config/data/PL_MEM_CM_rev3.yml
@@ -11,7 +11,7 @@ metadata:
 config:
   - name: firefly
     start: 2
-    count: 120
+    count: 160
     mcu_call: firefly_info
     mcu_extra_call: null
     type: uint16_t


### PR DESCRIPTION
This pull request introduces several improvements and corrections to the Firefly (FF) power control and monitoring logic, MCU peripheral documentation, and ZynqMon data reporting. The main changes include a more robust check for Firefly presence and power wiring, improved error handling, expanded ZynqMon sensor reporting, and updated documentation for hardware pin assignments.
