### PR TITLE
Refactor memory management and optimize task configurations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,18 @@
 # CLAUDE.md — Apollo Command Module MCU Firmware
 
+## Our interactions
+
+* Research FIRST, then advise. Always web-search before giving product-specific advice, pricing, or recommendations. Your training data goes stale. Today's answer matters immensely!
+* Challenge my reasoning instead of validating it. If my approach has a flaw, say so. 
+* When there's a tradeoff, present options with evidence and let me decide. Don't silently pick the easy path.
+* If there's a known issue, raise it. "Good enough" is not good enough.
+* If you're unsure about something, say so. DO NOT guess or fabricate.
+* If my request is ambiguous, clarify before proceeding.
+* Be concise. Don't explain basics I already know.
+
 ## Project Overview
 
-This repository contains bare-metal firmware for the **Apollo command module**, targeting the **TI Tiva TM4C1290NCPDT** (ARM Cortex-M4F with FPU, 80 MHz). The firmware manages power sequencing, temperature/voltage monitoring, I2C communication, and FPGA/Firefly control for high-energy physics detector readout systems.
+This repository contains bare-metal firmware for the **Apollo command module**, targeting the **TI Tiva TM4C1290NCPDT** (ARM Cortex-M4F with FPU, 80 MHz). The firmware manages power sequencing, temperature/voltage monitoring, I2C communication, and FPGA/Firefly control for high-energy physics detector readout systems. It controls low-level functionality of the command module of an ATCA blade. The blade is to be used at the HL-LHC.
 
 ## Hardware
 
@@ -18,11 +28,11 @@ This repository contains bare-metal firmware for the **Apollo command module**, 
 - **Compiler**: `arm-none-eabi-gcc` 13.2.Rel1 — download from ARM, do **not** use the distribution-provided version (usually too old)
 - **Build System**: Make
 - **Version Control**: Git (with submodule support)
-- **Optional IDE**: Eclipse with GNU MCU Eclipse plugin
+- **Optional IDE**: Eclipse with GNU MCU Eclipse plugin or VS Code
 
 ### Platform Support
 
-- **Fully Supported**: Linux (RHEL7/SC7), macOS
+- **Fully Supported**: Linux (ALMA9), macOS
 - **Experimental**: Windows via WSL (recommended) or Cygwin (requires `make clean` between builds)
 
 ## Build

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -47,7 +47,7 @@ void setFFmask(uint32_t ff_combined_present)
 #ifdef REV1
   uint32_t data = (~ff_combined_present) & 0x1FFFFFFU;
 #elif defined(REV2) || defined(REV3) // TODO: check
-  uint32_t data = (ff_combined_present)&0xFFFFFU;
+  uint32_t data = (ff_combined_present) & 0xFFFFFU;
 #endif                               // REV1
   ff_USER_mask = read_eeprom_single(EEPROM_ID_FF_ADDR);
   ff_PRESENT_mask = data;
@@ -205,10 +205,10 @@ void readFFpresent(void)
   ff_bitmask_args[3].present_bit_mask = (~present_FFL4_F2_bar) & 0xFU;   // 4 bits
   ff_bitmask_args[2].present_bit_mask = (~present_FFL12_F2_bar) & 0x3FU; // 6 bits
 #elif defined(REV3)
-  present_FFL12_F1_bar = present_FFL12_F1_bar & 0xFFU;             // bottom 8 bits
-  present_FFL12_F2_bar = present_FFL12_F2_bar & 0xFFU;             // bottom 8 bits
-  present_FFL4_F1_bar = (present_FFL4_F1_bar >> 2) & 0x3U;         // bits 2-3
-  present_FFL4_F2_bar = (present_FFL4_F2_bar >> 2) & 0x3U;         // bits 2-3
+  present_FFL12_F1_bar = present_FFL12_F1_bar & 0xFFU;     // bottom 8 bits
+  present_FFL12_F2_bar = present_FFL12_F2_bar & 0xFFU;     // bottom 8 bits
+  present_FFL4_F1_bar = (present_FFL4_F1_bar >> 2) & 0x3U; // bits 2-3
+  present_FFL4_F2_bar = (present_FFL4_F2_bar >> 2) & 0x3U; // bits 2-3
 
   // active low
   uint32_t ff_combined_present_bar = ((present_FFL4_F2_bar) << 18) |  // 2 bits

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -47,7 +47,7 @@ void setFFmask(uint32_t ff_combined_present)
 #ifdef REV1
   uint32_t data = (~ff_combined_present) & 0x1FFFFFFU;
 #elif defined(REV2) || defined(REV3) // TODO: check
-  uint32_t data = (ff_combined_present) & 0xFFFFFU;
+  uint32_t data = (ff_combined_present)&0xFFFFFU;
 #endif                               // REV1
   ff_USER_mask = read_eeprom_single(EEPROM_ID_FF_ADDR);
   ff_PRESENT_mask = data;
@@ -205,10 +205,10 @@ void readFFpresent(void)
   ff_bitmask_args[3].present_bit_mask = (~present_FFL4_F2_bar) & 0xFU;   // 4 bits
   ff_bitmask_args[2].present_bit_mask = (~present_FFL12_F2_bar) & 0x3FU; // 6 bits
 #elif defined(REV3)
-  present_FFL12_F1_bar = present_FFL12_F1_bar & 0xFFU;     // bottom 8 bits
-  present_FFL12_F2_bar = present_FFL12_F2_bar & 0xFFU;     // bottom 8 bits
-  present_FFL4_F1_bar = (present_FFL4_F1_bar >> 2) & 0x3U; // bits 2-3
-  present_FFL4_F2_bar = (present_FFL4_F2_bar >> 2) & 0x3U; // bits 2-3
+  present_FFL12_F1_bar = present_FFL12_F1_bar & 0xFFU;             // bottom 8 bits
+  present_FFL12_F2_bar = present_FFL12_F2_bar & 0xFFU;             // bottom 8 bits
+  present_FFL4_F1_bar = (present_FFL4_F1_bar >> 2) & 0x3U;         // bits 2-3
+  present_FFL4_F2_bar = (present_FFL4_F2_bar >> 2) & 0x3U;         // bits 2-3
 
   // active low
   uint32_t ff_combined_present_bar = ((present_FFL4_F2_bar) << 18) |  // 2 bits

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -37,7 +37,7 @@ void stopwatch_reset(void);
 #define configCPU_CLOCK_HZ                      40000000
 #define configMAX_PRIORITIES                    (5)
 #define configMINIMAL_STACK_SIZE                ((unsigned short)256)
-#define configTOTAL_HEAP_SIZE                   ((size_t)(36 * 1024))
+#define configTOTAL_HEAP_SIZE                   ((size_t)(24 * 1024))
 #define configMAX_TASK_NAME_LEN                 (6)
 #define configUSE_TRACE_FACILITY                1
 #define configUSE_16_BIT_TICKS                  0

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -60,7 +60,7 @@ void InitTask(void *parameters)
   }
   xQueueSendToBack(xLedQueue, &LED_STATUS_NORMAL, pdMS_TO_TICKS(10));
 
-  vTaskSuspend(NULL);
   // Delete this task
-  vTaskDelete(xTaskGetCurrentTaskHandle());
+  vTaskDelete(NULL);
+  __builtin_unreachable();
 }

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -147,6 +147,8 @@ MonI2C_addresses.c: ${MONI2C_YAML_FILES}
 ${COMPILER}/ZynqMon_addresses.o: ZynqMon_addresses.c
 ${COMPILER}/ZynqMonTask.o: ZynqMon_addresses.c
 ${COMPILER}/cm_mcu.o: ZynqMon_addresses.c
+${COMPILER}/ZynqCommands.o: ZynqMon_addresses.c
+
 # Same pattern for MonI2C_addresses: mon_generate.py produces both .c and .h,
 # so any .o that includes MonI2C_addresses.h must wait for the generator.
 ${COMPILER}/ZynqMonTask.o: MonI2C_addresses.c

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -141,12 +141,18 @@ MonI2C_addresses.c: ${MONI2C_YAML_FILES}
 	fi
 	@python ${ROOT}/sm_cm_config/src/mon_generate.py -o $@ ${MONI2C_YAML_FILES}
 
-
 # these rules are required to force the generation of the ZynqMon_addresses.c
 # and .h file. The second one depends on the .h file only, but putting that
 # in as a target causes the rule above to be called 2x. So we lie to make.
-${COMPILER}/ZynqMon_addresses.o: ZynqMon_addresses.c 
+${COMPILER}/ZynqMon_addresses.o: ZynqMon_addresses.c
 ${COMPILER}/ZynqMonTask.o: ZynqMon_addresses.c
+${COMPILER}/cm_mcu.o: ZynqMon_addresses.c
+# Same pattern for MonI2C_addresses: mon_generate.py produces both .c and .h,
+# so any .o that includes MonI2C_addresses.h must wait for the generator.
+${COMPILER}/ZynqMonTask.o: MonI2C_addresses.c
+${COMPILER}/MonUtils.o: MonI2C_addresses.c
+${COMPILER}/FireflyUtils.o: MonI2C_addresses.c
+${COMPILER}/FireflyCommands.o: MonI2C_addresses.c
 #
 # Rules for building the project
 # 

--- a/projects/cm_mcu/Tasks.h
+++ b/projects/cm_mcu/Tasks.h
@@ -269,57 +269,6 @@ extern QueueHandle_t xEPRMQueue_out;
 uint64_t EPRMMessage(uint64_t action, uint64_t addr, uint64_t data);
 void EEPROMTask(void *parameters);
 
-// -- ZynqMon
-// #define ZYNQMON_TEST_MODE
-// ZynqMon queue messages
-#define ZYNQMON_ENABLE_TRANSMIT  0x1
-#define ZYNQMON_DISABLE_TRANSMIT 0x2
-#define ZYNQMON_TEST_SINGLE      0x3
-#define ZYNQMON_TEST_INCREMENT   0x4
-#define ZYNQMON_TEST_OFF         0x5
-#define ZYNQMON_TEST_SEND_ONE    0x6
-#define ZYNQMON_TEST_RAW         0x7
-
-extern QueueHandle_t xZynqMonQueue;
-void ZynqMonTask(void *parameters);
-// data for zynqmon task to be sent to Zynq
-#define ZM_NUM_ENTRIES 1024
-struct zynqmon_data_t {
-  uint16_t sensor;
-  union convert_16_t {
-    uint16_t us;   // cppcheck-suppress unusedStructMember
-    uint8_t uc[2]; // cppcheck-suppress unusedStructMember
-    char c[2];     // cppcheck-suppress unusedStructMember
-    int16_t i;     // cppcheck-suppress unusedStructMember
-    __fp16 f;
-  } data;
-};
-
-extern struct zynqmon_data_t zynqmon_data[ZM_NUM_ENTRIES];
-
-void zm_fill_structs(void);
-void zm_set_firefly_temps(struct zynqmon_data_t data[], int start);
-void zm_set_gitversion(struct zynqmon_data_t data[], int start);
-void zm_set_uptime(struct zynqmon_data_t data[], int start);
-void zm_set_firefly_bits(struct zynqmon_data_t data[], int start);
-void zm_set_clkconfigversion(struct zynqmon_data_t data[], int start, int n);
-void zm_set_firefly_info(struct zynqmon_data_t data[], int start);
-void zm_set_adcmon(struct zynqmon_data_t data[], int start);
-void zm_set_psmon_legacy(struct zynqmon_data_t data[], int start);
-void zm_set_psmon(struct zynqmon_data_t data[], int start);
-void zm_set_clock(struct zynqmon_data_t data[], int start);
-void zm_set_fpga(struct zynqmon_data_t data[], int start);
-void zm_set_allclk(struct zynqmon_data_t data[], int start);
-void zm_set_firefly_optpow12(struct zynqmon_data_t data[], int start);
-void zm_set_firefly_optpow4(struct zynqmon_data_t data[], int start);
-
-#ifdef ZYNQMON_TEST_MODE
-void setZYNQMonTestData(uint8_t sensor, uint16_t value);
-uint8_t getZYNQMonTestMode(void);
-uint8_t getZYNQMonTestSensor(void);
-uint16_t getZYNQMonTestData(void);
-#endif // ZYNQMON_TEST_MODE
-
 // utility functions
 const uint32_t *getSystemStack(void);
 int SystemStackWaterHighWaterMark(void);

--- a/projects/cm_mcu/ZynqMonTask.c
+++ b/projects/cm_mcu/ZynqMonTask.c
@@ -29,10 +29,10 @@
 
 #include "Tasks.h"
 #include "MonitorTask.h"
-#include "clocksynth.h"
 #include "common/log.h"
 
 #include "ZynqMon_addresses.h"
+#include "ZynqMonTask.h"
 
 // Rev 2
 // this was split into a SoftUART version (Rev1) and a hard UART version (Rev2+)

--- a/projects/cm_mcu/ZynqMonTask.h
+++ b/projects/cm_mcu/ZynqMonTask.h
@@ -1,0 +1,66 @@
+#ifndef ZYNQMON_TASK_H_
+#define ZYNQMON_TASK_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "FreeRTOS.h" // IWYU pragma: keep
+#include "task.h"
+#include "queue.h"
+
+#include "ZynqMon_addresses.h"
+
+// -- ZynqMon
+// #define ZYNQMON_TEST_MODE
+// ZynqMon queue messages
+#define ZYNQMON_ENABLE_TRANSMIT  0x1
+#define ZYNQMON_DISABLE_TRANSMIT 0x2
+#define ZYNQMON_TEST_SINGLE      0x3
+#define ZYNQMON_TEST_INCREMENT   0x4
+#define ZYNQMON_TEST_OFF         0x5
+#define ZYNQMON_TEST_SEND_ONE    0x6
+#define ZYNQMON_TEST_RAW         0x7
+
+
+
+extern QueueHandle_t xZynqMonQueue;
+void ZynqMonTask(void *parameters);
+// data for zynqmon task to be sent to Zynq
+#define ZM_NUM_ENTRIES ZMON_VALID_ENTRIES
+struct zynqmon_data_t {
+  uint16_t sensor;
+  union convert_16_t {
+    uint16_t us;   // cppcheck-suppress unusedStructMember
+    uint8_t uc[2]; // cppcheck-suppress unusedStructMember
+    char c[2];     // cppcheck-suppress unusedStructMember
+    int16_t i;     // cppcheck-suppress unusedStructMember
+    __fp16 f;
+  } data;
+};
+
+extern struct zynqmon_data_t zynqmon_data[ZM_NUM_ENTRIES];
+
+void zm_fill_structs(void);
+void zm_set_firefly_temps(struct zynqmon_data_t data[], int start);
+void zm_set_gitversion(struct zynqmon_data_t data[], int start);
+void zm_set_uptime(struct zynqmon_data_t data[], int start);
+void zm_set_firefly_bits(struct zynqmon_data_t data[], int start);
+void zm_set_clkconfigversion(struct zynqmon_data_t data[], int start, int n);
+void zm_set_firefly_info(struct zynqmon_data_t data[], int start);
+void zm_set_adcmon(struct zynqmon_data_t data[], int start);
+void zm_set_psmon_legacy(struct zynqmon_data_t data[], int start);
+void zm_set_psmon(struct zynqmon_data_t data[], int start);
+void zm_set_clock(struct zynqmon_data_t data[], int start);
+void zm_set_fpga(struct zynqmon_data_t data[], int start);
+void zm_set_allclk(struct zynqmon_data_t data[], int start);
+void zm_set_firefly_optpow12(struct zynqmon_data_t data[], int start);
+void zm_set_firefly_optpow4(struct zynqmon_data_t data[], int start);
+
+#ifdef ZYNQMON_TEST_MODE
+void setZYNQMonTestData(uint8_t sensor, uint16_t value);
+uint8_t getZYNQMonTestMode(void);
+uint8_t getZYNQMonTestSensor(void);
+uint16_t getZYNQMonTestData(void);
+#endif // ZYNQMON_TEST_MODE
+
+#endif // ZYNQMON_TASK_H_

--- a/projects/cm_mcu/ZynqMonTask.h
+++ b/projects/cm_mcu/ZynqMonTask.h
@@ -21,8 +21,6 @@
 #define ZYNQMON_TEST_SEND_ONE    0x6
 #define ZYNQMON_TEST_RAW         0x7
 
-
-
 extern QueueHandle_t xZynqMonQueue;
 void ZynqMonTask(void *parameters);
 // data for zynqmon task to be sent to Zynq

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -281,7 +281,7 @@ __attribute__((noreturn)) int main(void)
   // start the tasks here
   xTaskCreate(PowerSupplyTask, "POW", 384, NULL, tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(LedTask, "LED", 128, NULL, tskIDLE_PRIORITY + 2, NULL);
-  xTaskCreate(vCommandLineTask, "CLIZY", 384, &cli_uart, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(vCommandLineTask, "CLIZY", 512, &cli_uart, tskIDLE_PRIORITY + 4, NULL);
 #ifdef REV1
   xTaskCreate(vCommandLineTask, "CLIFP", 384, &cli_uart4, tskIDLE_PRIORITY + 4, NULL);
 #endif // REV1

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -135,7 +135,7 @@ void SystemInitInterrupts(void)
 #if defined(REV1)
   initI2C6(g_ui32SysClock); // controller for FPGAs
 #elif defined(REV2) || defined(REV3)
-  initI2C5(g_ui32SysClock); // controller for FPGAs
+  initI2C5(g_ui32SysClock);  // controller for FPGAs
 #endif
 
   // smbus
@@ -279,35 +279,27 @@ __attribute__((noreturn)) int main(void)
     fpga_args.pm_values[i] = -999.f;
 
   // start the tasks here
-  xTaskCreate(PowerSupplyTask, "POW", 2 * configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(LedTask, "LED", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 2, NULL);
-  xTaskCreate(vCommandLineTask, "CLIZY", 512, &cli_uart, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(PowerSupplyTask, "POW", 384, NULL, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(LedTask, "LED", 128, NULL, tskIDLE_PRIORITY + 2, NULL);
+  xTaskCreate(vCommandLineTask, "CLIZY", 384, &cli_uart, tskIDLE_PRIORITY + 4, NULL);
 #ifdef REV1
-  xTaskCreate(vCommandLineTask, "CLIFP", 512, &cli_uart4, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(vCommandLineTask, "CLIFP", 384, &cli_uart4, tskIDLE_PRIORITY + 4, NULL);
 #endif // REV1
-  xTaskCreate(ADCMonitorTask, "ADC", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(ADCMonitorTask, "ADC", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
 
 #if defined(REV2) || defined(REV3)
-  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 4,
-              NULL);
-  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 4,
-              NULL);
-  xTaskCreate(MonitorTaskI2C, clk_args.name, configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 4,
-              NULL);
-
+  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(MonitorTaskI2C, clk_args.name, configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 4, NULL);
 #endif // REV2
-  xTaskCreate(MonitorTask, dcdc_args.name, configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
-              NULL);
-  xTaskCreate(MonitorTask, fpga_args.name, configMINIMAL_STACK_SIZE, &fpga_args, tskIDLE_PRIORITY + 4,
-              NULL);
-  xTaskCreate(I2CSlaveTask, "I2CS0", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(EEPROMTask, "EPRM", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(MonitorTask, dcdc_args.name, 192, &dcdc_args, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(MonitorTask, fpga_args.name, 192, &fpga_args, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(I2CSlaveTask, "I2CS0", 192, NULL, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(EEPROMTask, "EPRM", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
   xTaskCreate(InitTask, "INIT", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(ZynqMonTask, "ZMON", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(GenericAlarmTask, "TALM", configMINIMAL_STACK_SIZE, &tempAlarmTask,
-              tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(GenericAlarmTask, "VALM", configMINIMAL_STACK_SIZE, &voltAlarmTask,
-              tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(ZynqMonTask, "ZMON", 192, NULL, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(GenericAlarmTask, "TALM", 192, &tempAlarmTask, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(GenericAlarmTask, "VALM", 192, &voltAlarmTask, tskIDLE_PRIORITY + 5, NULL);
   //  xTaskCreate(WatchdogTask, "WATCH", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY, NULL);
 
   // -------------------------------------------------

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -135,7 +135,7 @@ void SystemInitInterrupts(void)
 #if defined(REV1)
   initI2C6(g_ui32SysClock); // controller for FPGAs
 #elif defined(REV2) || defined(REV3)
-  initI2C5(g_ui32SysClock);  // controller for FPGAs
+  initI2C5(g_ui32SysClock); // controller for FPGAs
 #endif
 
   // smbus

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -30,6 +30,7 @@
 #include "MonUtils.h"
 #include "Tasks.h"
 #include "AlarmUtilities.h"
+#include "ZynqMonTask.h"
 
 // TI Includes
 #include "driverlib/rom.h"
@@ -287,22 +288,22 @@ __attribute__((noreturn)) int main(void)
   xTaskCreate(ADCMonitorTask, "ADC", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
 
 #if defined(REV2) || defined(REV3)
-  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, 2 * configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, 2 * configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorTaskI2C, clk_args.name, 2 * configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTaskI2C, clk_args.name, configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 4,
               NULL);
 
 #endif // REV2
-  xTaskCreate(MonitorTask, dcdc_args.name, 2 * configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTask, dcdc_args.name, configMINIMAL_STACK_SIZE, &dcdc_args, tskIDLE_PRIORITY + 4,
               NULL);
-  xTaskCreate(MonitorTask, fpga_args.name, 2 * configMINIMAL_STACK_SIZE, &fpga_args, tskIDLE_PRIORITY + 4,
+  xTaskCreate(MonitorTask, fpga_args.name, configMINIMAL_STACK_SIZE, &fpga_args, tskIDLE_PRIORITY + 4,
               NULL);
   xTaskCreate(I2CSlaveTask, "I2CS0", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(EEPROMTask, "EPRM", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
   xTaskCreate(InitTask, "INIT", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(ZynqMonTask, "ZMON", 2 * configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(ZynqMonTask, "ZMON", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(GenericAlarmTask, "TALM", configMINIMAL_STACK_SIZE, &tempAlarmTask,
               tskIDLE_PRIORITY + 5, NULL);
   xTaskCreate(GenericAlarmTask, "VALM", configMINIMAL_STACK_SIZE, &voltAlarmTask,

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -14,8 +14,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <string.h>
-
 // local includes
 #include "FreeRTOSConfig.h"
 #include "common/LocalUart.h"
@@ -279,27 +277,27 @@ __attribute__((noreturn)) int main(void)
     fpga_args.pm_values[i] = -999.f;
 
   // start the tasks here
-  xTaskCreate(PowerSupplyTask, "POW", 384, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(LedTask, "LED", 128, NULL, tskIDLE_PRIORITY + 2, NULL);
-  xTaskCreate(vCommandLineTask, "CLIZY", 512, &cli_uart, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(PowerSupplyTask, "POW", 384, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(LedTask, "LED", 128, NULL, tskIDLE_PRIORITY + 1, NULL);
+  xTaskCreate(vCommandLineTask, "CLIZY", 512, &cli_uart, tskIDLE_PRIORITY + 3, NULL);
 #ifdef REV1
-  xTaskCreate(vCommandLineTask, "CLIFP", 384, &cli_uart4, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(vCommandLineTask, "CLIFP", 384, &cli_uart4, tskIDLE_PRIORITY + 3, NULL);
 #endif // REV1
-  xTaskCreate(ADCMonitorTask, "ADC", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(ADCMonitorTask, "ADC", 192, NULL, tskIDLE_PRIORITY + 3, NULL);
 
 #if defined(REV2) || defined(REV3)
-  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 4, NULL);
-  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 4, NULL);
-  xTaskCreate(MonitorTaskI2C, clk_args.name, configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTaskI2C, clk_args.name, configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 3, NULL);
 #endif // REV2
-  xTaskCreate(MonitorTask, dcdc_args.name, 192, &dcdc_args, tskIDLE_PRIORITY + 4, NULL);
-  xTaskCreate(MonitorTask, fpga_args.name, 192, &fpga_args, tskIDLE_PRIORITY + 4, NULL);
-  xTaskCreate(I2CSlaveTask, "I2CS0", 192, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(EEPROMTask, "EPRM", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
-  xTaskCreate(InitTask, "INIT", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(ZynqMonTask, "ZMON", 192, NULL, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(GenericAlarmTask, "TALM", 192, &tempAlarmTask, tskIDLE_PRIORITY + 5, NULL);
-  xTaskCreate(GenericAlarmTask, "VALM", 192, &voltAlarmTask, tskIDLE_PRIORITY + 5, NULL);
+  xTaskCreate(MonitorTask, dcdc_args.name, 192, &dcdc_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTask, fpga_args.name, 192, &fpga_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(I2CSlaveTask, "I2CS0", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(EEPROMTask, "EPRM", 192, NULL, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(InitTask, "INIT", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(ZynqMonTask, "ZMON", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(GenericAlarmTask, "TALM", 192, &tempAlarmTask, tskIDLE_PRIORITY + 4, NULL);
+  xTaskCreate(GenericAlarmTask, "VALM", 192, &voltAlarmTask, tskIDLE_PRIORITY + 4, NULL);
   //  xTaskCreate(WatchdogTask, "WATCH", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY, NULL);
 
   // -------------------------------------------------

--- a/projects/cm_mcu/commands/ClockCommands.c
+++ b/projects/cm_mcu/commands/ClockCommands.c
@@ -108,7 +108,7 @@ BaseType_t clk_freq_fpga_cmd(int argc, char **argv, char *m)
                        fpga + 1, test);
     // set up which input from clocks to use (R0A or R0B)
   }
-  char *names[] = {
+  static const char *names[] = {
       "rw0", "rw1", "clk_200_ext", "lhc_clk", "tcds40_clk", "rt_x4_r0_clk",
       "rt_x12_r0_clk", "lf_x4_r0_clk", "lf_x12_r0_clk", "clk_100", "clk_325",
       "rt_r0_p", "rt_r0_n", "rt_r0_l", "rt_r0_i", "rt_r0_g", "rt_r0_e", "rt_r0_b",
@@ -117,7 +117,7 @@ BaseType_t clk_freq_fpga_cmd(int argc, char **argv, char *m)
       "lf_r1_y", "lf_r1_w", "lf_r1_u", "lf_r1_r", "lf_r1_af", "lf_r1_ad", "lf_r1_ab"};
 
   // these values are from Table 2 of the Rev3 Synthesizer testing document. This corresponds to step 1.1.1
-  const uint32_t EXPECTED_FREQ_R0A_F1[] = {
+  static const uint32_t EXPECTED_FREQ_R0A_F1[] = {
       0, 0, 200000000, 40000000, 55000000, 280000000, 160000000,
       150000000, 300000000, 100000000, 325000000, 280000000, 160000000,
       200000000, 160000000, 280000000, 160000000, 160000000, 300000000,
@@ -126,7 +126,7 @@ BaseType_t clk_freq_fpga_cmd(int argc, char **argv, char *m)
       155000000, 163000000, 312000000, 176000000, 296000000, 168000000,
       132000000, 220000000};
 
-  const uint32_t EXPECTED_FREQ_R0A_F2[] = {
+  static const uint32_t EXPECTED_FREQ_R0A_F2[] = {
       0, 0, 200000000, 40000000, 55000000, 140000000, 320000000,
       130000000, 260000000, 100000000, 325000000, 140000000, 320000000,
       200000000, 320000000, 140000000, 320000000, 320000000, 260000000,
@@ -135,7 +135,7 @@ BaseType_t clk_freq_fpga_cmd(int argc, char **argv, char *m)
       310000000, 134000000, 336000000, 326000000, 268000000, 156000000,
       148000000, 110000000};
   // these values are from Table 2 of the Rev3 Synthesizer testing document. This corresponds to step 1.1.3
-  const uint32_t EXPECTED_FREQ_R0B_F1[] = {
+  static const uint32_t EXPECTED_FREQ_R0B_F1[] = {
       0, 0, 200000000, 40000000, 55000000, 270000000, 155000000,
       145000000, 290000000, 100000000, 325000000, 270000000, 155000000,
       200000000, 155000000, 270000000, 155000000, 155000000, 290000000,
@@ -144,7 +144,7 @@ BaseType_t clk_freq_fpga_cmd(int argc, char **argv, char *m)
       155000000, 163000000, 312000000, 176000000, 296000000, 168000000,
       132000000, 220000000};
 
-  const uint32_t EXPECTED_FREQ_R0B_F2[] = {
+  static const uint32_t EXPECTED_FREQ_R0B_F2[] = {
       0, 0, 200000000, 40000000, 55000000, 135000000, 310000000,
       125000000, 250000000, 100000000, 325000000, 135000000, 310000000,
       200000000, 310000000, 135000000, 310000000, 310000000, 250000000,

--- a/projects/cm_mcu/commands/SoftwareCommands.c
+++ b/projects/cm_mcu/commands/SoftwareCommands.c
@@ -64,8 +64,10 @@ BaseType_t stack_ctl(int argc, char **argv, char *m)
 
 BaseType_t mem_ctl(int argc, char **argv, char *m)
 {
-  size_t heapSize = xPortGetFreeHeapSize();
-  snprintf(m, SCRATCH_SIZE, "heap: %u bytes\r\n", heapSize);
+  size_t heapFree = xPortGetFreeHeapSize();
+  size_t heapMin = xPortGetMinimumEverFreeHeapSize();
+  snprintf(m, SCRATCH_SIZE, "heap: %u free, %u min free (peak usage %u)\r\n",
+           heapFree, heapMin, configTOTAL_HEAP_SIZE - heapMin);
   return pdFALSE;
 }
 

--- a/projects/cm_mcu/commands/ZynqCommands.c
+++ b/projects/cm_mcu/commands/ZynqCommands.c
@@ -10,6 +10,7 @@
 #include "commands/parameters.h"
 #include "Tasks.h"
 #include "projdefs.h"
+#include "ZynqMonTask.h"
 
 BaseType_t zmon_ctl(int argc, char **argv, char *m)
 {

--- a/sm_cm_config/src/mcu_generate.py
+++ b/sm_cm_config/src/mcu_generate.py
@@ -48,7 +48,7 @@ with open(args.output, 'w', encoding="ascii") as fout:
     print(f"// Generated: {timestamp}", file=fout)
     print(r"//", file=fout)
 
-    print("#include \"Tasks.h\"", file=fout)
+    print("#include \"ZynqMonTask.h\"", file=fout)
     # include the header file we will write later
     print(f"#include \"{header_fname}\"", file=fout)
 


### PR DESCRIPTION
Cleanup: refactor and reduce BSS size. 

Key changes include:

**Build System and Dependency Updates:**
- Updated the `Makefile` to ensure that any object files depending on `MonI2C_addresses.h` or `ZynqMon_addresses.h` are correctly rebuilt when the generated source files change, preventing stale dependencies in the build. Was an issue for parallel builds.

**Memory and Task Stack Improvements:**
- Set explicit stack sizes for all tasks in `cm_mcu.c` 
- Reduced the FreeRTOS heap size from 36 KB to 24 KB in `FreeRTOSConfig.h` to optimize for actual usage. About 6 kB safety margin now. 

**Code Quality and Safety Improvements:**
- Delete `InitTask` after it runs. Previously it suspended itself and was never deleted. 
- Changed some local arrays in `ClockCommands.c` from non-static to static to avoid unnecessary stack usage. 
- Move Zynqmontask headers out of Tasks.h to its own file, and reserve exactly how much space we need for zynqmon (was generous by 2x before)

**Diagnostics and Reporting:**
- Enhanced the memory control command `mem` to report both current free heap and minimum-ever free heap