### PR TITLE
Speed up I2C master by changing from polling to notification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 ## Project Overview
 
-This repository contains bare-metal firmware for the **Apollo command module**, targeting the **TI Tiva TM4C1290NCPDT** (ARM Cortex-M4F with FPU, 80 MHz). The firmware manages power sequencing, temperature/voltage monitoring, I2C communication, and FPGA/Firefly control for high-energy physics detector readout systems. It controls low-level functionality of the command module of an ATCA blade. The blade is to be used at the HL-LHC.
+This repository contains bare-metal firmware for the **Apollo command module**, targeting the **TI Tiva TM4C1290NCPDT** (ARM Cortex-M4F with FPU, running at 40 MHz). The firmware manages power sequencing, temperature/voltage monitoring, I2C communication, and FPGA/Firefly control for high-energy physics detector readout systems. It controls low-level functionality of the command module of an ATCA blade. The blade is to be used at the HL-LHC.
 
 ## Hardware
 
@@ -269,6 +269,8 @@ Uninitialized EEPROM words read as `0xFFFFFFFF`. Code that loads EEPROM config m
 
 **I2C bus assignments** (initialized in `SystemInit()`):
 
+These are for Rev2 and later. 
+
 | Bus | Role |
 | --- | ---- |
 | I2C0 | I2C slave (responds to external master) |
@@ -276,7 +278,7 @@ Uninitialized EEPROM words read as `0xFFFFFFFF`. Code that loads EEPROM config m
 | I2C2 | SMBus master → clock synthesizers |
 | I2C3 | SMBus master → F2 Firefly optics |
 | I2C4 | SMBus master → F1 Firefly optics |
-| I2C5 | SMBus master → F1 Firefly optics (additional) |
+| I2C5 | SMBus master → FPGA F1 & F2 diagnostic registers |
 
 **prod_test CLI commands:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,7 @@ A `.gdbinit` file is provided: `cm_mcu.gdbinit`. Connect via Segger J-LINK EDU.
 
 ## Development Notes for AI Assistants
 
-- **Don't fix or fret about code formatting** (`clang-format` / `make format`). The maintainer handles formatting separately — `clang-format` is fiddly and sensitive to exact version mismatches. Write reasonable code and leave formatting cleanup to them; do not run `format-apply` or block on format errors.
+- **Don't fix or fret about code formatting** (`clang-format` / `make format`). The maintainer handles formatting separately — `clang-format` is fiddly and sensitive to exact version mismatches. Write reasonable code and leave formatting cleanup to them; do not run `format-apply` or block on format errors. Let the maintainer run the build tests.
 - Integers: use `uint32_t`, `int32_t`, etc. — not bare `int` for register-width values
 - Float-to-uint32 conversion for EEPROM: use `memcpy(&u32, &f, sizeof(float))` — not union type-punning
 - All EEPROM writes from tasks must use `write_eeprom()` (queue-based), never direct driver calls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,46 @@ The firmware uses a FreeRTOS multi-task architecture. All significant work happe
 - `LedTask` — status LED blink patterns
 - `I2CSlaveTask` — responds to commands from an external I2C master
 
+### cm_mcu: I2C/SMBus Architecture (notification-based)
+
+The codebase was converted from polling to interrupt-driven (notification-based) I2C. Each I2C master bus (1–6) has:
+
+- A global `tSMBus g_sMasterN` struct (defined in `InterruptHandlers.c`)
+- A global `volatile tSMBusStatus eStatusN` for the per-bus completion status
+- An entry in `pSMBus[10]` and `eStatus[10]` lookup arrays (index = bus number, 0/7–9 are NULL)
+- A dedicated ISR (`SMBusMasterIntHandlerN`) that calls the shared `SMBusMasterIntHandlerCore`
+
+**Transaction flow:**
+
+```c
+i2c_arm_notify_slot(device);        // stores xTaskGetCurrentTaskHandle() in TaskNotifySMBus[device]
+r = SMBusMasterXxx(...);            // initiates transfer; returns SMBUS_PERIPHERAL_BUSY if hw busy
+if (r == SMBUS_OK) {
+    i2c_wait_for_transfer(device);  // ulTaskNotifyTake with 250ms timeout
+    r = *eStatus[device];           // ISR wrote the final status here
+} else {
+    TaskNotifySMBus[device] = NULL; // clean up if initiation failed
+}
+```
+
+The ISR (`SMBusMasterIntHandlerCore`, `InterruptHandlers.c:194`) calls `SMBusMasterIntProcess` (the TI state machine), then — if `FLAG_TRANSFER_IN_PROGRESS` is cleared AND `TaskNotifySMBus[device] != NULL` — calls `vTaskNotifyGiveFromISR` and nulls the slot.
+
+**Bus locking:** Each bus has a FreeRTOS mutex (`i2c1_sem` … `i2c6_sem`, defined in `Semaphore.c`). Callers acquire the mutex before a transaction sequence and release it after. Two helpers are provided:
+- `acquireI2CSemaphore(s)` — tries up to 500 times with a 10-tick wait each try
+- `acquireI2CSemaphoreBlock(s)` — tries up to 500 times with a 0-tick wait (immediate poll each try)
+
+The mutex is passed as part of the task argument struct (`args->xSem`) in `MonitorTask` and `MonitorTaskI2C`, and accessed directly by name in `LocalTasks.c`.
+
+**`apollo_pmbus_rw`** performs two sequential transactions on the same bus: a mux-select write (`apollo_i2c_ctl_w`) followed by the device read/write (`SMBusMasterByteWordRead/Write`). It re-arms the notify slot between them.
+
+**Known fragility in the notification scheme** — see [`i2c_lockup_notes.md`](i2c_lockup_notes.md) for full analysis:
+
+1. *Hardware-timeout / auto-STOP race* — When `I2C_MASTER_INT_TIMEOUT` fires (35ms SMBus hw timeout, e.g. slave stretching clock), the ISR clears `FLAG_TRANSFER_IN_PROGRESS` and immediately notifies the task, but the hardware then issues an automatic STOP that takes ~2.5–20 μs (400–100 kHz). A context switch lands the task before the STOP completes; the next `SMBusMasterXxx` call sees `MAP_I2CMasterBusy() == true` → `SMBUS_PERIPHERAL_BUSY`.
+
+2. *`SMBUS_STATE_IDLE` conditional clear* — For write-only transactions, `FLAG_TRANSFER_IN_PROGRESS` is cleared in the `SMBUS_STATE_IDLE` ISR case only if `!MAP_I2CMasterBusy()` (`smbus.c:2440`). If the DATA interrupt fires while BUSY is briefly still asserted (possible race), the flag stays set and no further ISR fires. The FreeRTOS 250ms timeout then fires; a late ISR arriving after the next `i2c_arm_notify_slot` can deliver a spurious notification, causing the following transaction to see PERIPHERAL_BUSY.
+
+3. *NACK error status overwrite* — On address/data NACK, the first ISR issues `BURST_SEND_ERROR_STOP` but does not clear the flag or notify. A second ISR fires in `SMBUS_STATE_IDLE`, clears the flag, and returns `SMBUS_OK`, overwriting the NACK error in `eStatusN`. The caller sees `SMBUS_OK` on a failed transaction.
+
 ### cm_mcu: EEPROM Access Pattern
 
 > **This pattern applies only to cm_mcu**, which has a dedicated `EEPROMTask` gatekeeper. The `prod_test` project does not use this pattern.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,7 @@ A `.gdbinit` file is provided: `cm_mcu.gdbinit`. Connect via Segger J-LINK EDU.
 
 ## Development Notes for AI Assistants
 
+- **Don't fix or fret about code formatting** (`clang-format` / `make format`). The maintainer handles formatting separately — `clang-format` is fiddly and sensitive to exact version mismatches. Write reasonable code and leave formatting cleanup to them; do not run `format-apply` or block on format errors.
 - Integers: use `uint32_t`, `int32_t`, etc. — not bare `int` for register-width values
 - Float-to-uint32 conversion for EEPROM: use `memcpy(&u32, &f, sizeof(float))` — not union type-punning
 - All EEPROM writes from tasks must use `write_eeprom()` (queue-based), never direct driver calls

--- a/common/log.c
+++ b/common/log.c
@@ -321,7 +321,6 @@ static void init_event(log_Event *ev, void *udata)
 void log_log(int level, const char *file, int line, enum log_facility_t facility,
              const char *fmt, ...)
 {
-  volatile int level_chk = level;
   log_Event ev = {
       .fmt = fmt,
       .file = file,

--- a/common/log.c
+++ b/common/log.c
@@ -185,6 +185,9 @@ void log_dump(void (*f)(const char *s))
   f("\033[0m\r\n"); // turn off color and add a newline to ensure that everything is cleaned up.
 }
 
+static bool lock(void);
+static void unlock(void);
+
 void ApolloLog(log_Event *ev)
 {
   // note to self: before you change the size of this buffer
@@ -203,17 +206,25 @@ void ApolloLog(log_Event *ev)
   r += snprintf(tmp + r, SZ - r, "%s", "\033[0m");
 #endif
   configASSERT(r < SZ); // not the best way to go but ....
-  log_add_string(tmp, &b);
+  // Only the shared ring buffer needs protection, and only briefly. If we
+  // cannot get the lock (near-impossible at 0-tick contention), drop the
+  // buffer append rather than block; the UART output below is unaffected and
+  // self-serializes via xUARTMutex in Print().
+  if (lock()) {
+    log_add_string(tmp, &b);
+    unlock();
+  }
   Print(tmp);
 }
 
 // apollo log specfic functions end
 
-static void lock(void)
+static bool lock(void)
 {
   if (L.lock) {
-    L.lock(true, L.udata);
+    return L.lock(true, L.udata);
   }
+  return true; // no lock configured -> proceed
 }
 
 static void unlock(void)
@@ -319,7 +330,6 @@ void log_log(int level, const char *file, int line, enum log_facility_t facility
       .fac = facility,
   };
 
-  lock();
   if (facility >= NUM_LOG_FACILITIES) {
     facility = LOG_DEFAULT; //
   }
@@ -348,6 +358,4 @@ void log_log(int level, const char *file, int line, enum log_facility_t facility
       }
     }
   }
-
-  unlock();
 }

--- a/common/log.c
+++ b/common/log.c
@@ -333,13 +333,6 @@ void log_log(int level, const char *file, int line, enum log_facility_t facility
   if (facility >= NUM_LOG_FACILITIES) {
     facility = LOG_DEFAULT; //
   }
-  if (level != level_chk) {
-#ifdef GET_LR                     // not defined for prod_test e.g.
-    volatile void *lr = GET_LR(); // who called log_log
-    (void)lr;
-#endif
-    __asm volatile("bkpt #0");
-  }
   if (!L.quiet && level <= L.level[facility]) {
     init_event(&ev, NULL);
     va_start(ev.ap, fmt);

--- a/common/log.c
+++ b/common/log.c
@@ -334,11 +334,11 @@ void log_log(int level, const char *file, int line, enum log_facility_t facility
     facility = LOG_DEFAULT; //
   }
   if (level != level_chk) {
-#ifdef GET_LR // not defined for prod_test e.g.
-    volatile void *lr = GET_LR();   // who called log_log
+#ifdef GET_LR                     // not defined for prod_test e.g.
+    volatile void *lr = GET_LR(); // who called log_log
     (void)lr;
 #endif
-    __asm volatile ("bkpt #0");
+    __asm volatile("bkpt #0");
   }
   if (!L.quiet && level <= L.level[facility]) {
     init_event(&ev, NULL);

--- a/common/log.c
+++ b/common/log.c
@@ -310,6 +310,7 @@ static void init_event(log_Event *ev, void *udata)
 void log_log(int level, const char *file, int line, enum log_facility_t facility,
              const char *fmt, ...)
 {
+  volatile int level_chk = level;
   log_Event ev = {
       .fmt = fmt,
       .file = file,
@@ -322,7 +323,13 @@ void log_log(int level, const char *file, int line, enum log_facility_t facility
   if (facility >= NUM_LOG_FACILITIES) {
     facility = LOG_DEFAULT; //
   }
-
+  if (level != level_chk) {
+#ifdef GET_LR // not defined for prod_test e.g.
+    volatile void *lr = GET_LR();   // who called log_log
+    (void)lr;
+#endif
+    __asm volatile ("bkpt #0");
+  }
   if (!L.quiet && level <= L.level[facility]) {
     init_event(&ev, NULL);
     va_start(ev.ap, fmt);

--- a/common/log.h
+++ b/common/log.h
@@ -49,7 +49,7 @@ typedef struct {
 } log_Event;
 
 typedef void (*log_LogFn)(log_Event *ev);
-typedef void (*log_LockFn)(bool lock, void *udata);
+typedef bool (*log_LockFn)(bool lock, void *udata);
 
 #define log_trace(LOG_FACILITY, ...) log_log(LOG_TRACE, __FILE_NAME__, __LINE__, LOG_FACILITY, __VA_ARGS__)
 #define log_debug(LOG_FACILITY, ...) log_log(LOG_DEBUG, __FILE_NAME__, __LINE__, LOG_FACILITY, __VA_ARGS__)

--- a/common/smbus_helper.c
+++ b/common/smbus_helper.c
@@ -65,3 +65,6 @@ const char *SMBUS_get_error(tSMBusStatus error)
       break;
   }
 }
+
+// provide external linkage to this inline function
+extern inline bool SMBUS_is_NACK(tSMBusStatus error);

--- a/common/smbus_helper.h
+++ b/common/smbus_helper.h
@@ -3,4 +3,10 @@
 #include "smbus.h"
 const char *SMBUS_get_error(tSMBusStatus error);
 
+// Check if the SMBus error is a NACK (Not Acknowledge) error
+inline bool SMBUS_is_NACK(tSMBusStatus error)
+{
+  return (error == SMBUS_DATA_ACK_ERROR) || (error == SMBUS_ADDR_ACK_ERROR);
+}
+
 #endif // SMBUS_HELPER_H

--- a/common/utils.h
+++ b/common/utils.h
@@ -194,4 +194,11 @@ inline unsigned long long maxull(unsigned long long const x, unsigned long long 
        double: fabs)(n))
 // clang-format on
 
+#ifdef USE_FREERTOS
+// busy-loop a delay from Tivaware ROM. SysCtlDelay is 3 clock cyles.
+// round the us number with this arithmetic.
+#define DELAY_US(us) \
+  ROM_SysCtlDelay((((us)*configCPU_CLOCK_HZ) + 1500000UL) / 3000000UL)
+#endif // USE_FREERTOS
+
 #endif /* COMMON_UTILS_H_ */

--- a/common/utils.h
+++ b/common/utils.h
@@ -198,7 +198,7 @@ inline unsigned long long maxull(unsigned long long const x, unsigned long long 
 // busy-loop a delay from Tivaware ROM. SysCtlDelay is 3 clock cyles.
 // round the us number with this arithmetic.
 #define DELAY_US(us) \
-  ROM_SysCtlDelay((((us)*configCPU_CLOCK_HZ) + 1500000UL) / 3000000UL)
+  ROM_SysCtlDelay((((us) * configCPU_CLOCK_HZ) + 1500000UL) / 3000000UL)
 #endif // USE_FREERTOS
 
 #endif /* COMMON_UTILS_H_ */

--- a/i2c_lockup_notes.md
+++ b/i2c_lockup_notes.md
@@ -1,0 +1,193 @@
+# I2C Rare Lockup / PERIPHERAL_BUSY Analysis
+
+**Branch:** `hotfix/stale_temp_alarm`  
+**Observed symptom:** Occasional `SMBUS_PERIPHERAL_BUSY` returns from `SMBusMasterXxx` initiation
+functions, approximately every 13 minutes (high variance) despite hundreds of I2C transactions per
+second.
+
+---
+
+## Background: notification-based I2C
+
+The branch switched from polling (`SMBusStatusGet` spin loop) to FreeRTOS task notifications.  The
+pattern in `I2CCommunication.c`:
+
+```c
+i2c_arm_notify_slot(device);        // stores current task handle in TaskNotifySMBus[device]
+r = SMBusMasterXxx(...);            // initiates hw transfer; SMBUS_PERIPHERAL_BUSY if hw busy
+if (r == SMBUS_OK) {
+    i2c_wait_for_transfer(device);  // ulTaskNotifyTake, 250 ms FreeRTOS timeout
+    r = *eStatus[device];           // ISR wrote final status here
+} else {
+    TaskNotifySMBus[device] = NULL;
+}
+```
+
+The ISR (`SMBusMasterIntHandlerCore`, `InterruptHandlers.c:194`) calls `SMBusMasterIntProcess`,
+then — if `FLAG_TRANSFER_IN_PROGRESS` is cleared **and** `TaskNotifySMBus[device] != NULL` —
+calls `vTaskNotifyGiveFromISR` and nulls the slot.
+
+`SMBUS_PERIPHERAL_BUSY` is returned by every `SMBusMasterXxx` initiation function when
+`MAP_I2CMasterBusy()` (hardware BUSY bit) returns true at function entry.
+
+---
+
+## Root cause candidates
+
+### 1. Hardware-timeout ISR notifies task before auto-STOP completes (primary suspect)
+
+**Where:** `SMBusMasterIntProcess`, `smbus.c:2312–2331`
+
+```c
+if (ui32IntStatus & I2C_MASTER_INT_TIMEOUT) {
+    MAP_I2CMasterIntClearEx(..., I2C_MASTER_INT_TIMEOUT | I2C_MASTER_INT_DATA);
+    HWREGBITB(&psSMBus->ui16Flags, FLAG_TRANSFER_IN_PROGRESS) = 0;
+    return SMBUS_TIMEOUT;
+    // comment: "peripheral will automatically issue a stop, just clear and return"
+}
+```
+
+**Race:**
+1. SMBus 35 ms hardware timeout fires (slave stretching SCL, or bus anomaly — consistent
+   with HL-LHC environment).
+2. ISR clears `FLAG_TRANSFER_IN_PROGRESS`, returns `SMBUS_TIMEOUT`.
+3. `SMBusMasterIntHandlerCore` sends task notification; `portYIELD_FROM_ISR` context-switches
+   to the waiting task within ~1–5 µs (80 MHz CPU).
+4. Hardware is still issuing its automatic STOP on the bus (~2.5–20 µs at 400–100 kHz).
+5. Task calls the next `apollo_i2c_ctl_xxx` → `SMBusMasterXxx` → `MAP_I2CMasterBusy()` = **true**
+   → **`SMBUS_PERIPHERAL_BUSY`**.
+
+**Why rare:** the 35 ms hardware timeout only fires when a slave holds SCL low past the SMBus
+limit; the context-switch window vs. STOP duration is only a few microseconds.
+
+**Fix direction:** after the timeout ISR, spin-wait on `MAP_I2CMasterBusy()` before notifying,
+or add a brief guard in `i2c_wait_for_transfer` / at the start of each `apollo_i2c_ctl_xxx`.
+
+---
+
+### 2. `SMBUS_STATE_IDLE` conditional flag clear creates a dead end for write transactions
+
+**Where:** `SMBusMasterIntProcess`, `smbus.c:2433–2451`
+
+```c
+case SMBUS_STATE_IDLE:
+    if (!MAP_I2CMasterBusy(psSMBus->ui32I2CBase))   // conditional — unlike every other state
+        HWREGBITB(&psSMBus->ui16Flags, FLAG_TRANSFER_IN_PROGRESS) = 0;
+    break;
+```
+
+Write-only transactions end in `WRITE_FINAL` → `BURST_SEND_FINISH` → state set to `IDLE`.  The
+subsequent DATA ISR enters this case.  All other terminal states (`READ_WAIT`, `READ_ERROR_STOP`)
+clear `FLAG_TRANSFER_IN_PROGRESS` unconditionally.
+
+If the DATA interrupt fires while the hardware BUSY bit is still asserted (possible if the
+interrupt assertion and BUSY-clear are not perfectly synchronous), the flag stays set and **no
+further ISR is generated**.  The FreeRTOS 250 ms timeout then fires:
+
+1. `TaskNotifySMBus[device] = NULL` (timeout handler).
+2. Caller starts next transaction: `i2c_arm_notify_slot(device)` sets a new non-NULL handle.
+3. Late ISR from the previous stuck transaction fires in this window → sees non-NULL handle →
+   sends **spurious notification** → nulls the slot.
+4. The new `SMBusMasterXxx` succeeds (hardware is now idle).
+5. `ulTaskNotifyTake` returns immediately on the spurious count without waiting for the new ISR.
+6. Task reads stale `*eStatus`, proceeds to another transaction.
+7. New transaction's ISR fires, sees NULL handle, does not notify.
+8. Yet another transaction starts: hardware still in previous transfer → **`SMBUS_PERIPHERAL_BUSY`**.
+
+---
+
+### 3. NACK error recovery overwrites error status with `SMBUS_OK` (latent correctness bug)
+
+**Where:** `SMBusMasterIntProcess`, `smbus.c:2369–2421`
+
+On address or data NACK with bus still busy, the ISR issues `BURST_SEND_ERROR_STOP` and returns
+the NACK error **without** clearing `FLAG_TRANSFER_IN_PROGRESS`.  A second ISR fires (IDLE state
+after STOP), clears the flag, and returns `SMBUS_OK`.  `SMBusMasterIntHandlerCore` overwrites
+`*status` with `SMBUS_OK`; the task sees a successful transaction despite the NACK.
+
+Not a direct cause of PERIPHERAL_BUSY, but masks real errors.
+
+---
+
+### 4. Double-logging / missing early return on initiation failure
+
+**Where:** all four `apollo_i2c_ctl_xxx` functions in `I2CCommunication.c`
+
+When `SMBusMasterXxx` returns a non-OK status (initiation failed), the `else` branch logs the
+error but then falls through to a second `if (r != SMBUS_OK)` block that logs again.  Adding
+`return r` in the `else` branch eliminates the duplicate log and makes the early exit explicit.
+`apollo_pmbus_rw` already handles this correctly.
+
+---
+
+## Summary table
+
+| # | Location | Mechanism | Direct cause of PERIPHERAL_BUSY? |
+|---|----------|-----------|----------------------------------|
+| 1 | `smbus.c:2312` timeout ISR | task resumes before auto-STOP finishes | **Yes — primary** |
+| 2 | `smbus.c:2440` IDLE case | stuck flag → FreeRTOS timeout → spurious late notification | Yes — secondary |
+| 3 | `smbus.c:2369` NACK recovery | error status overwritten with OK | No (correctness bug) |
+| 4 | `I2CCommunication.c` else branches | double log, no early return | No — **fixed in `c8f8c45`** (early `return r`) |
+
+---
+
+## Overnight run analysis (2026-05-29 14:30 → 05-30 08:26, ~17.9 h)
+
+Captured on commit `c8f8c45` ("chase rare errors in i2c transactions"). **Important:** the board
+was running a *dirty/uncommitted* build of that same code, so the log already includes the
+TCA9548A mux-reset mitigation and the early-`return r` fix. The overnight log is therefore an
+unintended A/B test of the mux-reset.
+
+### Frequency
+
+- 77 `PERIPHERAL_BUSY` events / 17.9 h ⇒ **mean spacing 14.2 min** (matches the "~13 min" estimate).
+- Inter-arrival stdev (13.1 min) ≈ mean (14.2 min) ⇒ **memoryless / Poisson** — sporadic random
+  event, not periodic.
+- First half 34 vs second half 43, ~4/hr every hour ⇒ **stationary, no overnight degradation**
+  (the bus is not slowly wedging).
+
+### Breakdown by instance / op / slot
+
+| Instance | Bus (`dev`) | Events | Failing op | Dominant slot (`ps`) |
+|----------|-------------|--------|------------|----------------------|
+| CLK   | 2 | 40 (52%) | **mux write** (single-byte W) | ps=3 (33/40) |
+| FF_F2 | 3/4 | 21 (27%) | **read** CHANNEL_DISABLE | ps=1 (15) |
+| FF_F1 | 3/4 | 16 (21%) | **read** CHANNEL_DISABLE | ps=7 (10), ps=9 (6) |
+
+`ps` is the **loop index** into the instance's device table (`MonitorTaskI2C.c` lines 105/143/160),
+**not** the I2C slave address. The failing transaction is always the *first one issued right after
+the previous one completed*: CLK's mux-select (line 105) follows the prior device's mux-clear
+(line 166); FF's CHANNEL_DISABLE is the first read after the mux+page write→read turnaround. Both
+are classic STOP-race positions.
+
+### Why this points at the on-chip master FSM (hypothesis b), not the external mux (a)
+
+1. Each instance is one task on its own I2C peripheral, holding that bus's mutex for the whole
+   sweep ⇒ no cross-task contention. `PERIPHERAL_BUSY` is `MAP_I2CMasterBusy()` at the *top* of
+   `SMBusMasterXxx`, **before any bus access** (`SMBUS_BUS_BUSY`/`ADDR_ACK` come later). So it is
+   the on-chip master not yet idle from the *previous* transaction — the auto-STOP / state-machine
+   race.
+2. **The mux-reset mitigation was live and did not help** — rate stayed flat (~4/hr) with no decay.
+   A wedged TCA9548A would have been cured or changed signature by the reset.
+3. **Failures are isolated, not runs.** A stuck mux/bus would fail consecutive 250 ms sweeps until
+   reset; instead we see single events minutes apart, each followed by clean sweeps ⇒ the bus was
+   never staying wedged.
+4. The mux-reset resets the external chip, but `PERIPHERAL_BUSY` originates on the TM4C master
+   before it touches the mux ⇒ likely a no-op for this status (keep it only as a `BUS_BUSY`
+   fallback).
+
+**Caveat the log cannot resolve:** we can't *prove* the reset wasn't silently rescuing a real wedge
+each time (turning a would-be hang into one logged event). The diagnostic below settles it.
+
+### Diagnostic plan (to confirm a vs b on the next run)
+
+Instrument `I2CCommunication.c`:
+- **Bounded idle-wait** folded into `i2c_arm_notify_slot` (the choke point all wrappers + 
+  `apollo_pmbus_rw` use before initiating): `while (MAP_I2CMasterBusy(base) && us < 250) DELAY_US(1)`.
+  If errors vanish across **all** instances/slots ⇒ confirmed (b); demote mux-reset to a fallback.
+  If a specific `ps` still fails ⇒ that physical device is marginal (a).
+- **Capture raw `MCS` at the failure site, before the mux reset toggles:** log `BUSY` vs `BUSBSY`
+  (`HWREG(base + I2C_O_MCS)`, bits `I2C_MCS_BUSY` / `I2C_MCS_BUSBSY` from `inc/hw_i2c.h`).
+  `BUSY` only ⇒ on-chip ⇒ (b); `BUSBSY` ⇒ line held externally ⇒ (a).
+- **Close the logging gap:** the read path (`I2CCommunication.c:121`) logs neither bus nor slave
+  address; add `address` so failures map to a physical port, not just a `ps` slot index.

--- a/i2c_lockup_notes.md
+++ b/i2c_lockup_notes.md
@@ -191,3 +191,71 @@ Instrument `I2CCommunication.c`:
   `BUSY` only ⇒ on-chip ⇒ (b); `BUSBSY` ⇒ line held externally ⇒ (a).
 - **Close the logging gap:** the read path (`I2CCommunication.c:121`) logs neither bus nor slave
   address; add `address` so failures map to a physical port, not just a `ps` slot index.
+
+---
+
+## Companion anomaly: a `log_debug` printed once at `FTL` level (silent memory corruption)
+
+Observed in the same overnight log, exactly once:
+
+```
+202605291910 MONI2C FTL MonitorTaskI2C.c:125:FF_F2: command OPT_POWER_CH7 not for device 8 (mask: 8 this: 4)
+```
+
+The source at that line is a **`log_debug`** call (level `LOG_DEBUG == 4`), yet it printed and was
+tagged `FTL` (`LOG_FATAL == 0`). Debug is normally suppressed for `MONI2C`.
+
+### Why this is proof of a flipped value, not a config change
+
+In `common/log.c`:
+- gate (line 326): `if (!L.quiet && level <= L.level[facility])`
+- tag (line 200): `level_strings[ev->level]`, with `level_strings[0] == "FTL"`
+
+For the line to **print and read `FTL`**, `level` had to be `0` both at the gate and in `ApolloLog`
+(`ev.level` is set `= level` at line 317, before both uses). `0 <= L.level[fac]` is true for any
+threshold — which is exactly why a normally-suppressed debug line printed. So a single transient
+corruption flipped the `level` value **4 → 0** inside `log_log`'s stack frame. Logging merely
+*surfaced* a stray write into the calling task's stack frame; it is not a logging bug.
+
+### Ruled out
+- **Not a log-config change**: no `log_set_lock` is ever installed, no level change.
+- **Not interrupt-priority misconfig**: all I2C ISRs are at `configKERNEL_INTERRUPT_PRIORITY`
+  (`cm_mcu.c:152–178`), same as ADC/UART → legal for `...FromISR`.
+- **Not classic task-stack overflow**: `configCHECK_FOR_STACK_OVERFLOW=2` is on and high-water shows
+  >100 words free on every MonitorI2C task. (But high-water/end-canary do **not** catch a *localized*
+  OOB write that lands inside the still-valid stack — so this does not exonerate a stray write.)
+
+### Likely cause and relation to PERIPHERAL_BUSY
+The `FTL` flip needs a write into the **task's own stack frame** (a stack local). That points away
+from the ISR (context is HW-saved, priorities correct) and toward a **localized OOB write in the
+MonitorI2C task context**, most economically fed by the *same* not-airtight completion handshake
+(#2/#3): a spurious/late notification or NACK-overwritten-as-OK lets `ulTaskNotifyTake` return with
+**stale/garbage data**, which is then used as an index/size. Amplifiers in the path:
+- `devtype = 31 - __builtin_clz(devtype_mask)` (`MonitorTaskI2C.c:119`): if `devtype_mask == 0`,
+  `__builtin_clz(0)` is **undefined** → huge `devtype` → wild `commands[c].page[devtype]` /
+  `command[devtype]` indexing.
+- data-derived indices into `storeData(..., device)` etc.
+
+Contributing latent bug (parallel, not the flip itself): **`log_log` is not thread-safe** — no lock
+installed, so every task writes the shared global ring buffer `b`/`log_buffer` with no mutual
+exclusion. Benign under the old `vTaskDelay` cadence; genuinely concurrent now. Corrupts globals
+(saved text), not `ev.level`, so it does not explain the `FTL` flip — but remove it to de-noise.
+
+**Verdict:** treat PERIPHERAL_BUSY and the `FTL`/corruption as the **same family, different
+severity** — both new since dropping the polling wait, both rooted in the ISR/notification handshake.
+The busy error is benign; the corruption is the dangerous cousin.
+
+### Investigation ideas
+1. **`-fstack-protector-strong`** on `MonitorTaskI2C.c` + `MonUtils.c` to trap a localized stack
+   overrun at function return; or a J-Link **DWT data watchpoint** on the target once reproducible.
+2. **Paint the MSP/system (startup) stack** and scan low-water — `configCHECK_FOR_STACK_OVERFLOW`
+   does not cover handler-mode MSP. (Ranked lower: MSP overflow would hit globals, not `ev.level`.)
+3. **Install `log_set_lock`** (mutex / critical section) to remove the unprotected shared-buffer
+   corruptor as a confound.
+4. **Guard the UB**: `if (devtype_mask == 0) continue;` before `__builtin_clz`, and bounds-check
+   `devtype` against the type-table size. Verify `FireflyType*/ClockType` cannot transiently return 0.
+5. **Test the shared root**: apply the #2/#3 handshake hardening; if the `FTL`/corruption anomalies
+   vanish together with reduced PERIPHERAL_BUSY, the common cause is confirmed.
+6. **Correlate with more data**: log a monotonic counter + instance on every busy event and every
+   anomaly; check whether corruption events cluster near busy events on the same bus. (The single
+   `FTL`, 19:10 FF_F2, sits among FF_F2 busy errors at 18:54 / 19:20 — suggestive, not conclusive.)

--- a/i2c_lockup_notes.md
+++ b/i2c_lockup_notes.md
@@ -465,3 +465,54 @@ bus 4, …). It's a device-**model** behavior **across buses**, not "device 8." 
   six buses uniformly.
 - Still unverified (would need the Samtec datasheet for P/N `B0425040011201`): *why* this model
   clock-stretches and whether it's spec'd or marginal. Does not gate the firmware fix.
+
+---
+
+## First soak WITH the structural fix (2026-06-01): buffer fix held, benign busy-error persists
+
+Build under test: **`0fc7091`** ("move to static buffer for use-after-release bug",
+`v0.99.22-10-g0fc7091`, 2026-05-31 12:56) — the **first soak with the per-bus static RX/TX buffers in
+place** (not a timing-perturbed diagnostic build). Ran **726 min (12.1 h)**:
+
+```
+202606010458 I2C   WRN I2CCommunication.c:94 :dev 3 reg read PERIPHERAL_BUSY MCS=0x41 BUSY=1 BUSBSY=1
+202606010458 MONI2C ERR MonitorTaskI2C.c:160:FF_F2: TEMPERATURE_ALARM read Error PERIPHERAL_BUSY, break (ps=8)
+```
+
+**No `bkpt`, no memory corruption** in 726 min.
+
+### Read
+
+1. **Corruption stayed away on the real fix.** Earlier clean runs were quieter/noisier diagnostic
+   builds with no logic change → I (correctly) flagged them as "improved/masked." This run has the
+   actual `.bss`-buffer change: a late completion ISR now writes into a persistent per-bus buffer, not
+   a freed stack frame. If the use-after-return model is right, the corruption path is **closed**, not
+   hidden. One soak ≠ proof (the event was always rare, and invisible-byte hits — large I2C data
+   values — wouldn't print), but this is the first evidence that weighs toward *fixed* over *masked*.
+
+2. **The benign `PERIPHERAL_BUSY` persists exactly as predicted.** Same fingerprint: **dev 3 / ps=8**
+   (F2_5, the B0425040011201 4-ch XCVR) / **MCS=0x41**. The static buffer is a **memory-safety net
+   only** — it does nothing to the early-wake race, so this residual is expected, not a regression.
+   Rate (1 event / 12.1 h) is the same order as the prior single-sample leak-through (~1 / 17.5 h).
+
+### Diagnostic gap on this event
+
+The `waited N us` line is back at **`log_debug`** (suppressed), so we **cannot tell whether the bounded
+idle-wait engaged** on this event. The whole single-sample-fooled diagnosis hinged on *no preceding
+`waited` line ⇒ `us==0`*; without it, this event neither confirms nor refutes that theory — just "still
+happening at the expected rate." `MCS=0x41` caveats unchanged: **BUSY=1 invalidates the other MCS bits**,
+so `BUSBSY=1` here is indeterminate (not "bus held externally"); and it's sampled at the *failing*
+`SMBusMasterI2CWriteRead` entry, ~1 µs after the wait's own sample.
+
+### Recommendation (unchanged, reaffirmed)
+
+To retire the benign error (and the underlying stale-read risk) — correctness fix, not more diagnostics:
+1. **Cheap:** spin the idle-wait while `(MCS & (I2C_MCS_BUSY | I2C_MCS_BUSBSY))`, not just
+   `MAP_I2CMasterBusy()` (BUSY). BUSBSY is valid once BUSY reads 0 — catches the transient BUSY-low that
+   fools the single sample. One-liner in `i2c_arm_notify_slot`, lowest-risk test of the residual.
+2. **Proper:** notify on the TM4C **STOP interrupt** (`I2C_MASTER_INT_STOP`, unused) instead of the last
+   DATA interrupt — removes the race at the source. Bigger change, separate.
+
+If instrumenting first: flip only the `waited` line back to `log_warn` (or log only when `us` hits the
+250 cap) so the next leak-through reveals whether the wait engaged. User is letting `0fc7091` soak
+longer before changing anything.

--- a/i2c_lockup_notes.md
+++ b/i2c_lockup_notes.md
@@ -1,6 +1,9 @@
 # I2C Rare Lockup / PERIPHERAL_BUSY Analysis
 
-**Branch:** `hotfix/stale_temp_alarm`  
+**Branch:** `feature/i2c_speedup`
+**Soak-test baseline firmware:** `06f23fb` (`v0.99.22-7-g06f23fb`, "claude.md error fix", 2026-05-30) —
+this is the build the overnight soak ran on. Return to it with `git checkout 06f23fb` to reproduce the
+baseline behavior before the item-2/item-3 fixes below were applied.  
 **Observed symptom:** Occasional `SMBUS_PERIPHERAL_BUSY` returns from `SMBusMasterXxx` initiation
 functions, approximately every 13 minutes (high variance) despite hundreds of I2C transactions per
 second.
@@ -259,3 +262,206 @@ The busy error is benign; the corruption is the dangerous cousin.
 6. **Correlate with more data**: log a monotonic counter + instance on every busy event and every
    anomaly; check whether corruption events cluster near busy events on the same bus. (The single
    `FTL`, 19:10 FF_F2, sits among FF_F2 busy errors at 18:54 / 19:20 — suggestive, not conclusive.)
+
+---
+
+## Semaphore / direct-hardware audit (cm_mcu only) and fixes applied
+
+Audit of every I2C call site against the per-bus mutex discipline
+(bus1=`i2c1_sem`/dcdc, bus2/clk, bus3/ff_f2, bus4/ff_f1, bus5/fpga). No task-context code pokes the
+I2C hardware registers directly — all `HWREG`/`MAP_I2C`/`ROM_I2C` touches are in the ISR or one-time
+init before the scheduler. Three findings:
+
+1. **Raw CLI commands bypass the semaphore — by design.** `commands/I2CCommands.c`
+   (`i2cr`/`i2crr`/`i2cw`/`i2cwr`/`i2c_scan`) take no mutex so they can be composed under a manually
+   held lock via `sem_ctl <bus> take/release`. Verified this still works under the notification
+   driver: the UART stream buffer and the I2C `ulTaskNotifyTake` share task-notification index 0 but
+   never overlap (the stream buffer only notifies a task parked in `xStreamBufferReceive`). Caveat +
+   robust fix (own notification index) documented in `projects/cm_mcu/README.md`. **Left as-is.**
+
+2. **`snapdump` leaked `i2c1_sem` on three error returns** (`LocalTasks.c`). **FIXED** — converted to a
+   single `cleanup:` label that always releases the mutex.
+
+3. **`MonitorTask` (dcdc bus 1, fpga bus 5) and `snapdump` used the old polling completion**
+   (`SMBusStatusGet` + `vTaskDelayUntil`) and direct `SMBusMaster*` calls, bypassing the `apollo_*`
+   wrappers and the notification handshake. **FIXED** — both now go through `apollo_i2c_ctl_*`:
+   - Added `apollo_i2c_ctl_block_r()` (variable-length SMBus block read via the notification
+     handshake) and exposed `smbus_get_device_index()` in `I2CCommunication.{c,h}`.
+   - `MonitorTask` derives its bus index from `args->smbus` and uses `apollo_i2c_ctl_w` /
+     `apollo_i2c_ctl_reg_w` / `apollo_i2c_ctl_reg_r`. All `SMBusStatusGet` poll loops removed.
+   - Behavior note: the old code distinguished initiation-failure (`continue`) from completion-error
+     (`break`) on register reads; these merge into one `break`-on-error path now. Wire transactions
+     are unchanged (no PEC was used).
+
+Builds clean for REV1/REV2/REV3, no warnings. Applied on top of soak baseline `06f23fb`.
+
+---
+
+## Second corruption event (soak on `06f23fb`, 2026-05-30 10:55)
+
+```
+202605301055 MONI2C DBG MonitorTaskI2C.c:158:FF_F2: dev08<<reg OPT_POWER_CH4 (pg 0 add 0x28), value 0x4
+```
+
+`MonitorTaskI2C.c:158` is the success-path `log_debug`. Default `L.level[MONI2C]=LOG_INFO(3)`
+(`cm_mcu.c:237`); no facility is at DEBUG, so this is anomalous (unless `loglevel` was used).
+
+**Decode:** tag is `DBG` ⇒ `ev.level==4` (correct, *not* corrupted). For the gate
+`level <= L.level[fac]` (`log.c:326`) to pass, the `level` used at the gate was transiently below
+threshold while `ev.level` (copied at `log.c:317`, used for the tag) stayed 4. ⇒ **same family as the
+FTL event** — a clobber of the log-level value in `log_log`'s frame — caught *after* `ev.level=level`
+this time instead of before. Same victim, transient, one-off.
+
+**Key result: the clz guard is exonerated.** `MonitorTaskI2C.c:119–124` skips `devtype_mask==0` and
+is in `06f23fb`, yet corruption recurred. ⇒ `__builtin_clz(0)` is not the source. Suspicion shifts to
+the still-open items: smbus.c handshake races (#2/#3), the **unprotected `log_log`** (no
+`log_set_lock`; shared `b`/`log_buffer`/`L` written with no mutex), and the unguarded store below.
+
+**Audit finding — unbounded `set_*_data`:** every firefly store is
+`void set_FF_Fx_..._data(uint16_t data, int which){ ..._data[which]=data; }` with **no bounds check**
+(`MonI2C_addresses.c`). Arrays are sized `[NFIREFLIES_Fx]` and `which==device<n_devices`, so in-bounds
+today (`dev08` is fine for size 10). But it is a bare `.bss` store that fails *silently* the moment
+`which` is ever wrong — and `L` (log levels), `log_buffer`, `b` are file-scope statics adjacent in
+`.bss`. Exactly the profile of a data-dependent wild store.
+
+**Resolved (user, 2026-05-30):** ONE line, none in the following ~30 min, `loglevel` NOT changed.
+⇒ the threshold global was **not** persistently corrupted; this was a **transient, one-off,
+self-healing clobber of the `level` value in `log_log`'s frame**, same victim as the FTL event.
+- **SEU considered, ranked down:** HL-LHC firmware, so a one-off self-healing bit flip *looks* like a
+  single-event upset — but 2 events in ~16 h is far above the bench cosmic-ray SEU rate for one TM4C
+  (~weeks–months/upset). Treat as a firmware defect unless the board is in a beam/source.
+- **`set_*_data` downgraded as a source:** arrays, getters, setters all come from one YAML pass, so
+  `which == device < n_devices == array length` by construction — no size mismatch. Keep a bounds
+  check only as a **tripwire** for a *corrupted* index, not as a presumed fix.
+
+**Decisive next steps (re-ordered for a transient stack/register victim):**
+1. `-fstack-protector-strong` on `MonitorTaskI2C.c`, `MonUtils.c`, `log.c` — best catch if the source
+   is a localized stack overrun; traps at function return and names the frame.
+2. J-Link DWT data watchpoint on `&L.level[LOG_MONI2C]` as a *filter* — catches a stray write to that
+   global (even self-healing). If it never fires, the corruption is register/stack-local.
+3. `set_*_data`/`get_*_data` bounds-check tripwire — logs `which` + caller when out of range.
+4. Install `log_set_lock`; apply smbus.c #2/#3 hardening; re-soak.
+
+---
+
+## Session update (2026-05-30/31): root-cause #1 confirmed-fixed; corruption model + suspect device
+
+### PERIPHERAL_BUSY (root cause #1) — fixed by the bounded idle-wait, confirmed
+`fddacb4` added a bounded spin in `i2c_arm_notify_slot` (`while (MAP_I2CMasterBusy() && us<250) DELAY_US(1)`).
+This is the **real fix**, not diagnostics: it converts the auto-STOP/FSM race into a bounded wait.
+Turning that wait's `log_debug` into `log_warn` showed it firing constantly (`dev N waited M us`), with a
+clear per-bus signature: **FF_F2 (dev 3) routinely ~76–84 µs**, CLK (dev 2) ~9 µs, FF_F1 (dev 4) mixed —
+i.e. a slow/clock-stretching device on FF_F2.
+
+**One leak-through remained** (1 in ~17.5 h): `dev 3 reg read PERIPHERAL_BUSY MCS=0x41` with **no preceding
+`waited` line** (`us==0`). So `BUSY` read clear when the wait sampled it, then `BUSY` was set ~1 µs later at
+`SMBusMasterI2CWriteRead`'s own check. The single-sample wait was fooled by a transient `BUSY` low during the
+prior transaction's completion. **Fix:** spin on `(MCS & (BUSY|BUSBSY))`, not just `MAP_I2CMasterBusy()` (BUSY).
+Note: on TM4C, **`BUSY=1` invalidates the other MCS status bits**, so the `BUSBSY=1` in `MCS=0x41` is
+indeterminate — don't over-read it (I did at first).
+
+### MSP overflow — RULED OUT
+The boot/idle line `Stack canary now N` is **not** the SSP guard; it's a home-grown **MSP (system-stack)
+high-water monitor** (`SystemStackWaterHighWaterMark()` in `cm_mcu.c`, paints 128 words with `0xdeadbeef`).
+It sat at ~45/128 words free, stable, over 17.5 h ⇒ the handler/ISR stack is **not** overflowing. Removes the
+one stack region `configCHECK_FOR_STACK_OVERFLOW` can't see. Task stacks also healthy/stable (~138 free).
+
+### The corruption: suspect device + mechanism model
+**All three anomalies are FF_F2, device index 8** — FTL ("not for **device 8**"), DBG ("**dev08** OPT_POWER_CH4"),
+and the PERIPHERAL_BUSY leak (**ps=8**). On REV3, `ff_moni2c_addrs_f2[8]` = **"F2_5 4 XCVR"** (mux `0x70` bit 2,
+addr `0x50`), present, serial `B0425040011201`. (REV2 index 8 = "F2_6 4 XCVR".) This 4-channel XCVR is the
+clock-stretcher behind the long FF_F2 waits and the prime hardware suspect.
+
+**Model (well-supported, 2 data points):** `log_log`'s `level` parameter (the spilled-`r0` stack slot at a
+fixed frame offset) is overwritten **after** the `ev.level = level` copy (`log.c:313`) but **before** the gate
+(`log.c:326`). The **DBG event proves the value arrives correct** (`ev.level==4` ⇒ tag "DBG") and is clobbered
+*inside* the function. Same 4-byte slot hit **twice** ⇒ not a random spray but a **deterministic OOB store** in
+the repeatable `FF_F2 monitor → log_debug → log_log` path (same task, same stack layout). A single OOB store
+(`a[bad_i]=v` / wild pointer) does **not** cross the SSP canary (which only catches contiguous overruns at
+return) — consistent with the canary never tripping.
+
+### Heisenbug warning
+Corruption appeared on the *quieter* builds and **vanished** on the stack-protector + noisy-`log_warn` build
+(17.5 h clean). Neither change fixes logic ⇒ likely **timing-masked, not fixed**. To catch it: go *quieter*
+(idle-wait back to `log_debug`), keep a *minimal* trap. Don't pile on diagnostics.
+
+### Catch mechanism in place (committed separately)
+- `common/log.c`: shadow check — `volatile int level_chk = level;` then `if (level != level_chk) { GET_LR(); bkpt #0; }`
+  right before the gate. Catches the **effect** (slot clobbered) and halts in the offending frame.
+- `-fstack-protector-strong` on `MonitorTaskI2C.o`/`MonUtils.o`/`log.o` (catches it only if it's a contiguous overrun).
+- `cm_mcu.c`: `__stack_chk_fail` prints `LR` (Thumb-bit cleared) for `addr2line`, then `configASSERT` (freeze in DEBUG).
+- At a `bkpt` halt, first grab `p &level`, `p/x level` (the overwriting value often fingerprints the source) and `bt`
+  (expect the FF_F2 device-8 read/error path).
+
+### Open / next
+- The bug is **not yet caught or fixed** — best evidence is "improved/masked." Need a soak at failing-timing
+  (quiet) with the shadow trap, ideally catching the `bkpt`.
+- Hardening still pending: idle-wait → `(BUSY|BUSBSY)`; the item-2/#3 + smbus.c #2/#3 changes are on a separate
+  uncommitted track.
+
+---
+
+## Mechanism refined (2026-05-31): use-after-return on a stack RX buffer (not an OOB store)
+
+Reading `MonitorTaskI2C.c` + `I2CCommunication.c` end-to-end overturned the earlier "deterministic OOB
+store in MonitorTaskI2C" guess. There is **no stack-smashing write in MonitorTaskI2C's own code**
+(its only writes are `storeData()` → `.bss`, in-bounds). The real defect is in the I2C wrapper layer:
+
+- `apollo_i2c_ctl_reg_r` declares **`uint8_t data[MAX_BYTES]` on its stack** and hands `&data` to the
+  TI SMBus driver (`pui8RxBuffer`). The driver's ISR writes received bytes into it.
+- It's **spatially safe** — the driver bounds-checks `ui8RxIndex >= ui8RxSize` and `nbytes ≤ MAX_BYTES`.
+- It's **temporally unsafe**: if the task is notified/returns *before the transfer truly completes*
+  (the early/cross-wake that also yields the PERIPHERAL_BUSY leak), `apollo_i2c_ctl_reg_r` returns, its
+  frame is freed, `MonitorTaskI2C` immediately calls `log_debug → log_log` which **reuses that stack
+  region**, and the **late completion ISR writes a received byte into the dead `data[]` → onto
+  `log_log`'s `level`** (in-bounds index, stale pointer). Classic "return a pointer to a local, write
+  through it later."
+
+This explains everything the OOB-store guess strained to: same slot every time (fixed `reg_r → log`
+call structure → fixed frame overlap), canary-silent (in-bounds single byte), value = an I2C data byte
+(small → visible "printed when suppressed"; large → silent), device-8-triggered (its clock-stretch
+creates the overlap), self-healing (next `log_log` re-spills the correct `level`).
+
+**Device 8 (F2_5 XCVR) is the trigger, not the cause.** The cause is the firmware lifetime bug; any
+slow/marginal slave would trip it. Masking device 8 would hide the symptom and leave the landmine.
+
+### Fixes
+- **Memory-safety net (implementing now):** per-bus **static** RX/TX scratch buffers in
+  `I2CCommunication.c`, passed to `SMBusMasterI2C*` instead of stack locals. Stays in our code — `tSMBus`
+  is **TI vendor code** (`common/smbus.h`); its `pui8RxBuffer`/`pui8TxBuffer` are already
+  *caller-provided pointers*, so we just make ours persistent `.bss`, indexed by bus, safe under the
+  per-bus semaphore. A late straggler then lands in `.bss`, not a live frame.
+- **Correctness fix (later):** STOP-interrupt completion (`I2C_MASTER_INT_STOP`) and/or a robust
+  `BUSY|BUSBSY` idle-wait — removes the early-wake race itself (also fixes stale-data and PERIPHERAL_BUSY).
+- **Landed (independent):** `page[devtype]`/`command[devtype]` **OOB read** guard in `MonitorTaskI2C.c`
+  (`DEVICE_NONE`=0x80 → devtype 7 vs `[4]` arrays; `if (devtype >= sizeof(args->commands->page)) continue;`).
+  A device-8 agitator (garbage register on a misread type), not the smash.
+
+### Caveats
+The early/cross-wake step (ISR giving B's notification while A trails) is consistent with the data but
+not yet proven against an smbus.c ISR-sequence trace. The static buffer is a safety net regardless; the
+shadow-`bkpt` in `log.c` should still be used to catch a live event and confirm the value/offset.
+
+---
+
+## Trigger generalizes off device 8 → the 4-ch XCVR Firefly *model* (2026-05-31)
+
+A PERIPHERAL_BUSY leak appeared on a **different bus and device**: `2026-05-31 17:07 dev 4 (FF_F1)
+reg read PERIPHERAL_BUSY MCS=0x41`, `FF_F1: RX_POWER_ALARM ... (ps=9)` — same `MCS=0x41`, no preceding
+`waited` line (`us==0`), i.e. the same single-sample idle-wait fooled. Benign (no corruption), stacks/
+heap fine, uptime 6.5 h. This was on the **old code** (no buffer/wait fix).
+
+FF_F1 idx 9 (REV3) = **F1_6 "4 XCVR"** (mux 0x71 bit 2, addr 0x50). Its ID register reads
+`B0425040011201` — the same value as FF_F2 idx 8 (**F2_5**). **`B0425040011201` is the part MODEL
+number** (read from the ID reg), *not* a serial — so two units reading it identically is expected.
+
+**Conclusion:** the trigger is the **4-channel XCVR Firefly model `B0425040011201`**, whose ~80 µs
+clock-stretching trips the early-wake race wherever a unit of that model sits (F2_5 on bus 3, F1_6 on
+bus 4, …). It's a device-**model** behavior **across buses**, not "device 8." Implications:
+- "Swap the bad device" is off the table; the fix must be firmware-side and bus-agnostic — which is what
+  the per-bus static buffers (+ robust `BUSY|BUSBSY` wait / STOP interrupt) are.
+- The visible *corruption* has only been seen on F2_5 so far, but F1_6 has the identical race, so it can
+  smash on FF_F1 too (just with an invisible byte value, or not-yet-observed). The buffer fix covers all
+  six buses uniformly.
+- Still unverified (would need the Samtec datasheet for P/N `B0425040011201`): *why* this model
+  clock-stretches and whether it's spec'd or marginal. Does not gate the firmware fix.

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -99,6 +99,12 @@ static struct command_t commands[] = {
         0,
     },
     {
+        "ff_present",
+        ff_present,
+        "Live read+show FF present bits\r\n",
+        0,
+    },
+    {
         "ff_los",
         ff_los_alarm,
         "Show FF loss of signal alarms\r\n",

--- a/projects/cm_mcu/CommandLineTask.c
+++ b/projects/cm_mcu/CommandLineTask.c
@@ -436,7 +436,7 @@ void vCommandLineTask(void *pvParameters)
   StreamBufferHandle_t uartStreamBuffer = args->UartStreamBuffer;
   uint32_t uart_base = args->uart_base;
 
-  UARTPrint(uart_base, pcWelcomeMessage);
+  Print(pcWelcomeMessage);
   struct microrl_user_data_t rl_userdata = {
       .uart_base = uart_base,
   };

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -65,7 +65,16 @@ void setFFmask(uint32_t ff_combined_present)
   return;
 }
 
-void readFFpresent(void)
+// Read the *PRESENT pins from the I/O expanders live over I2C and return the
+// combined, active-high present word. Also refreshes the per-FF present bit
+// masks (ff_bitmask_args) and the 4v0 select globals. Does NOT touch the EEPROM
+// or the enable masks (ff_PRESENT_mask/ff_USER_mask) -- that is done by the
+// readFFpresent() wrapper via setFFmask().
+//
+// If acquire_sem is true the i2c3/i2c4 bus semaphores are taken around the
+// transfers (boot path). Pass false to skip all semaphore handling -- used by
+// the CLI, which must not block on / take the bus mutexes.
+uint32_t readFFpresentSignals(bool acquire_sem)
 {
   // outputs from *_PRESENT pins for constructing ff_PRESENT_mask
 #ifdef REV1
@@ -85,7 +94,9 @@ void readFFpresent(void)
 
   // grab the semaphore to ensure unique access to I2C controller
   // otherwise, block its operations indefinitely until it's available
-  acquireI2CSemaphoreBlock(i2c4_sem);
+  if (acquire_sem) {
+    acquireI2CSemaphoreBlock(i2c4_sem);
+  }
 
 #ifdef REV1
   // to port 7
@@ -129,7 +140,9 @@ void readFFpresent(void)
 
   // grab the semaphore to ensure unique access to I2C controller
   // otherwise, block its operations indefinitely until it's available
-  acquireI2CSemaphoreBlock(i2c3_sem);
+  if (acquire_sem) {
+    acquireI2CSemaphoreBlock(i2c3_sem);
+  }
 
 #ifdef REV1
   // to port 0
@@ -234,6 +247,13 @@ void readFFpresent(void)
   log_info(LOG_SERVICE, "F2  4-ch FF mask: 0x%02x\r\n", ff_bitmask_args[3].present_bit_mask);
 #endif
 
+  return ff_combined_present;
+}
+
+// Read the present signals at boot and persist the derived mask to EEPROM.
+void readFFpresent(void)
+{
+  uint32_t ff_combined_present = readFFpresentSignals(true);
   setFFmask(ff_combined_present);
 }
 

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -49,8 +49,17 @@ void setFFmask(uint32_t ff_combined_present)
 #elif defined(REV2) || defined(REV3) // TODO: check
   uint32_t data = (ff_combined_present) & 0xFFFFFU;
 #endif                               // REV1
-  ff_USER_mask = read_eeprom_single(EEPROM_ID_FF_ADDR);
+  uint32_t current = read_eeprom_single(EEPROM_ID_FF_ADDR);
+  ff_USER_mask = current;
   ff_PRESENT_mask = data;
+
+  // read/modify/write: only touch the EEPROM if the stored value differs from
+  // what we are about to write (avoids unnecessary write/wear and unlock/lock churn)
+  if (current == data) {
+    log_debug(LOG_SERVICE, "%s:FF EEPROM mask unchanged (0x%lx), skipping write\r\n", __func__, data);
+    return;
+  }
+
   uint64_t block = EEPROMBlockFromAddr(ADDR_FF);
 
   uint64_t unlock = EPRMMessage((uint64_t)EPRM_UNLOCK_BLOCK, block, PASS);

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -121,16 +121,20 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                               // clear the mux
 #elif defined(REV3)
   // to port 7
-  apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
-  apollo_i2c_ctl_reg_r(4, 0x20, 1, 0x01, 1, &present_FFL12_F1_bar); // active low
-  apollo_i2c_ctl_w(4, 0x70, 1, 0x8);                                // clear the mux
+  int r = apollo_i2c_ctl_w(4, 0x70, 1, 0x80);
+  r += apollo_i2c_ctl_reg_r(4, 0x20, 1, 0x01, 1, &present_FFL12_F1_bar); // active low
+  r += apollo_i2c_ctl_w(4, 0x70, 1, 0x8);                                // clear the mux
 
   // to port 6
-  apollo_i2c_ctl_w(4, 0x71, 1, 0x40);
-  apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFL4_F1_bar); // active low
-  apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x01, 1, &f1_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
+  r += apollo_i2c_ctl_w(4, 0x71, 1, 0x40);
+  r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFL4_F1_bar); // active low
+  r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x01, 1, &f1_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
+  log_info(LOG_SERVICE, "raw read f1_ff12xmit_4v0_sel: 0x%x\r\n", f1_ff12xmit_4v0_sel);
   f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0xF;          // bits 4-7
-  apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                               // clear the mux
+  r += apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                               // clear the mux
+  if (r) {
+    log_error(LOG_SERVICE, "\tFailed to read F1 optics presence (r=%d)\r\n", r);
+  }
 #endif
 
   // if we have a semaphore, give it
@@ -165,17 +169,23 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0x7;          // bits 4-6
   apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
 #elif defined(REV3)
+  r = 0;
   // to port 7
-  apollo_i2c_ctl_w(3, 0x70, 1, 0x80);
-  apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2_bar); // active low
-  apollo_i2c_ctl_w(3, 0x70, 1, 0x8);                                // clear the mux
+  r += apollo_i2c_ctl_w(3, 0x70, 1, 0x80);
+  r += apollo_i2c_ctl_reg_r(3, 0x20, 1, 0x01, 1, &present_FFL12_F2_bar); // active low
+  r += apollo_i2c_ctl_w(3, 0x70, 1, 0x8);                                // clear the mux
 
   // to port 6
-  apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
-  apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFL4_F2_bar); // active low
-  apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &f2_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
+  r += apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
+  r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFL4_F2_bar); // active low
+  r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &f2_ff12xmit_4v0_sel); // reading FPGA2 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
+  log_info(LOG_SERVICE, "raw read f2_ff12xmit_4v0_sel: 0x%x\r\n", f2_ff12xmit_4v0_sel);
   f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0xF;          // bits 4-7
-  apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                               // clear the mux
+  r += apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                               // clear the mux
+  if (r) {
+    log_error(LOG_SERVICE, "\tFailed to read F2 optics presence (r=%d)\r\n", r);
+  }
+  log_info(LOG_SERVICE, "sel switches: F1: 0x%x, F2: 0x%x\r\n", f1_ff12xmit_4v0_sel, f2_ff12xmit_4v0_sel);
 
 #endif
   // if we have a semaphore, give it

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -139,8 +139,8 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   r += apollo_i2c_ctl_w(4, 0x71, 1, 0x40);
   r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFL4_F1_bar); // active low
   r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x01, 1, &f1_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
-  f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0xF; // bits 4-7
-  r += apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                 // clear the mux
+  f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0xF;               // bits 4-7
+  r += apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                               // clear the mux
   if (r) {
     log_error(LOG_SERVICE, "\tFailed to read F1 optics presence (r=%d)\r\n", r);
   }
@@ -188,8 +188,8 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   r += apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
   r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFL4_F2_bar); // active low
   r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &f2_ff12xmit_4v0_sel); // reading FPGA2 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
-  f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0xF; // bits 4-7
-  r += apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                 // clear the mux
+  f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0xF;               // bits 4-7
+  r += apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                               // clear the mux
   if (r) {
     log_error(LOG_SERVICE, "\tFailed to read F2 optics presence (r=%d)\r\n", r);
   }

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -130,8 +130,8 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFL4_F1_bar); // active low
   r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x01, 1, &f1_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
   log_info(LOG_SERVICE, "raw read f1_ff12xmit_4v0_sel: 0x%x\r\n", f1_ff12xmit_4v0_sel);
-  f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0xF;          // bits 4-7
-  r += apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                               // clear the mux
+  f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0xF; // bits 4-7
+  r += apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                 // clear the mux
   if (r) {
     log_error(LOG_SERVICE, "\tFailed to read F1 optics presence (r=%d)\r\n", r);
   }
@@ -180,8 +180,8 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFL4_F2_bar); // active low
   r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &f2_ff12xmit_4v0_sel); // reading FPGA2 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
   log_info(LOG_SERVICE, "raw read f2_ff12xmit_4v0_sel: 0x%x\r\n", f2_ff12xmit_4v0_sel);
-  f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0xF;          // bits 4-7
-  r += apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                               // clear the mux
+  f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0xF; // bits 4-7
+  r += apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                 // clear the mux
   if (r) {
     log_error(LOG_SERVICE, "\tFailed to read F2 optics presence (r=%d)\r\n", r);
   }

--- a/projects/cm_mcu/FireflyUtils.c
+++ b/projects/cm_mcu/FireflyUtils.c
@@ -72,8 +72,18 @@ void setFFmask(uint32_t ff_combined_present)
 // readFFpresent() wrapper via setFFmask().
 //
 // If acquire_sem is true the i2c3/i2c4 bus semaphores are taken around the
-// transfers (boot path). Pass false to skip all semaphore handling -- used by
-// the CLI, which must not block on / take the bus mutexes.
+// transfers (boot path). Pass false to skip all semaphore handling.
+//
+// acquire_sem == false is an EXPERT-ONLY path. It exists so the CLI can read the
+// present signals even when the bus mutex is held by a stuck transaction (wedged
+// bus) -- blocking on the mutex there would defeat the diagnostic. It is NOT
+// internally race-free: without the bus mutex these transfers share the per-bus
+// scratch buffers and the single TaskNotifySMBus[bus] completion slot with any
+// MonitorTaskI2C running buses 3/4 concurrently. Because those buffers are static
+// .bss the failure mode is a wrong value or a 250 ms SMBUS_TIMEOUT, never memory
+// corruption -- but the result is unreliable. For trustworthy results, hold the
+// bus manually around the call: sem_ctl 3 take / sem_ctl 4 take ... sem_ctl release.
+// See README.md "Higher-level semaphore-free helpers and unprogrammed exploration".
 uint32_t readFFpresentSignals(bool acquire_sem)
 {
   // outputs from *_PRESENT pins for constructing ff_PRESENT_mask
@@ -129,7 +139,6 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   r += apollo_i2c_ctl_w(4, 0x71, 1, 0x40);
   r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x00, 1, &present_FFL4_F1_bar); // active low
   r += apollo_i2c_ctl_reg_r(4, 0x21, 1, 0x01, 1, &f1_ff12xmit_4v0_sel); // reading FPGA1 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
-  log_info(LOG_SERVICE, "raw read f1_ff12xmit_4v0_sel: 0x%x\r\n", f1_ff12xmit_4v0_sel);
   f1_ff12xmit_4v0_sel = (f1_ff12xmit_4v0_sel >> 4) & 0xF; // bits 4-7
   r += apollo_i2c_ctl_w(4, 0x71, 1, 0x0);                 // clear the mux
   if (r) {
@@ -179,7 +188,6 @@ uint32_t readFFpresentSignals(bool acquire_sem)
   r += apollo_i2c_ctl_w(3, 0x71, 1, 0x40);
   r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x00, 1, &present_FFL4_F2_bar); // active low
   r += apollo_i2c_ctl_reg_r(3, 0x21, 1, 0x01, 1, &f2_ff12xmit_4v0_sel); // reading FPGA2 12-ch xmit FF's power-supply physical selection (i.e either 3.3v or 4.0v)
-  log_info(LOG_SERVICE, "raw read f2_ff12xmit_4v0_sel: 0x%x\r\n", f2_ff12xmit_4v0_sel);
   f2_ff12xmit_4v0_sel = (f2_ff12xmit_4v0_sel >> 4) & 0xF; // bits 4-7
   r += apollo_i2c_ctl_w(3, 0x71, 1, 0x0);                 // clear the mux
   if (r) {

--- a/projects/cm_mcu/FireflyUtils.h
+++ b/projects/cm_mcu/FireflyUtils.h
@@ -81,7 +81,7 @@ uint16_t getFF12ChPresentTxMask(int device);
 uint8_t getFFstatus(const uint8_t i);
 unsigned isFFStale(void);
 TickType_t getFFupdateTick(int ff_t);
-void init_registers_ff(void);
+int init_registers_ff(void);
 
 uint16_t read_arbitrary_ff_register(uint16_t regnumber, int num_ff, uint8_t *value, uint8_t size);
 

--- a/projects/cm_mcu/FireflyUtils.h
+++ b/projects/cm_mcu/FireflyUtils.h
@@ -65,6 +65,7 @@ bool getFFch_low(uint8_t val, int channel);
 bool getFFch_high(uint8_t val, int channel);
 bool isEnabledFF(int ff);
 void readFFpresent(void);
+uint32_t readFFpresentSignals(bool acquire_sem);
 uint16_t getFFtemp(const uint8_t i);
 float getFFavgoptpow(const uint8_t i);
 float getFFoptpow(const uint8_t i, const uint8_t ch);

--- a/projects/cm_mcu/FreeRTOSConfig.h
+++ b/projects/cm_mcu/FreeRTOSConfig.h
@@ -37,7 +37,7 @@ void stopwatch_reset(void);
 #define configCPU_CLOCK_HZ                      40000000
 #define configMAX_PRIORITIES                    (5)
 #define configMINIMAL_STACK_SIZE                ((unsigned short)256)
-#define configTOTAL_HEAP_SIZE                   ((size_t)(24 * 1024))
+#define configTOTAL_HEAP_SIZE                   ((size_t)(25 * 1024))
 #define configMAX_TASK_NAME_LEN                 (6)
 #define configUSE_TRACE_FACILITY                1
 #define configUSE_16_BIT_TICKS                  0

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -25,8 +25,16 @@
 #include "Tasks.h"
 #include "I2CCommunication.h"
 #include "common/smbus_helper.h"
+#include "common/utils.h" // DELAY_US
 
 #include "InterruptHandlers.h"
+
+// TI hardware register access for I2C master state diagnostics
+#include "inc/hw_types.h"      // HWREG
+#include "inc/hw_i2c.h"        // I2C_O_MCS, I2C_MCS_BUSY, I2C_MCS_BUSBSY
+#include "driverlib/i2c.h"     // I2CMasterBusy
+#include "driverlib/rom.h"     // ROM_SysCtlDelay (used by DELAY_US)
+#include "driverlib/rom_map.h" // MAP_I2CMasterBusy
 
 extern tSMBus g_sMaster1;
 extern tSMBus g_sMaster2;
@@ -43,9 +51,40 @@ volatile tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus
 
 #define I2C_TIMEOUT_MS 250
 
+// Bounded wait (microseconds) for the on-chip I2C master FSM to finish a prior
+// transaction's STOP before we initiate a new one. This targets the suspected
+// PERIPHERAL_BUSY race where a task is notified and resumes before the hardware
+// auto-STOP completes. See i2c_lockup_notes.md.
+#define I2C_IDLE_WAIT_US 250
+
 static void i2c_arm_notify_slot(uint8_t device)
 {
+  // Bounded spin until the master FSM is idle, so a late-completing previous
+  // STOP cannot make this transaction's initiation return PERIPHERAL_BUSY.
+  uint32_t base = pSMBus[device]->ui32I2CBase;
+  uint32_t us = 0;
+  while (MAP_I2CMasterBusy(base) && us < I2C_IDLE_WAIT_US) {
+    DELAY_US(1);
+    ++us;
+  }
+  if (us) {
+    log_debug(LOG_I2C, "dev %d waited %u us for master idle\r\n", device, us);
+  }
+
   TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+}
+
+// Diagnostic: log the raw I2C master control/status register at the moment an
+// initiation returns PERIPHERAL_BUSY (or other non-OK). Must be called BEFORE
+// any recovery (e.g. mux reset) so it captures the true on-chip state.
+//   BUSY set, BUSBSY clear  -> on-chip master still finishing its STOP (FSM race)
+//   BUSBSY set              -> bus line held externally (device/mux)
+static void i2c_log_busy(uint8_t device, const char *op, tSMBusStatus r)
+{
+  uint32_t mcs = HWREG(pSMBus[device]->ui32I2CBase + I2C_O_MCS);
+  log_warn(LOG_I2C, "dev %d %s %s MCS=0x%02lx BUSY=%d BUSBSY=%d\r\n", device, op,
+           SMBUS_get_error(r), (unsigned long)mcs, !!(mcs & I2C_MCS_BUSY),
+           !!(mcs & I2C_MCS_BUSBSY));
 }
 
 static void i2c_wait_for_transfer(uint8_t device)
@@ -80,7 +119,7 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   }
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
-    log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
+    i2c_log_busy(device, "read", r);
     return r;
   }
   if (r != SMBUS_OK) {
@@ -118,7 +157,7 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
   }
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
-    log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
+    i2c_log_busy(device, "reg read", r);
     return r;
   }
   // pack the data for return to the caller
@@ -167,7 +206,7 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   }
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
-    log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+    i2c_log_busy(device, "reg write", r);
     return r;
   }
 
@@ -202,7 +241,7 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   }
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
-    log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+    i2c_log_busy(device, "write", r);
     return r;
   }
 
@@ -251,7 +290,7 @@ tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_s
     r = SMBusMasterByteWordWrite(smbus, add->dev_addr, cmd->command, value, cmd->size);
   }
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "PMBUS read/write fail %s\r\n", SMBUS_get_error(r));
+    i2c_log_busy(device, read ? "pmbus read" : "pmbus write", r);
     TaskNotifySMBus[device] = NULL;
     return r;
   }

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -54,7 +54,17 @@ volatile tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus
 // ISR reads/writes it as bytes arrive. Passing these persistent .bss buffers instead of a
 // stack local means a late ISR completing after the wrapper has returned writes here, not
 // into a freed/reused stack frame (the memory-corruption root cause; see i2c_lockup_notes.md).
-// Safe to share per bus because each bus is serialized by its own semaphore.
+//
+// OWNERSHIP CONTRACT: these buffers are shared by every caller of a given bus and are NOT
+// internally locked. They are safe ONLY because each bus is serialized by its own mutex
+// (i2c1_sem..i2c6_sem) and the caller is required to hold that mutex across the whole
+// transaction sequence. If two callers touch the same bus without that mutex (e.g. the
+// deliberately semaphore-free CLI exploration helpers -- readFFpresentSignals(false),
+// ff_present -- running concurrently with a MonitorTaskI2C on the same bus), they race on
+// these buffers AND on TaskNotifySMBus[bus]. Because the storage is static .bss the worst
+// case is a wrong value or a 250 ms SMBUS_TIMEOUT, never memory corruption -- but the result
+// is unreliable. See README.md "Higher-level semaphore-free helpers and unprogrammed
+// exploration" for the safe workflow (manual sem_ctl lock) and hardening options.
 static uint8_t i2c_rxbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BYTES];
 static uint8_t i2c_txbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BYTES_ADDR + MAX_BYTES];
 

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -277,8 +277,37 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   }
   return r;
 }
-// for PMBUS commands
-static uint8_t smbus_get_device_index(tSMBus *smbus)
+// read a variable-length SMBus block from an I2C device, through the
+// notification handshake. The slave reports the length; on success the data
+// is in data[] and the count is available via SMBusRxPacketSizeGet().
+int apollo_i2c_ctl_block_r(uint8_t device, uint8_t address, uint8_t command, uint8_t *data)
+{
+  tSMBus *p_sMaster = pSMBus[device];
+  volatile tSMBusStatus *p_eStatus = eStatus[device];
+  configASSERT(p_sMaster != NULL);
+
+  i2c_arm_notify_slot(device);
+
+  tSMBusStatus r = SMBusMasterBlockRead(p_sMaster, address, command, data);
+  if (r == SMBUS_OK) { // the block read was successfully initiated
+    i2c_wait_for_transfer(device);
+    r = *p_eStatus;
+  }
+  else {
+    TaskNotifySMBus[device] = NULL; // clean up if initiation failed
+    log_error(LOG_I2C, "dev %d block read fail %s\r\n", device, SMBUS_get_error(r));
+    return r;
+  }
+
+  if (r != SMBUS_OK) {
+    log_error(LOG_I2C, "dev %d block read fail %s\r\n", device, SMBUS_get_error(r));
+  }
+  return r;
+}
+
+// for PMBUS commands. Returns the I2C bus/device index (1-6) for a given
+// SMBus controller pointer, or 0 if not found.
+uint8_t smbus_get_device_index(tSMBus *smbus)
 {
   for (int i = 1; i <= 6; i++) {
     if (pSMBus[i] == smbus) {

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -84,6 +84,7 @@ static void i2c_arm_notify_slot(uint8_t device)
   // Bounded spin until the master FSM is idle, so a late-completing previous
   // STOP cannot make this transaction's initiation return PERIPHERAL_BUSY.
   uint32_t base = pSMBus[device]->ui32I2CBase;
+  configASSERT(base != 0);
   uint32_t us = 0;
   uint32_t mcs = 0;
   while (((mcs = HWREG(base + I2C_O_MCS)) & (I2C_MCS_BUSY | I2C_MCS_BUSBSY)) &&
@@ -160,9 +161,6 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
       log_error(LOG_I2C, "dev %d read fail %s\r\n", device, SMBUS_get_error(r));
     }
   }
-  else {
-    log_debug(LOG_I2C, "dev %d read success 0x%0*X\r\n", device, nbytes * 2, data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24));
-  }
   return r;
 }
 
@@ -208,9 +206,6 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
     else {
       log_error(LOG_I2C, "dev %d reg read fail %s\r\n", device, SMBUS_get_error(r));
     }
-  }
-  else {
-    log_debug(LOG_I2C, "dev %d reg read success 0x%0*X\r\n", device, nbytes * 2, *packed_data);
   }
   return r;
 }
@@ -258,9 +253,6 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
       log_error(LOG_I2C, "dev %d reg write fail %s\r\n", device, SMBUS_get_error(r));
     }
   }
-  else {
-    log_debug(LOG_I2C, "dev %d reg write success 0x%0*X\r\n", device, nbytes * 2, packed_data);
-  }
   return r;
 }
 
@@ -297,9 +289,6 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
     else {
       log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
     }
-  }
-  else {
-    log_debug(LOG_I2C, "dev %d write success 0x%0*X\r\n", device, nbytes * 2, value);
   }
   return r;
 }
@@ -340,8 +329,9 @@ int apollo_i2c_ctl_block_r(uint8_t device, uint8_t address, uint8_t command, uin
   }
   else {
     uint8_t received = SMBusRxPacketSizeGet(p_sMaster);
-    if (received > MAX_BLOCK_BYTES)
+    if (received > MAX_BLOCK_BYTES) {
       received = MAX_BLOCK_BYTES;
+    }
     memcpy(data, rxbuf, received);
   }
   return r;
@@ -379,7 +369,9 @@ tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_s
   // TRANSACTION 2: device read/write. PMBus/SMBus command.
   i2c_arm_notify_slot(device);
   if (read) {
-    r = SMBusMasterByteWordRead(smbus, add->dev_addr, cmd->command, value, cmd->size);
+    uint8_t *v = i2c_rxbuf[device];
+    const size_t sz = cmd->size;
+    r = SMBusMasterByteWordRead(smbus, add->dev_addr, cmd->command, v, sz);
   }
   else {
     r = SMBusMasterByteWordWrite(smbus, add->dev_addr, cmd->command, value, cmd->size);
@@ -390,6 +382,12 @@ tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_s
     return r;
   }
   i2c_wait_for_transfer(device);
+  if (read) {
+    // copy the result back to the value
+    for (int i = 0; i < cmd->size; ++i) {
+      value[i] = i2c_rxbuf[device][i];
+    }
+  }
   // ISR writes the per-bus status (SMBUS_OK or specific error).
   r = *smbus_status;
 

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -43,13 +43,19 @@ volatile tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus
 
 #define I2C_TIMEOUT_MS 250
 
+static void i2c_arm_notify_slot(uint8_t device)
+{
+  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+}
+
 static void i2c_wait_for_transfer(uint8_t device)
 {
   // Caller must have already set TaskNotifySMBus[device]
   if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(I2C_TIMEOUT_MS)) == 0) {
     // timeout — no notification arrived
+    *eStatus[device] = SMBUS_TIMEOUT;
     TaskNotifySMBus[device] = NULL;
-    log_warn(LOG_I2C, "transfer stuck\r\n");
+    log_warn(LOG_I2C, "transfer stuck, dev %d\r\n", device);
   }
 }
 
@@ -60,11 +66,12 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
 
   configASSERT(p_sMaster != NULL);
 
-  memset(data, 0, nbytes * sizeof(data[0]));
   if (nbytes > MAX_BYTES)
     nbytes = MAX_BYTES;
 
-  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+  memset(data, 0, nbytes * sizeof(data[0]));
+
+  i2c_arm_notify_slot(device);
 
   tSMBusStatus r = SMBusMasterI2CRead(p_sMaster, address, data, nbytes);
   if (r == SMBUS_OK) { // the read was successfully initiated
@@ -74,6 +81,12 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
+  }
+  if (r != SMBUS_OK) {
+    log_error(LOG_I2C, "dev %d read fail %s\r\n", device, SMBUS_get_error(r));
+  }
+  else {
+    log_debug(LOG_I2C, "dev %d read success 0x%0*X\r\n", device, nbytes * 2, data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24));
   }
   return r;
 }
@@ -92,7 +105,10 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
   }
   uint8_t data[MAX_BYTES];
 
-  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+  if (nbytes > MAX_BYTES)
+    nbytes = MAX_BYTES;
+
+  i2c_arm_notify_slot(device);
 
   tSMBusStatus r = SMBusMasterI2CWriteRead(smbus, address, reg_address, nbytes_addr, data, nbytes);
   if (r == SMBUS_OK) { // the WriteRead was successfully initiated
@@ -108,6 +124,12 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
   nbytes = (nbytes > MAX_BYTES) ? MAX_BYTES : nbytes;
   for (int i = 0; i < nbytes; ++i) {
     *packed_data |= data[i] << (i * 8);
+  }
+  if (r != SMBUS_OK) {
+    log_error(LOG_I2C, "dev %d reg read fail %s\r\n", device, SMBUS_get_error(r));
+  }
+  else {
+    log_debug(LOG_I2C, "dev %d reg read success 0x%0*X\r\n", device, nbytes * 2, *packed_data);
   }
   return r;
 }
@@ -134,7 +156,7 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   if (nbytes > MAX_BYTES + nbytes_addr)
     nbytes = MAX_BYTES + nbytes_addr;
 
-  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+  i2c_arm_notify_slot(device);
 
   tSMBusStatus r = SMBusMasterI2CWrite(p_sMaster, address, data, nbytes);
   if (r == SMBUS_OK) { // the write was successfully initiated
@@ -143,9 +165,15 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   }
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
-    log_error(LOG_I2C, "write fail %s\r\n", SMBUS_get_error(r));
+    log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
   }
 
+  if (r != SMBUS_OK) {
+    log_error(LOG_I2C, "dev %d reg write fail %s\r\n", device, SMBUS_get_error(r));
+  }
+  else {
+    log_debug(LOG_I2C, "dev %d reg write success 0x%0*X\r\n", device, nbytes * 2, packed_data);
+  }
   return r;
 }
 
@@ -162,7 +190,7 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   if (nbytes > MAX_BYTES)
     nbytes = MAX_BYTES;
 
-  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+  i2c_arm_notify_slot(device);
 
   tSMBusStatus r = SMBusMasterI2CWrite(p_sMaster, address, data, nbytes);
   if (r == SMBUS_OK) { // the write was successfully initiated
@@ -171,9 +199,15 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   }
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
-    log_error(LOG_I2C, "write fail %s\r\n", SMBUS_get_error(r));
+    log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
   }
 
+  if (r != SMBUS_OK) {
+    log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+  }
+  else {
+    log_debug(LOG_I2C, "dev %d write success 0x%0*X\r\n", device, nbytes * 2, value);
+  }
   return r;
 }
 // for PMBUS commands
@@ -204,8 +238,8 @@ tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_s
     return r;
   }
 
-  // TRANSACTION 2: device read/write
-  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+  // TRANSACTION 2: device read/write. PMBus/SMBus command.
+  i2c_arm_notify_slot(device);
   if (read) {
     r = SMBusMasterByteWordRead(smbus, add->dev_addr, cmd->command, value, cmd->size);
   }
@@ -218,6 +252,8 @@ tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_s
     return r;
   }
   i2c_wait_for_transfer(device);
+  // ISR writes the per-bus status (SMBUS_OK or specific error).
+  r = *smbus_status;
 
-  return *smbus_status;
+  return r;
 }

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -26,31 +26,37 @@
 #include "I2CCommunication.h"
 #include "common/smbus_helper.h"
 
+#include "InterruptHandlers.h"
+
 extern tSMBus g_sMaster1;
-extern tSMBusStatus eStatus1;
 extern tSMBus g_sMaster2;
-extern tSMBusStatus eStatus2;
 extern tSMBus g_sMaster3;
-extern tSMBusStatus eStatus3;
 extern tSMBus g_sMaster4;
-extern tSMBusStatus eStatus4;
 extern tSMBus g_sMaster5;
-extern tSMBusStatus eStatus5;
 extern tSMBus g_sMaster6;
-extern tSMBusStatus eStatus6;
 
 tSMBus *const pSMBus[10] = {NULL, &g_sMaster1, &g_sMaster2, &g_sMaster3, &g_sMaster4, &g_sMaster5, &g_sMaster6, NULL, NULL, NULL};
-tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus3, &eStatus4, &eStatus5, &eStatus6, NULL, NULL, NULL};
+volatile tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus3, &eStatus4, &eStatus5, &eStatus6, NULL, NULL, NULL};
 
 #define MAX_BYTES_ADDR 2
 #define MAX_BYTES      4
 
-#define I2C_MAX_TRIES 25
+#define I2C_TIMEOUT_MS 250
+
+static void i2c_wait_for_transfer(uint8_t device)
+{
+  // Caller must have already set TaskNotifySMBus[device]
+  if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(I2C_TIMEOUT_MS)) == 0) {
+    // timeout — no notification arrived
+    TaskNotifySMBus[device] = NULL;
+    log_warn(LOG_I2C, "transfer stuck\r\n");
+  }
+}
 
 int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t data[MAX_BYTES])
 {
   tSMBus *p_sMaster = pSMBus[device];
-  tSMBusStatus *p_eStatus = eStatus[device];
+  volatile tSMBusStatus *p_eStatus = eStatus[device];
 
   configASSERT(p_sMaster != NULL);
 
@@ -58,19 +64,15 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   if (nbytes > MAX_BYTES)
     nbytes = MAX_BYTES;
 
+  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+
   tSMBusStatus r = SMBusMasterI2CRead(p_sMaster, address, data, nbytes);
   if (r == SMBUS_OK) { // the read was successfully initiated
-    int tries = 0;
-    while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
-      vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > I2C_MAX_TRIES) {
-        log_warn(LOG_I2C, "transfer stuck\r\n");
-        break;
-      }
-    }
+    i2c_wait_for_transfer(device);
     r = *p_eStatus;
   }
   else {
+    TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
   }
   return r;
@@ -81,7 +83,7 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
                          uint32_t *packed_data)
 {
   tSMBus *smbus = pSMBus[device];
-  tSMBusStatus *p_status = eStatus[device];
+  volatile tSMBusStatus *p_status = eStatus[device];
 
   configASSERT(smbus != NULL);
   uint8_t reg_address[MAX_BYTES_ADDR];
@@ -90,19 +92,15 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
   }
   uint8_t data[MAX_BYTES];
 
+  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+
   tSMBusStatus r = SMBusMasterI2CWriteRead(smbus, address, reg_address, nbytes_addr, data, nbytes);
   if (r == SMBUS_OK) { // the WriteRead was successfully initiated
-    int tries = 0;
-    while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
-      vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > I2C_MAX_TRIES) {
-        log_warn(LOG_I2C, "transfer stuck\r\n");
-        break;
-      }
-    }
+    i2c_wait_for_transfer(device);
     r = *p_status;
   }
   else {
+    TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
   }
   // pack the data for return to the caller
@@ -117,7 +115,7 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
 int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, uint16_t packed_reg_address, uint8_t nbytes, uint32_t packed_data)
 {
   tSMBus *p_sMaster = pSMBus[device];
-  tSMBusStatus *p_eStatus = eStatus[device];
+  volatile tSMBusStatus *p_eStatus = eStatus[device];
 
   configASSERT(p_sMaster != NULL);
 
@@ -136,19 +134,15 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   if (nbytes > MAX_BYTES + nbytes_addr)
     nbytes = MAX_BYTES + nbytes_addr;
 
+  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+
   tSMBusStatus r = SMBusMasterI2CWrite(p_sMaster, address, data, nbytes);
   if (r == SMBUS_OK) { // the write was successfully initiated
-    int tries = 0;
-    while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
-      vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > I2C_MAX_TRIES) {
-        log_warn(LOG_I2C, "transfer stuck\r\n");
-        break;
-      }
-    }
+    i2c_wait_for_transfer(device);
     r = *p_eStatus;
   }
   else {
+    TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "write fail %s\r\n", SMBUS_get_error(r));
   }
 
@@ -158,7 +152,7 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
 int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned int value)
 {
   tSMBus *p_sMaster = pSMBus[device];
-  tSMBusStatus *p_eStatus = eStatus[device];
+  volatile tSMBusStatus *p_eStatus = eStatus[device];
   configASSERT(p_sMaster != NULL);
 
   uint8_t data[MAX_BYTES];
@@ -168,65 +162,62 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   if (nbytes > MAX_BYTES)
     nbytes = MAX_BYTES;
 
+  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
+
   tSMBusStatus r = SMBusMasterI2CWrite(p_sMaster, address, data, nbytes);
   if (r == SMBUS_OK) { // the write was successfully initiated
-    int tries = 0;
-    while (SMBusStatusGet(p_sMaster) == SMBUS_TRANSFER_IN_PROGRESS) {
-      vTaskDelay(pdMS_TO_TICKS(10));
-      if (tries++ > I2C_MAX_TRIES) {
-        log_warn(LOG_I2C, "transfer stuck\r\n");
-        break;
-      }
-    }
+    i2c_wait_for_transfer(device);
     r = *p_eStatus;
   }
   else {
+    TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "write fail %s\r\n", SMBUS_get_error(r));
   }
 
   return r;
 }
 // for PMBUS commands
+static uint8_t smbus_get_device_index(tSMBus *smbus)
+{
+  for (int i = 1; i <= 6; i++) {
+    if (pSMBus[i] == smbus) {
+      return i;
+    }
+  }
+  return 0; // error/not found
+}
+
 tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *const smbus_status, bool read,
                              struct dev_i2c_addr_t *add, struct pm_command_t *cmd, uint8_t *value)
 {
-  // select the appropriate output for the mux
+  uint8_t device = smbus_get_device_index(smbus);
+  if (device == 0) {
+    log_error(LOG_I2C, "PMBUS invalid device\r\n");
+    return SMBUS_PERIPHERAL_BUSY;
+  }
+
+  // TRANSACTION 1: mux selection via existing helper
   uint8_t data = 0x1U << add->mux_bit;
-  tSMBusStatus r = SMBusMasterI2CWrite(smbus, add->mux_addr, &data, 1);
+  tSMBusStatus r = apollo_i2c_ctl_w(device, add->mux_addr, 1, data);
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "PMBUS write fail %s\r\n", SMBUS_get_error(r));
+    log_error(LOG_I2C, "PMBUS mux write fail %s\r\n", SMBUS_get_error(r));
     return r;
   }
-  int tries = 0;
-  while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
-    vTaskDelay(pdMS_TO_TICKS(10));
-    if (tries++ > I2C_MAX_TRIES) {
-      log_warn(LOG_I2C, "transfer stuck\r\n");
-      break;
-    }
-  }
-  if (*smbus_status != SMBUS_OK) {
-    return *smbus_status;
-  }
-  // read/write to the device itself
+
+  // TRANSACTION 2: device read/write
+  TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
   if (read) {
     r = SMBusMasterByteWordRead(smbus, add->dev_addr, cmd->command, value, cmd->size);
   }
-  else { // write
+  else {
     r = SMBusMasterByteWordWrite(smbus, add->dev_addr, cmd->command, value, cmd->size);
   }
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "PMBUS write/read fail %s\r\n", SMBUS_get_error(r));
+    log_error(LOG_I2C, "PMBUS read/write fail %s\r\n", SMBUS_get_error(r));
+    TaskNotifySMBus[device] = NULL;
     return r;
   }
-  tries = 0;
-  while (SMBusStatusGet(smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
-    vTaskDelay(pdMS_TO_TICKS(10));
-    if (tries++ > I2C_MAX_TRIES) {
-      log_warn(LOG_I2C, "transfer stuck\r\n");
-      break;
-    }
-  }
+  i2c_wait_for_transfer(device);
 
-  return r;
+  return *smbus_status;
 }

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -81,6 +81,7 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
+    return r;
   }
   if (r != SMBUS_OK) {
     log_error(LOG_I2C, "dev %d read fail %s\r\n", device, SMBUS_get_error(r));
@@ -118,6 +119,7 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "read fail %s\r\n", SMBUS_get_error(r));
+    return r;
   }
   // pack the data for return to the caller
   *packed_data = 0UL;
@@ -166,6 +168,7 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+    return r;
   }
 
   if (r != SMBUS_OK) {
@@ -200,6 +203,7 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+    return r;
   }
 
   if (r != SMBUS_OK) {

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -49,6 +49,15 @@ volatile tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus
 #define MAX_BYTES_ADDR 2
 #define MAX_BYTES      4
 
+// Per-bus scratch buffers for I2C transfers, indexed by device the same as pSMBus[].
+// The TI SMBus driver keeps a *pointer* (pui8Rx/TxBuffer) to the caller's buffer and its
+// ISR reads/writes it as bytes arrive. Passing these persistent .bss buffers instead of a
+// stack local means a late ISR completing after the wrapper has returned writes here, not
+// into a freed/reused stack frame (the memory-corruption root cause; see i2c_lockup_notes.md).
+// Safe to share per bus because each bus is serialized by its own semaphore.
+static uint8_t i2c_rxbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BYTES];
+static uint8_t i2c_txbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BYTES_ADDR + MAX_BYTES];
+
 #define I2C_TIMEOUT_MS 250
 
 // Bounded wait (microseconds) for the on-chip I2C master FSM to finish a prior
@@ -108,11 +117,14 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   if (nbytes > MAX_BYTES)
     nbytes = MAX_BYTES;
 
-  memset(data, 0, nbytes * sizeof(data[0]));
+  // Read into the persistent per-bus buffer rather than the caller's (possibly stack) buffer,
+  // so a late ISR completing after this function returns can't write into a freed/reused frame.
+  uint8_t *rxbuf = i2c_rxbuf[device];
+  memset(rxbuf, 0, nbytes * sizeof(rxbuf[0]));
 
   i2c_arm_notify_slot(device);
 
-  tSMBusStatus r = SMBusMasterI2CRead(p_sMaster, address, data, nbytes);
+  tSMBusStatus r = SMBusMasterI2CRead(p_sMaster, address, rxbuf, nbytes);
   if (r == SMBUS_OK) { // the read was successfully initiated
     i2c_wait_for_transfer(device);
     r = *p_eStatus;
@@ -120,8 +132,10 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   else {
     TaskNotifySMBus[device] = NULL; // clean up if initiation failed
     i2c_log_busy(device, "read", r);
+    memcpy(data, rxbuf, nbytes); // hand back zeros (rxbuf was memset)
     return r;
   }
+  memcpy(data, rxbuf, nbytes); // copy results to the caller before returning
   if (r != SMBUS_OK) {
     log_error(LOG_I2C, "dev %d read fail %s\r\n", device, SMBUS_get_error(r));
   }
@@ -139,11 +153,11 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
   volatile tSMBusStatus *p_status = eStatus[device];
 
   configASSERT(smbus != NULL);
-  uint8_t reg_address[MAX_BYTES_ADDR];
+  uint8_t *reg_address = i2c_txbuf[device]; // persistent per-bus TX buffer (see note at top)
   for (int i = 0; i < nbytes_addr; ++i) {
     reg_address[i] = (packed_reg_address >> (nbytes_addr - 1 - i) * 8) & 0xFF; // the first byte is high byte in EEPROM's two-byte reg address
   }
-  uint8_t data[MAX_BYTES];
+  uint8_t *data = i2c_rxbuf[device]; // persistent per-bus RX buffer
 
   if (nbytes > MAX_BYTES)
     nbytes = MAX_BYTES;
@@ -183,7 +197,7 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   configASSERT(p_sMaster != NULL);
 
   // first byte (if write to one of five clock chips) or two bytes (if write to EEPROM) is the register, others are the data
-  uint8_t data[MAX_BYTES_ADDR + MAX_BYTES];
+  uint8_t *data = i2c_txbuf[device]; // persistent per-bus TX buffer (see note at top)
   for (int i = 0; i < nbytes_addr; ++i) {
     data[i] = (packed_reg_address >> (nbytes_addr - 1 - i) * 8) & 0xFF; // the first byte is high byte in EEPROM's two-byte reg address
   }
@@ -225,7 +239,7 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   volatile tSMBusStatus *p_eStatus = eStatus[device];
   configASSERT(p_sMaster != NULL);
 
-  uint8_t data[MAX_BYTES];
+  uint8_t *data = i2c_txbuf[device]; // persistent per-bus TX buffer (see note at top)
   for (int i = 0; i < MAX_BYTES; ++i) {
     data[i] = (value >> i * 8) & 0xFFUL;
   }

--- a/projects/cm_mcu/I2CCommunication.c
+++ b/projects/cm_mcu/I2CCommunication.c
@@ -68,6 +68,9 @@ volatile tSMBusStatus *const eStatus[10] = {NULL, &eStatus1, &eStatus2, &eStatus
 static uint8_t i2c_rxbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BYTES];
 static uint8_t i2c_txbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BYTES_ADDR + MAX_BYTES];
 
+#define MAX_BLOCK_BYTES 32 // SMBus spec maximum block-read payload
+static uint8_t i2c_block_rxbuf[sizeof(pSMBus) / sizeof(pSMBus[0])][MAX_BLOCK_BYTES];
+
 #define I2C_TIMEOUT_MS 250
 
 // Bounded wait (microseconds) for the on-chip I2C master FSM to finish a prior
@@ -82,12 +85,15 @@ static void i2c_arm_notify_slot(uint8_t device)
   // STOP cannot make this transaction's initiation return PERIPHERAL_BUSY.
   uint32_t base = pSMBus[device]->ui32I2CBase;
   uint32_t us = 0;
-  while (MAP_I2CMasterBusy(base) && us < I2C_IDLE_WAIT_US) {
+  uint32_t mcs = 0;
+  while (((mcs = HWREG(base + I2C_O_MCS)) & (I2C_MCS_BUSY | I2C_MCS_BUSBSY)) &&
+         us < I2C_IDLE_WAIT_US) {
     DELAY_US(1);
     ++us;
   }
   if (us) {
-    log_debug(LOG_I2C, "dev %d waited %u us for master idle\r\n", device, us);
+    log_debug(LOG_I2C, "dev %d waited %u us for idle (MCS=0x%02lx)\r\n", device, us,
+              (unsigned long)mcs);
   }
 
   TaskNotifySMBus[device] = xTaskGetCurrentTaskHandle();
@@ -147,7 +153,12 @@ int apollo_i2c_ctl_r(uint8_t device, uint8_t address, uint8_t nbytes, uint8_t da
   }
   memcpy(data, rxbuf, nbytes); // copy results to the caller before returning
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "dev %d read fail %s\r\n", device, SMBUS_get_error(r));
+    if (SMBUS_is_NACK(r)) {
+      log_debug(LOG_I2C, "dev %d read NACK\r\n", device);
+    }
+    else {
+      log_error(LOG_I2C, "dev %d read fail %s\r\n", device, SMBUS_get_error(r));
+    }
   }
   else {
     log_debug(LOG_I2C, "dev %d read success 0x%0*X\r\n", device, nbytes * 2, data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24));
@@ -191,7 +202,12 @@ int apollo_i2c_ctl_reg_r(uint8_t device, uint8_t address, uint8_t nbytes_addr,
     *packed_data |= data[i] << (i * 8);
   }
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "dev %d reg read fail %s\r\n", device, SMBUS_get_error(r));
+    if (SMBUS_is_NACK(r)) {
+      log_debug(LOG_I2C, "dev %d reg read NACK\r\n", device);
+    }
+    else {
+      log_error(LOG_I2C, "dev %d reg read fail %s\r\n", device, SMBUS_get_error(r));
+    }
   }
   else {
     log_debug(LOG_I2C, "dev %d reg read success 0x%0*X\r\n", device, nbytes * 2, *packed_data);
@@ -235,7 +251,12 @@ int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr, u
   }
 
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "dev %d reg write fail %s\r\n", device, SMBUS_get_error(r));
+    if (SMBUS_is_NACK(r)) {
+      log_debug(LOG_I2C, "dev %d reg write NACK\r\n", device);
+    }
+    else {
+      log_error(LOG_I2C, "dev %d reg write fail %s\r\n", device, SMBUS_get_error(r));
+    }
   }
   else {
     log_debug(LOG_I2C, "dev %d reg write success 0x%0*X\r\n", device, nbytes * 2, packed_data);
@@ -270,7 +291,12 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
   }
 
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+    if (SMBUS_is_NACK(r)) {
+      log_debug(LOG_I2C, "dev %d write NACK\r\n", device);
+    }
+    else {
+      log_error(LOG_I2C, "dev %d write fail %s\r\n", device, SMBUS_get_error(r));
+    }
   }
   else {
     log_debug(LOG_I2C, "dev %d write success 0x%0*X\r\n", device, nbytes * 2, value);
@@ -279,16 +305,21 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
 }
 // read a variable-length SMBus block from an I2C device, through the
 // notification handshake. The slave reports the length; on success the data
-// is in data[] and the count is available via SMBusRxPacketSizeGet().
+// is copied into data[] (caller must supply at least MAX_BLOCK_BYTES bytes).
+// Uses a persistent per-bus .bss buffer so a late ISR completing after this
+// function returns cannot write into a freed/reused stack frame.
 int apollo_i2c_ctl_block_r(uint8_t device, uint8_t address, uint8_t command, uint8_t *data)
 {
   tSMBus *p_sMaster = pSMBus[device];
   volatile tSMBusStatus *p_eStatus = eStatus[device];
   configASSERT(p_sMaster != NULL);
 
+  uint8_t *rxbuf = i2c_block_rxbuf[device];
+  memset(rxbuf, 0, MAX_BLOCK_BYTES);
+
   i2c_arm_notify_slot(device);
 
-  tSMBusStatus r = SMBusMasterBlockRead(p_sMaster, address, command, data);
+  tSMBusStatus r = SMBusMasterBlockRead(p_sMaster, address, command, rxbuf);
   if (r == SMBUS_OK) { // the block read was successfully initiated
     i2c_wait_for_transfer(device);
     r = *p_eStatus;
@@ -300,7 +331,18 @@ int apollo_i2c_ctl_block_r(uint8_t device, uint8_t address, uint8_t command, uin
   }
 
   if (r != SMBUS_OK) {
-    log_error(LOG_I2C, "dev %d block read fail %s\r\n", device, SMBUS_get_error(r));
+    if (SMBUS_is_NACK(r)) {
+      log_debug(LOG_I2C, "dev %d block read NACK\r\n", device);
+    }
+    else {
+      log_error(LOG_I2C, "dev %d block read fail %s\r\n", device, SMBUS_get_error(r));
+    }
+  }
+  else {
+    uint8_t received = SMBusRxPacketSizeGet(p_sMaster);
+    if (received > MAX_BLOCK_BYTES)
+      received = MAX_BLOCK_BYTES;
+    memcpy(data, rxbuf, received);
   }
   return r;
 }

--- a/projects/cm_mcu/I2CCommunication.h
+++ b/projects/cm_mcu/I2CCommunication.h
@@ -27,8 +27,12 @@ int apollo_i2c_ctl_w(uint8_t device, uint8_t address, uint8_t nbytes, unsigned i
 int apollo_i2c_ctl_reg_w(uint8_t device, uint8_t address, uint8_t nbytes_addr,
                          uint16_t packed_reg_address, uint8_t nbytes,
                          uint32_t packed_data);
+// read a variable-length SMBus block (slave reports length) from an I2C device
+int apollo_i2c_ctl_block_r(uint8_t device, uint8_t address, uint8_t command, uint8_t *data);
 // read/write a register using the PMBUS protocol
 tSMBusStatus apollo_pmbus_rw(tSMBus *smbus, volatile tSMBusStatus *smbus_status, bool read,
                              struct dev_i2c_addr_t *add, struct pm_command_t *cmd, uint8_t *value);
+// return the I2C bus/device index (1-6) for an SMBus controller, or 0 if not found
+uint8_t smbus_get_device_index(tSMBus *smbus);
 
 #endif /* PROJECTS_CM_MCU_I2CCOMMUNICATION_H_ */

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -49,9 +49,9 @@ void InitTask(void *parameters)
     vTaskDelay(pdMS_TO_TICKS(1000));
   }
 #endif                               // REV1
-  init_registers_ff();               // initialize I/O expander for fireflies -- with FF monitoring via I2C in other threads, it grabs semaphore inside
-  int status = init_registers_clk(); // initialize I/O expander for clocks
-  readFFpresent();
+  int status = init_registers_ff();  // initialize I/O expander for fireflies -- with FF monitoring via I2C in other threads, it grabs semaphore inside
+  log_info(LOG_SERVICE, "Firefly I/O expander init %s\r\n", status==0?"OK":"Fail");
+  status = init_registers_clk(); // initialize I/O expander for clocks
   if (status == 0)
     log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");
   else {

--- a/projects/cm_mcu/InitTask.c
+++ b/projects/cm_mcu/InitTask.c
@@ -48,9 +48,9 @@ void InitTask(void *parameters)
   while (getPowerControlState() != POWER_ON) {
     vTaskDelay(pdMS_TO_TICKS(1000));
   }
-#endif                               // REV1
-  int status = init_registers_ff();  // initialize I/O expander for fireflies -- with FF monitoring via I2C in other threads, it grabs semaphore inside
-  log_info(LOG_SERVICE, "Firefly I/O expander init %s\r\n", status==0?"OK":"Fail");
+#endif                              // REV1
+  int status = init_registers_ff(); // initialize I/O expander for fireflies -- with FF monitoring via I2C in other threads, it grabs semaphore inside
+  log_info(LOG_SERVICE, "Firefly I/O expander init %s\r\n", status == 0 ? "OK" : "Fail");
   status = init_registers_clk(); // initialize I/O expander for clocks
   if (status == 0)
     log_info(LOG_SERVICE, "Clock I/O expander initialized\r\n");

--- a/projects/cm_mcu/InterruptHandlers.c
+++ b/projects/cm_mcu/InterruptHandlers.c
@@ -9,12 +9,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <string.h>
-
 #include "InterruptHandlers.h"
 
 // local includes
-#include "common/LocalUart.h"
 #include "common/utils.h"
 #include "common/power_ctl.h"
 #include "common/i2c_reg.h"
@@ -194,72 +191,47 @@ volatile tSMBusStatus eStatus5 = SMBUS_OK;
 volatile tSMBusStatus eStatus6 = SMBUS_OK;
 
 TaskHandle_t TaskNotifySMBus[10] = {NULL}; // indexed same as pSMBus[]
+static void SMBusMasterIntHandlerCore(uint8_t device, tSMBus *master, volatile tSMBusStatus *status)
+{
+  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+  *status = SMBusMasterIntProcess(master);
+  if (SMBusStatusGet(master) != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[device] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[device], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[device] = NULL;
+  }
+  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+}
 
 // SMBUs specific handler for I2C
 void SMBusMasterIntHandler1(void)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  eStatus1 = SMBusMasterIntProcess(&g_sMaster1);
-  if (eStatus1 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[1] != NULL) {
-    vTaskNotifyGiveFromISR(TaskNotifySMBus[1], &xHigherPriorityTaskWoken);
-    TaskNotifySMBus[1] = NULL;
-  }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+  SMBusMasterIntHandlerCore(1, &g_sMaster1, &eStatus1);
 }
 
 void SMBusMasterIntHandler2(void)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  eStatus2 = SMBusMasterIntProcess(&g_sMaster2);
-  if (eStatus2 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[2] != NULL) {
-    vTaskNotifyGiveFromISR(TaskNotifySMBus[2], &xHigherPriorityTaskWoken);
-    TaskNotifySMBus[2] = NULL;
-  }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+  SMBusMasterIntHandlerCore(2, &g_sMaster2, &eStatus2);
 }
 
 void SMBusMasterIntHandler3(void)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  eStatus3 = SMBusMasterIntProcess(&g_sMaster3);
-  if (eStatus3 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[3] != NULL) {
-    vTaskNotifyGiveFromISR(TaskNotifySMBus[3], &xHigherPriorityTaskWoken);
-    TaskNotifySMBus[3] = NULL;
-  }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+  SMBusMasterIntHandlerCore(3, &g_sMaster3, &eStatus3);
 }
 
 void SMBusMasterIntHandler4(void)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  eStatus4 = SMBusMasterIntProcess(&g_sMaster4);
-  if (eStatus4 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[4] != NULL) {
-    vTaskNotifyGiveFromISR(TaskNotifySMBus[4], &xHigherPriorityTaskWoken);
-    TaskNotifySMBus[4] = NULL;
-  }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+  SMBusMasterIntHandlerCore(4, &g_sMaster4, &eStatus4);
 }
 
 void SMBusMasterIntHandler5(void)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  eStatus5 = SMBusMasterIntProcess(&g_sMaster5);
-  if (eStatus5 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[5] != NULL) {
-    vTaskNotifyGiveFromISR(TaskNotifySMBus[5], &xHigherPriorityTaskWoken);
-    TaskNotifySMBus[5] = NULL;
-  }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+  SMBusMasterIntHandlerCore(5, &g_sMaster5, &eStatus5);
 }
 
 void SMBusMasterIntHandler6(void)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  eStatus6 = SMBusMasterIntProcess(&g_sMaster6);
-  if (eStatus6 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[6] != NULL) {
-    vTaskNotifyGiveFromISR(TaskNotifySMBus[6], &xHigherPriorityTaskWoken);
-    TaskNotifySMBus[6] = NULL;
-  }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+  SMBusMasterIntHandlerCore(6, &g_sMaster6, &eStatus6);
 }
 
 // Stores the handle of the task that will be notified when the

--- a/projects/cm_mcu/InterruptHandlers.c
+++ b/projects/cm_mcu/InterruptHandlers.c
@@ -193,76 +193,72 @@ volatile tSMBusStatus eStatus4 = SMBUS_OK;
 volatile tSMBusStatus eStatus5 = SMBUS_OK;
 volatile tSMBusStatus eStatus6 = SMBUS_OK;
 
+TaskHandle_t TaskNotifySMBus[10] = {NULL}; // indexed same as pSMBus[]
+
 // SMBUs specific handler for I2C
 void SMBusMasterIntHandler1(void)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-  //
-  // Process the interrupt.
-  //
   eStatus1 = SMBusMasterIntProcess(&g_sMaster1);
-  // handle errors in the returning function
+  if (eStatus1 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[1] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[1], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[1] = NULL;
+  }
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 void SMBusMasterIntHandler2(void)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-  //
-  // Process the interrupt.
-  //
   eStatus2 = SMBusMasterIntProcess(&g_sMaster2);
-  // handle errors in the returning function
+  if (eStatus2 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[2] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[2], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[2] = NULL;
+  }
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 void SMBusMasterIntHandler3(void)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-  //
-  // Process the interrupt.
-  //
   eStatus3 = SMBusMasterIntProcess(&g_sMaster3);
-  // handle errors in the returning function
+  if (eStatus3 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[3] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[3], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[3] = NULL;
+  }
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 void SMBusMasterIntHandler4(void)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-  //
-  // Process the interrupt.
-  //
   eStatus4 = SMBusMasterIntProcess(&g_sMaster4);
-  // handle errors in the returning function
+  if (eStatus4 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[4] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[4], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[4] = NULL;
+  }
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 void SMBusMasterIntHandler5(void)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-  //
-  // Process the interrupt.
-  //
   eStatus5 = SMBusMasterIntProcess(&g_sMaster5);
-  // handle errors in the returning function
+  if (eStatus5 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[5] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[5], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[5] = NULL;
+  }
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 void SMBusMasterIntHandler6(void)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-  //
-  // Process the interrupt.
-  //
   eStatus6 = SMBusMasterIntProcess(&g_sMaster6);
-  // handle errors in the returning function
+  if (eStatus6 != SMBUS_TRANSFER_IN_PROGRESS && TaskNotifySMBus[6] != NULL) {
+    vTaskNotifyGiveFromISR(TaskNotifySMBus[6], &xHigherPriorityTaskWoken);
+    TaskNotifySMBus[6] = NULL;
+  }
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 

--- a/projects/cm_mcu/InterruptHandlers.h
+++ b/projects/cm_mcu/InterruptHandlers.h
@@ -32,7 +32,7 @@ extern tSMBus g_sMaster1; // for I2C #1
 extern tSMBus g_sMaster2; // for I2C #2
 extern tSMBus g_sMaster3; // for I2C #3
 extern tSMBus g_sMaster4; // for I2C #4
-extern tSMBus g_sMaster5; // for I2C #4
+extern tSMBus g_sMaster5; // for I2C #5
 extern tSMBus g_sMaster6; // for I2C #6
 
 extern volatile tSMBusStatus eStatus1;
@@ -41,6 +41,8 @@ extern volatile tSMBusStatus eStatus3;
 extern volatile tSMBusStatus eStatus4;
 extern volatile tSMBusStatus eStatus5;
 extern volatile tSMBusStatus eStatus6;
+
+extern TaskHandle_t TaskNotifySMBus[10];
 
 void SMBusMasterIntHandler1(void);
 void SMBusMasterIntHandler2(void);

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -448,7 +448,6 @@ static void snapdump_locked(struct dev_i2c_addr_t *add, uint8_t page, uint8_t sn
     log_error(LOG_SERVICE, "ctrl w fail, dev 0x%x (%s)\r\n", add->dev_addr, add->name);
     return;
   }
-#if 0
   // actual command -- read snapshot (variable-length SMBus block read, via the
   // notification handshake)
   r = apollo_i2c_ctl_block_r(1, add->dev_addr, extra_cmds[3].command, &snapshot[0]);
@@ -456,7 +455,7 @@ static void snapdump_locked(struct dev_i2c_addr_t *add, uint8_t page, uint8_t sn
     log_error(LOG_SERVICE, "block %d\r\n", r);
     return;
   }
-#endif // 0
+
   if (reset) {
     // reset SNAPSHOT. This will fail if the device is on.
     cmd = 0x3;

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -376,6 +376,7 @@ struct MonitorTaskArgs_t fpga_args = {
     .smbus_status = &eStatus5,
 #endif
     .xSem = NULL,
+    .ignoreNACK = true,
     .requirePower = true,
     .stack_size = 4096U,
 };
@@ -448,6 +449,11 @@ static void snapdump_locked(struct dev_i2c_addr_t *add, uint8_t page, uint8_t sn
     log_error(LOG_SERVICE, "ctrl w fail, dev 0x%x (%s)\r\n", add->dev_addr, add->name);
     return;
   }
+  // The device needs time to copy NVRAM into the snapshot register after the
+  // SNAPSHOT_CONTROL write. The old polling code provided ~20ms of implicit
+  // delay via vTaskDelay(10ms) per poll. Without an explicit wait here the
+  // device returns a zero-length block read (DATA_SIZE_ERROR).
+  vTaskDelay(pdMS_TO_TICKS(20));
   // actual command -- read snapshot (variable-length SMBus block read, via the
   // notification handshake)
   r = apollo_i2c_ctl_block_r(1, add->dev_addr, extra_cmds[3].command, &snapshot[0]);
@@ -575,6 +581,7 @@ struct MonitorTaskArgs_t dcdc_args = {
     .smbus = &g_sMaster1,
     .smbus_status = &eStatus1,
     .xSem = NULL,
+    .ignoreNACK = false,
     .requirePower = false,
     .stack_size = 4096U,
 };

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -448,6 +448,7 @@ static void snapdump_locked(struct dev_i2c_addr_t *add, uint8_t page, uint8_t sn
     log_error(LOG_SERVICE, "ctrl w fail, dev 0x%x (%s)\r\n", add->dev_addr, add->name);
     return;
   }
+#if 0
   // actual command -- read snapshot (variable-length SMBus block read, via the
   // notification handshake)
   r = apollo_i2c_ctl_block_r(1, add->dev_addr, extra_cmds[3].command, &snapshot[0]);
@@ -455,6 +456,7 @@ static void snapdump_locked(struct dev_i2c_addr_t *add, uint8_t page, uint8_t sn
     log_error(LOG_SERVICE, "block %d\r\n", r);
     return;
   }
+#endif // 0
   if (reset) {
     // reset SNAPSHOT. This will fail if the device is on.
     cmd = 0x3;

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -728,7 +728,7 @@ int init_registers_clk(void)
   }
   return status;
 }
-void init_registers_ff(void)
+int init_registers_ff(void)
 {
 
   // =====================================================
@@ -825,6 +825,7 @@ void init_registers_ff(void)
   if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
     xSemaphoreGive(i2c3_sem);
   }
+  return 0; // dummy value
 }
 #endif // REV1
 #if defined(REV2) || defined(REV3)
@@ -900,7 +901,7 @@ int init_registers_clk(void)
 #endif // REV2 || REV3
 
 #ifdef REV2
-void init_registers_ff(void)
+int init_registers_ff(void)
 {
   log_info(LOG_SERVICE, "%s\r\n", __func__);
   int result;
@@ -961,6 +962,7 @@ void init_registers_ff(void)
   // grab the semaphore to ensure unique access to I2C controller
   // otherwise, block its operations indefinitely until it's available
   acquireI2CSemaphoreBlock(i2c3_sem);
+  int r1 = result;
   result = 0;
   // =====================================================
   // CMv2 Schematic 4.06 I2C FPGA#2 OPTICS
@@ -1012,6 +1014,7 @@ void init_registers_ff(void)
   if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
     xSemaphoreGive(i2c3_sem);
   }
+  return r1 + result;
 }
 #elif defined(REV3)
 int init_registers_ff(void)

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -1014,7 +1014,7 @@ void init_registers_ff(void)
   }
 }
 #elif defined(REV3)
-void init_registers_ff(void)
+int init_registers_ff(void)
 {
   log_info(LOG_SERVICE, "%s\r\n", __func__);
   int result;
@@ -1075,6 +1075,7 @@ void init_registers_ff(void)
   // grab the semaphore to ensure unique access to I2C controller
   // otherwise, block its operations indefinitely until it's available
   acquireI2CSemaphoreBlock(i2c3_sem);
+  int r1 = result;
   result = 0;
   // =====================================================
   // CMv3 Schematic 4.06 I2C FPGA#2 OPTICS
@@ -1126,6 +1127,7 @@ void init_registers_ff(void)
   if (xSemaphoreGetMutexHolder(i2c3_sem) == xTaskGetCurrentTaskHandle()) {
     xSemaphoreGive(i2c3_sem);
   }
+  return r1 + result;
 }
 
 #endif // REV2

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -1275,7 +1275,7 @@ int load_all_clocks(void)
   for (int i = 0; i < CLOCK_NUM_CLOCKS; ++i) {
     status += init_load_clk(i); // load each clock config from EEPROM
     // get and print out the file name
-    vTaskDelay(pdMS_TO_TICKS(500));
+    vTaskDelay(pdMS_TO_TICKS(50));
     getClockProgram(i, clkprog_args[i].progname_clkdesgid, clkprog_args[i].progname_eeprom);
     log_info(LOG_SERVICE, "CLK%d: %s\r\n", i, clkprog_args[i].progname_clkdesgid);
   }

--- a/projects/cm_mcu/LocalTasks.c
+++ b/projects/cm_mcu/LocalTasks.c
@@ -430,13 +430,10 @@ struct pm_command_t extra_cmds[N_EXTRA_CMDS] = {
     {0xD5, 1, "MULTIPHASE_RAMP_GAIN", "", PM_STATUS},
 };
 
-void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bool reset)
+// Does the snapshot transactions; assumes i2c1_sem is already held.
+// Returns early on the first failed transaction.
+static void snapdump_locked(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bool reset)
 {
-  // grab the semaphore to ensure unique access to I2C controller
-  if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
-    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
-    return;
-  }
   // page register
   int r = apollo_pmbus_rw(&g_sMaster1, &eStatus1, false, add, &extra_cmds[0], &page);
   if (r) {
@@ -451,18 +448,12 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
     log_error(LOG_SERVICE, "ctrl w fail, dev 0x%x (%s)\r\n", add->dev_addr, add->name);
     return;
   }
-  // actual command -- read snapshot
-  tSMBusStatus r2 =
-      SMBusMasterBlockRead(&g_sMaster1, add->dev_addr, extra_cmds[3].command, &snapshot[0]);
-  if (r2 != SMBUS_OK) {
-    log_error(LOG_SERVICE, "block %d\r\n", r2);
+  // actual command -- read snapshot (variable-length SMBus block read, via the
+  // notification handshake)
+  r = apollo_i2c_ctl_block_r(1, add->dev_addr, extra_cmds[3].command, &snapshot[0]);
+  if (r != SMBUS_OK) {
+    log_error(LOG_SERVICE, "block %d\r\n", r);
     return;
-  }
-  while ((r2 = SMBusStatusGet(&g_sMaster1)) == SMBUS_TRANSFER_IN_PROGRESS) {
-    vTaskDelay(pdMS_TO_TICKS(10)); // wait
-  }
-  if (r2 != SMBUS_TRANSFER_COMPLETE) {
-    log_error(LOG_SERVICE, "SMBUS %d\r\n", r2);
   }
   if (reset) {
     // reset SNAPSHOT. This will fail if the device is on.
@@ -472,8 +463,19 @@ void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bo
       log_error(LOG_SERVICE, "error reset %s\r\n", add->name);
     }
   }
+}
 
-  // if we have a semaphore, give it
+void snapdump(struct dev_i2c_addr_t *add, uint8_t page, uint8_t snapshot[32], bool reset)
+{
+  // grab the semaphore to ensure unique access to I2C controller
+  if (acquireI2CSemaphore(i2c1_sem) == pdFAIL) {
+    log_warn(LOG_SERVICE, "could not get semaphore in time\r\n");
+    return;
+  }
+
+  snapdump_locked(add, page, snapshot, reset);
+
+  // always release the semaphore, including on the helper's error paths
   if (xSemaphoreGetMutexHolder(i2c1_sem) == xTaskGetCurrentTaskHandle()) {
     xSemaphoreGive(i2c1_sem);
   }

--- a/projects/cm_mcu/Makefile
+++ b/projects/cm_mcu/Makefile
@@ -155,9 +155,16 @@ ${COMPILER}/ZynqMonTask.o: MonI2C_addresses.c
 ${COMPILER}/MonUtils.o: MonI2C_addresses.c
 ${COMPILER}/FireflyUtils.o: MonI2C_addresses.c
 ${COMPILER}/FireflyCommands.o: MonI2C_addresses.c
+
+# Stack-smashing detection on just the three translation units implicated in the
+# rare memory-corruption anomaly (see i2c_lockup_notes.md). Per-object via a
+# target-specific variable, so the rest of the firmware is unaffected. The SSP
+# runtime symbols (__stack_chk_guard / __stack_chk_fail) are provided by
+# cm_mcu.c, which is itself NOT instrumented.
+${COMPILER}/MonitorTaskI2C.o ${COMPILER}/MonUtils.o ${COMPILER}/log.o: CFLAGS += -fstack-protector-strong
 #
 # Rules for building the project
-# 
+#
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/cm_mcu.o
 ifdef REV1
 ${COMPILER}/cm_mcu.axf: ${COMPILER}/pinout_rev1.o

--- a/projects/cm_mcu/MonUtils.c
+++ b/projects/cm_mcu/MonUtils.c
@@ -3,6 +3,7 @@
 #include "FireflyUtils.h"
 #include "Tasks.h"
 #include "common/log.h"
+#include "common/pinsel.h"
 #include "MonUtils.h"
 
 #ifdef REV1
@@ -191,6 +192,7 @@ struct MonitorTaskI2CArgs_t ff_f1_args = {
     .commands = sm_command_test_FF_F1,
     .n_commands = NCOMMANDS_FF_F1,
     .selpage_reg = FF_SELPAGE_REG,
+    .mux_reset_pin_bar = _F1_OPTICS_I2C_RESET,
     .xSem = NULL,
     .stack_size = 4096U,
     .typeCallback = FireflyType,
@@ -205,6 +207,7 @@ struct MonitorTaskI2CArgs_t ff_f2_args = {
     .commands = sm_command_test_FF_F2,
     .n_commands = NCOMMANDS_FF_F2,
     .selpage_reg = FF_SELPAGE_REG,
+    .mux_reset_pin_bar = _F2_OPTICS_I2C_RESET,
     .xSem = NULL,
     .stack_size = 4096U,
     .typeCallback = FireflyTypeF2,
@@ -220,6 +223,7 @@ struct MonitorTaskI2CArgs_t clk_args = {
     .commands = sm_command_test_CLK,
     .n_commands = NCOMMANDS_CLK,
     .selpage_reg = CLK_SELPAGE_REG,
+    .mux_reset_pin_bar = _CLOCKS_I2C_RESET,
     .xSem = NULL,
     .stack_size = 4096U,
     .typeCallback = ClockType,

--- a/projects/cm_mcu/MonitorTask.c
+++ b/projects/cm_mcu/MonitorTask.c
@@ -23,11 +23,13 @@
 // local includes
 #include "common/utils.h"
 #include "common/smbus.h"
+#include "common/smbus_helper.h"
 #include "common/log.h"
 #include "common/smbus_units.h"
 #include "MonitorTask.h"
 #include "Tasks.h"
 #include "Semaphore.h"
+#include "I2CCommunication.h"
 
 // Todo: rewrite to get away from awkward/bad SMBUS implementation from TI
 
@@ -43,6 +45,11 @@ void MonitorTask(void *parameters)
   struct MonitorTaskArgs_t *args = parameters;
 
   configASSERT(args->name != 0);
+
+  // derive the I2C bus index (1-6) from the controller pointer so we can use
+  // the notification-based apollo_i2c_ctl_* wrappers.
+  uint8_t i2c_dev = smbus_get_device_index(args->smbus);
+  configASSERT(i2c_dev != 0);
 
   bool log = false;
   args->updateTick = xLastWakeTime; // initial value
@@ -74,7 +81,7 @@ void MonitorTask(void *parameters)
         }
         else {                   // if the power state is fully on
           if (!isFullyPowered) { // was previously off
-            log_info(LOG_MON, "%s: PWR on. (Re)starting I2C monitoring.\r\n", args->name);
+            log_info(LOG_MON, "%s: PWR on. (Re)start PMBUS mon\r\n", args->name);
             isFullyPowered = true;
           }
         }
@@ -84,39 +91,20 @@ void MonitorTask(void *parameters)
       // select the appropriate output for the mux
       data[0] = 0x1U << args->devices[ps].mux_bit;
       log_trace(LOG_MON, "%s: mux to 0x%02x\r\n", args->name, data[0]);
-      tSMBusStatus r = SMBusMasterI2CWrite(args->smbus, args->devices[ps].mux_addr, data, 1);
-      if (r != SMBUS_OK) {
-        log_debug(LOG_MON, "%s: I2CBus command failed  (setting mux)\r\n", args->name);
-        continue;
-      }
-      int tries = 0;
-      while (SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
-        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(10)); // wait
-        if (++tries > 500) {
-          log_warn(LOG_MON, "timed out (SMBUSxfer mux) (%s, dev=%d)\r\n",
-                   args->name, ps);
-          break;
-        }
-      }
-      if (*args->smbus_status != SMBUS_OK) {
-        log_trace(LOG_MON, "%s:Mux w error %d, break (ps=%d)\r\n", args->name, *args->smbus_status,
-                  ps);
+      int r = apollo_i2c_ctl_w(i2c_dev, args->devices[ps].mux_addr, 1, data[0]);
+      if (r != SMBUS_OK) { // mux should always be accessible
+        log_warn(LOG_MON, "%s:Mux w error %s, break (ps=%d)\r\n", args->name, SMBUS_get_error(r), ps);
         break;
       }
 
       // loop over pages on the supply
       for (uint8_t page = 0; page < args->n_pages; ++page) {
-        r = SMBusMasterByteWordWrite(args->smbus, args->devices[ps].dev_addr, PAGE_COMMAND, &page,
-                                     1);
+        r = apollo_i2c_ctl_reg_w(i2c_dev, args->devices[ps].dev_addr, 1, PAGE_COMMAND, 1, page);
         if (r != SMBUS_OK) {
-          log_warn(LOG_MON, "SMBUS page failed %s\r\n", args->name);
-        }
-        while (SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
-          vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(10)); // wait
-        }
-        // this is checking the return from the interrupt
-        if (*args->smbus_status != SMBUS_OK) {
-          log_warn(LOG_MON, "%s: Page SMBUS ERROR: %d\r\n", args->name, *args->smbus_status);
+          if (!args->ignoreNACK && SMBUS_is_NACK(r)) {
+            log_warn(LOG_MON, "%s: Page SMBUS ERROR: %s\r\n", args->name, SMBUS_get_error(r));
+          }
+          continue;
         }
         log_trace(LOG_MON, "%s: Page %d\r\n", args->name, page);
 
@@ -124,34 +112,22 @@ void MonitorTask(void *parameters)
         for (int c = 0; c < args->n_commands; ++c) {
           int index = ps * (args->n_commands * args->n_pages) + page * args->n_commands + c;
 
-          data[0] = 0x0U;
-          data[1] = 0x0U;
-          r = SMBusMasterByteWordRead(args->smbus, args->devices[ps].dev_addr,
-                                      args->commands[c].command, data, args->commands[c].size);
+          uint32_t output_raw = 0;
+          r = apollo_i2c_ctl_reg_r(i2c_dev, args->devices[ps].dev_addr, 1,
+                                   args->commands[c].command, args->commands[c].size, &output_raw);
           if (r != SMBUS_OK) {
-            log_warn(LOG_MON, "%s: SMBUS failed (master/bus busy, (ps=%d,c=%d,p=%d)\r\n", args->name,
-                     ps, c, page);
-            args->pm_values[index] = __builtin_nanf("");
-            continue; // abort reading this register
-          }
-          tries = 0;
-          while (SMBusStatusGet(args->smbus) == SMBUS_TRANSFER_IN_PROGRESS) {
-            vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(10)); // wait
-            if (++tries > 500) {
-              log_warn(LOG_MON, "timed out (SMBUSxfer) (%s, c=%d,dev=%d)\r\n",
-                       args->name, c, ps);
-              break;
+            if (!args->ignoreNACK && SMBUS_is_NACK(r)) {
+              log_warn(LOG_MON, "%s: Error %s, break out of loop (ps=%d,c=%d,p=%d) ...\r\n", args->name,
+                       SMBUS_get_error(r), ps, c, page);
             }
-          }
-          if (*args->smbus_status != SMBUS_OK) {
-            log_warn(LOG_MON, "%s: Error %d, break out of loop (ps=%d,c=%d,p=%d) ...\r\n", args->name,
-                     *args->smbus_status, ps, c, page);
             // abort reading this device
             args->pm_values[index] = __builtin_nanf("");
             if (log)
               errbuffer_put(EBUF_I2C, (uint16_t)args->name[0]);
             break;
           }
+          data[0] = output_raw & 0xFFU;
+          data[1] = (output_raw >> 8) & 0xFFU;
           float val;
           if (args->commands[c].type == PM_LINEAR11) {
             linear11_val_t ii;

--- a/projects/cm_mcu/MonitorTask.h
+++ b/projects/cm_mcu/MonitorTask.h
@@ -43,6 +43,7 @@ struct MonitorTaskArgs_t {
   tSMBus *smbus;                       // pointer to I2C controller
   volatile tSMBusStatus *smbus_status; // pointer to I2C status
   volatile TickType_t updateTick;      // last update time, in ticks
+  bool ignoreNACK;                     // true if NACKs should be ignored
   SemaphoreHandle_t xSem;              // semaphore for controlling access to device
   const bool requirePower;             // true if device requires power
   UBaseType_t stack_size;              // stack size of task

--- a/projects/cm_mcu/MonitorTaskI2C.c
+++ b/projects/cm_mcu/MonitorTaskI2C.c
@@ -120,7 +120,7 @@ void MonitorTaskI2C(void *parameters)
         log_warn(LOG_MONI2C, "%s: device %d type 0 for CLZ call\r\n", args->name, device);
         continue; // skip if type is 0 (e.g., not determined)
       }
-      // clz behavior is undefined if argument is zero. 
+      // clz behavior is undefined if argument is zero.
       uint32_t devtype = 31 - __builtin_clz(devtype_mask); // highest bit set FIXME: this is backwards
       // devtype indexes page[] and command[] (same dimension). A devtype past the end of those
       // arrays -- e.g. DEVICE_NONE (0x80) -> 7, or any misread/garbage mask with a bit above the

--- a/projects/cm_mcu/MonitorTaskI2C.c
+++ b/projects/cm_mcu/MonitorTaskI2C.c
@@ -67,7 +67,7 @@ void MonitorTaskI2C(void *parameters)
     // -------------------------------
     for (int device = 0; device < args->n_devices; ++device) {
       log_debug(LOG_MONI2C, "%s: device %s\r\n", args->name, args->devices[device].name);
-      // if there is a present call back and it reurns false, skip this device
+      // if there is a present call back and it returns false, skip this device
       if (args->presentCallback && !args->presentCallback(device)) {
         log_debug(LOG_MONI2C, "%s: device %d not present\r\n", args->name, device);
         continue;
@@ -103,6 +103,13 @@ void MonitorTaskI2C(void *parameters)
       int res = apollo_i2c_ctl_w(args->i2c_dev, args->devices[device].mux_addr, 1, data);
       if (res != 0) {
         log_warn(LOG_MONI2C, "Mux write error %s, break (instance=%s,ps=%d)\r\n", SMBUS_get_error(res), args->name, device);
+        // toggle the MUX reset line. According to TCA9548A this can be as short as
+        // 6 ns
+        if (args->mux_reset_pin_bar > 0) {
+          write_gpio_pin(args->mux_reset_pin_bar, 0); // active low
+          DELAY_US(1);
+          write_gpio_pin(args->mux_reset_pin_bar, 1); // active low
+        }
         break;
       }
       uint8_t last_page_reg_value = 0xff;
@@ -136,8 +143,6 @@ void MonitorTaskI2C(void *parameters)
         uint32_t output_raw;
         int res = apollo_i2c_ctl_reg_r(args->i2c_dev, args->devices[device].dev_addr, args->commands[c].reg_size,
                                        args->commands[c].command[devtype], args->commands[c].size, &output_raw);
-        log_debug(LOG_MONI2C, "%s: dev%02d<<reg %s (pg %d add 0x%x), value 0x%x\r\n", args->name, device, args->commands[c].name, page_reg_value,
-                  args->commands[c].command[devtype], output_raw);
         if (res != 0) {
           log_error(LOG_MONI2C, "%s: %s read Error %s, break (ps=%d)\r\n",
                     args->name, args->commands[c].name, SMBUS_get_error(res), device);
@@ -145,6 +150,9 @@ void MonitorTaskI2C(void *parameters)
           break;
         }
         else {
+          log_debug(LOG_MONI2C, "%s: dev%02d<<reg %s (pg %d add 0x%x), value 0x%x\r\n",
+                    args->name, device, args->commands[c].name, page_reg_value,
+                    args->commands[c].command[devtype], output_raw);
           uint16_t masked_output = output_raw & args->commands[c].bit_mask;
           args->commands[c].storeData(masked_output, device);
         }
@@ -158,6 +166,13 @@ void MonitorTaskI2C(void *parameters)
       res = apollo_i2c_ctl_w(args->i2c_dev, args->devices[device].mux_addr, 1, 0);
       if (res != 0) {
         log_warn(LOG_MONI2C, "Mux write error %s, break (instance=%s,ps=%d)\r\n", SMBUS_get_error(res), args->name, device);
+        // toggle the MUX reset line. According to TCA9548A this can be as short as
+        // 6 ns
+        if (args->mux_reset_pin_bar > 0) {
+          write_gpio_pin(args->mux_reset_pin_bar, 0); // active low
+          DELAY_US(1);
+          write_gpio_pin(args->mux_reset_pin_bar, 1); // active low
+        }
         break;
       }
       log_debug(LOG_MONI2C, "%s: reset mux\r\n", args->name);

--- a/projects/cm_mcu/MonitorTaskI2C.c
+++ b/projects/cm_mcu/MonitorTaskI2C.c
@@ -116,6 +116,11 @@ void MonitorTaskI2C(void *parameters)
 
       // what kind of device is this
       uint32_t devtype_mask = args->typeCallback(device);
+      if (devtype_mask == 0) {
+        log_warn(LOG_MONI2C, "%s: device %d type 0 for CLZ call\r\n", args->name, device);
+        continue; // skip if type is 0 (e.g., not determined)
+      }
+      // clz behavior is undefined if argument is zero. 
       uint32_t devtype = 31 - __builtin_clz(devtype_mask); // highest bit set FIXME: this is backwards
       // Loop to read I2C registers/commands
       for (int c = 0; c < args->n_commands; ++c) {

--- a/projects/cm_mcu/MonitorTaskI2C.c
+++ b/projects/cm_mcu/MonitorTaskI2C.c
@@ -122,6 +122,14 @@ void MonitorTaskI2C(void *parameters)
       }
       // clz behavior is undefined if argument is zero. 
       uint32_t devtype = 31 - __builtin_clz(devtype_mask); // highest bit set FIXME: this is backwards
+      // devtype indexes page[] and command[] (same dimension). A devtype past the end of those
+      // arrays -- e.g. DEVICE_NONE (0x80) -> 7, or any misread/garbage mask with a bit above the
+      // top valid type bit -- would read out of bounds. Bound by the array size, skip otherwise.
+      if (devtype >= sizeof(args->commands->page)) {
+        log_warn(LOG_MONI2C, "%s: device %d unexpected type mask 0x%x (devtype %u), skipping\r\n",
+                 args->name, device, devtype_mask, devtype);
+        continue;
+      }
       // Loop to read I2C registers/commands
       for (int c = 0; c < args->n_commands; ++c) {
         // check if the command is for this device

--- a/projects/cm_mcu/MonitorTaskI2C.h
+++ b/projects/cm_mcu/MonitorTaskI2C.h
@@ -38,6 +38,7 @@ struct MonitorTaskI2CArgs_t {
   struct i2c_reg_command_t *commands;    // list of commands
   const uint8_t n_commands;              // number of commands
   const uint16_t selpage_reg;            // register for selecting page
+  const int mux_reset_pin_bar;           // MCU pin for resetting the I2C Mux. active low.
   TickType_t updateTick;                 // last update time, in ticks
   SemaphoreHandle_t xSem;                // semaphore for controlling access to device
   UBaseType_t stack_size;                // stack size of task

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -349,6 +349,9 @@ void PowerSupplyTask(void *parameters)
           nextState = POWER_FAILURE;
         }
         else {
+          // read the present bits for the firefiles
+          // the 3.3V is needed for the 3.8V sel switches.
+          readFFpresent();
           turn_on_ps_at_prio(f2_enable, f1_enable, 5);
           nextState = POWER_L5ON;
         }

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -73,8 +73,9 @@ static uint16_t getPSFailMask(void)
 
 void printfail(uint16_t failed_mask, uint16_t supply_ok_mask, uint16_t supply_bitset)
 {
-  log_error(LOG_PWRCTL, "psfail: fail, supply_mask, bitset =  %x,%x,%x\r\n", failed_mask,
-            supply_ok_mask, supply_bitset);
+  const char *state = getPowerControlStateName(currentState);
+  log_error(LOG_PWRCTL, "%s: psfail: fail, supply_mask, bitset =  %x,%x,%x\r\n",
+            state, failed_mask, supply_ok_mask, supply_bitset);
 }
 
 static const char *const power_system_state_names[] = {
@@ -349,9 +350,6 @@ void PowerSupplyTask(void *parameters)
           nextState = POWER_FAILURE;
         }
         else {
-          // read the present bits for the firefiles
-          // the 3.3V is needed for the 3.8V sel switches.
-          readFFpresent();
           turn_on_ps_at_prio(f2_enable, f1_enable, 5);
           nextState = POWER_L5ON;
         }
@@ -406,6 +404,10 @@ void PowerSupplyTask(void *parameters)
         else {
           // check 12-ch FF parts from vendors on FPGA1/2
           vTaskDelay(pdMS_TO_TICKS(1000));
+          // read the present bits for the firefiles, as well as the 3.8V sel switches.
+          // the 3.3V is needed for the 3.8V sel switches.
+          readFFpresent();
+
           (void)ff_map_25gb_parts();
           uint32_t pair_mask_f1 = getFF12Ch25GTxMask(0);        // 25G TX parts, F1
           uint32_t pair_mask_f2 = getFF12Ch25GTxMask(1);        // 25G TX parts, F2

--- a/projects/cm_mcu/PowerSupplyTask.c
+++ b/projects/cm_mcu/PowerSupplyTask.c
@@ -431,6 +431,14 @@ void PowerSupplyTask(void *parameters)
               log_info(LOG_PWRCTL, "enable 3v8\r\n");
               blade_power_ok(true);
               nextState = POWER_ON;
+              // load all clocks from EEPROM
+              int ret = load_all_clocks();
+              if (ret != 0) {
+                log_error(LOG_PWRCTL, "load_all_clocks failed with %d\r\n", ret);
+                disable_ps(); // turn off power
+                power_supply_alarm = true;
+                nextState = POWER_FAILURE;
+              }
             }
           }
           else {
@@ -443,14 +451,6 @@ void PowerSupplyTask(void *parameters)
             else
               log_warn(LOG_PWRCTL, "disable 3v8 failed with %d\r\n", ret);
             disable_ps();
-            power_supply_alarm = true;
-            nextState = POWER_FAILURE;
-          }
-          // load all clocks from EEPROM
-          int ret = load_all_clocks();
-          if (ret != 0) {
-            log_error(LOG_PWRCTL, "load_all_clocks failed with %d\r\n", ret);
-            disable_ps(); // turn off power
             power_supply_alarm = true;
             nextState = POWER_FAILURE;
           }

--- a/projects/cm_mcu/README.md
+++ b/projects/cm_mcu/README.md
@@ -103,9 +103,65 @@ The `led` CLI command can force a state for debugging:
 led init | idle | load | normal | warn | alarm | psfault | fwfault | white
 ```
 
+## I2C bus access and semaphores
+
+Each I2C master bus (1–6) is protected by its own FreeRTOS mutex (`i2c1_sem` … `i2c6_sem`, see
+`Semaphore.c`). Any task that issues a transaction sequence on a bus must hold that bus's mutex for
+the duration. The monitor tasks, the `clocksynth`/`FireflyUtils` helpers, and the `commands/`
+handlers (`FireflyCommands`, `ClockCommands`, `PowerCommands`) all acquire the correct per-bus mutex.
+
+**Deliberate exception — the raw CLI commands.** The generic raw-access commands in
+`commands/I2CCommands.c` (`i2cr`, `i2crr`, `i2cw`, `i2cwr`, `i2c_scan`) **intentionally do not take
+the semaphore.** This lets a user compose a longer interactive sequence under a *manually* held lock
+via the `sem_ctl <bus> take` / `sem_ctl <bus> release` command (`commands/SoftwareCommands.c`).
+The intended workflow is:
+
+```
+sem_ctl 2 take      # manually grab the bus-2 (clocks) mutex
+i2cw  2 0x70 1 0x4  # ... raw transactions, mutually excluded from the monitors ...
+i2cr  2 0x6b 1
+sem_ctl 2 release   # hand the bus back to the monitor tasks
+```
+
+This still works under the interrupt/notification-based I2C driver: the I2C completion handshake
+(`ulTaskNotifyTake` / `vTaskNotifyGiveFromISR`) and the UART stream buffer both use task-notification
+index 0, but they never overlap — the stream buffer only notifies the CLI task while it is parked
+inside `xStreamBufferReceive`, which is mutually exclusive with the task waiting on an I2C
+transaction. **Caveat / footgun:** this safety relies on that single shared notification index never
+being contended. If the CLI task is ever made to wait on its task notification for another purpose,
+the raw-command + I2C path will break silently. The robust fix is to give I2C completion its own
+notification index (`configTASK_NOTIFICATION_ARRAY_ENTRIES = 2`, using the `…Indexed` notify APIs),
+leaving index 0 to the stream buffer. See `i2c_lockup_notes.md` for the full analysis.
+
+## Logging and the log mutex
+
+The logger is a modified copy of [rxi/log.c](https://github.com/rxi/log.c) in `common/log.c`. The
+Apollo-specific sink `ApolloLog()` does two things per line: it appends the formatted text to an
+in-RAM circular scrollback buffer (`log_buffer` / `struct buff_t b`, dumpable from the CLI via
+`log_dump`), and it writes the line to the UART(s) through `Print()`.
+
+`Print()` busy-waits one character at a time on the UART FIFO (`MAP_UARTCharPut`), so emitting a full
+line takes on the order of the line's transmit time (several ms at typical baud). `Print()` is
+independently serialized by its own `xUARTMutex`.
+
+**The log mutex (`log_sem`) protects only the shared scrollback buffer**, not the UART. It is wired in
+via rxi's `log_set_lock()` hook, with `vGiveOrTakeSemaphore()` (in `Semaphore.c`) as the callback:
+
+- The critical section is just the `log_add_string()` append inside `ApolloLog()` — microseconds.
+  `Print()` is deliberately left *outside* the log mutex so a slow UART transmit in one task never
+  blocks another task's logging.
+- Acquire is **non-blocking** (`xSemaphoreTake(s, 0)`). The `log_LockFn` contract returns `bool`; on a
+  failed acquire `ApolloLog()` **drops the scrollback append and still prints the line**. Logging must
+  never stall a task on the lock, and the live UART output is never lost — only the in-RAM copy.
+- `log_set_lock()` captures the mutex handle by value, so `initSemaphores()` **must run before**
+  `log_set_lock()` in `main()`. With the order reversed the handle is still `0` and the lock is
+  silently a no-op.
+- Polarity: the `log_LockFn` first argument is `true` to **acquire**, `false` to release
+  (`vGiveOrTakeSemaphore(bool take, …)` — `take==true` ⇒ `xSemaphoreTake`).
+
+**Constraint:** `log_*` is task-context only. The lock uses `xSemaphoreTake`/`Give`, which must not be
+called from an ISR. ISR-side logging would need the `FromISR` variants or a separate lockless path.
+
 ## Building FreeRTOS
 
 FreeRTOS is now included as a git submodule. 
-
-```make
-```

--- a/projects/cm_mcu/README.md
+++ b/projects/cm_mcu/README.md
@@ -133,6 +133,50 @@ the raw-command + I2C path will break silently. The robust fix is to give I2C co
 notification index (`configTASK_NOTIFICATION_ARRAY_ENTRIES = 2`, using the `…Indexed` notify APIs),
 leaving index 0 to the stream buffer. See `i2c_lockup_notes.md` for the full analysis.
 
+### Higher-level semaphore-free helpers and unprogrammed exploration
+
+A few *higher-level* helpers also intentionally skip the bus mutex so they stay usable for expert
+exploration and when a bus is wedged (i.e. when the mutex is held by a stuck transaction and blocking
+on it would defeat the diagnostic). The current examples are `readFFpresentSignals(acquire_sem=false)`
+and its CLI front-end `ff_present`, which walk the F1/F2 optics I/O-expander muxes on buses 3 and 4.
+
+**This is no longer a memory-safety hazard.** The original crash was a *stack* use-after-return — the
+SMBus ISR writing into a freed/reused stack frame after the wrapper returned. The wrappers now use
+persistent per-bus `.bss` scratch buffers (`i2c_txbuf` / `i2c_rxbuf` in `I2CCommunication.c`) instead
+of stack locals, so a late ISR or a concurrent caller can only ever produce a *wrong value* — never
+corrupt an unrelated frame.
+
+**What is still shared and unprotected if you skip the mutex while a monitor task runs the same bus:**
+
+- the per-bus scratch buffers — a concurrent `MonitorTaskI2C` transaction can interleave bytes into
+  the same `i2c_txbuf[bus]`/`i2c_rxbuf[bus]`, giving a garbage reading;
+- `TaskNotifySMBus[bus]`, the *single* per-bus completion slot — last writer wins, so the loser never
+  gets its `vTaskNotifyGiveFromISR` and waits out the full 250 ms timeout, returning `SMBUS_TIMEOUT`.
+
+Neither corrupts memory; both just make the result unreliable.
+
+**Safe workflow today:** wrap the exploration in a manually held lock, exactly like the raw commands
+above — `sem_ctl 3 take` / `sem_ctl 4 take`, run the semaphore-free helper(s), then `sem_ctl … release`.
+That excludes the monitor tasks for the duration and makes the shared buffer/notify-slot races moot.
+
+**For future consideration** (increasing robustness), if the manual-lock workflow proves too easy to
+forget:
+
+1. Default the one-shot diagnostics (`ff_present`) to a *bounded-timeout* acquire
+   (`acquireI2CSemaphoreTime(s, pdMS_TO_TICKS(100))`) and print `bus busy, try again` on failure;
+   keep an explicit `force` argument for the genuine wedged-bus case rather than skipping the lock by
+   default.
+2. Give the `force`/bypass path its **own dedicated scratch buffer**, separate from the monitor-task
+   buffers, so even bypass mode can never alias `i2c_txbuf`/`i2c_rxbuf`. (The notify-slot race
+   remains, but only costs a 250 ms timeout — not corruption.)
+3. Add a maintenance **pause** (`mon_pause` / `mon_resume`) that `vTaskSuspend`s the three
+   `MonitorTaskI2C` instances. This is the only option that gives exploration *exclusive*,
+   uncontended bus access **and** persistent mux state across a sequence of commands — the monitor
+   tasks otherwise reset the mux to 0 between their own transactions. It needs the task handles, which
+   are currently created with `NULL` in `cm_mcu.c`; the cleanest wiring is for each task to store
+   `xTaskGetCurrentTaskHandle()` into its own `args` struct at startup, which the CLI already
+   references.
+
 ## Logging and the log mutex
 
 The logger is a modified copy of [rxi/log.c](https://github.com/rxi/log.c) in `common/log.c`. The

--- a/projects/cm_mcu/Semaphore.c
+++ b/projects/cm_mcu/Semaphore.c
@@ -15,6 +15,7 @@ SemaphoreHandle_t i2c3_sem = 0;
 SemaphoreHandle_t i2c4_sem = 0;
 SemaphoreHandle_t i2c5_sem = 0;
 SemaphoreHandle_t i2c6_sem = 0;
+SemaphoreHandle_t log_sem = 0;
 
 void initSemaphores(void)
 {
@@ -25,6 +26,7 @@ void initSemaphores(void)
   i2c4_sem = xSemaphoreCreateMutex();
   i2c5_sem = xSemaphoreCreateMutex();
   i2c6_sem = xSemaphoreCreateMutex();
+  log_sem = xSemaphoreCreateMutex();
 }
 
 SemaphoreHandle_t getSemaphore(int number)
@@ -73,4 +75,21 @@ int acquireI2CSemaphoreTime(SemaphoreHandle_t s, TickType_t tickWaits)
     }
   }
   return retval;
+}
+
+// Used as the log_set_lock() callback. take==true acquires, false releases.
+// Returns whether the requested operation succeeded; the logging code uses a
+// false return on acquire to drop a message rather than block. Acquire is
+// non-blocking (0 tick wait): logging must never stall a task on the lock.
+bool vGiveOrTakeSemaphore(bool take, void *sem)
+{
+  SemaphoreHandle_t s = (SemaphoreHandle_t)sem;
+  if (s == NULL) {
+    return true; // no lock configured -> proceed
+  }
+  if (take) {
+    return xSemaphoreTake(s, 0) == pdTRUE;
+  }
+  xSemaphoreGive(s);
+  return true;
 }

--- a/projects/cm_mcu/Semaphore.h
+++ b/projects/cm_mcu/Semaphore.h
@@ -21,6 +21,11 @@ extern SemaphoreHandle_t i2c4_sem;
 extern SemaphoreHandle_t i2c5_sem;
 extern SemaphoreHandle_t i2c6_sem;
 
+// semaphore for the log_XXX functions
+extern SemaphoreHandle_t log_sem;
+
+bool vGiveOrTakeSemaphore(bool take, void *sem);
+
 void initSemaphores(void);
 
 SemaphoreHandle_t getSemaphore(int number);

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -358,17 +358,24 @@ __attribute__((noreturn)) int main(void)
   __builtin_unreachable();
 }
 
-uintptr_t __stack_chk_guard = 0xdeadbeef;
-
-__attribute__((noreturn)) void __stack_chk_fail(void)
+uintptr_t __stack_chk_guard = 0xdeadbeef; // NOLINT(bugprone-reserved-identifier)
+// decode this with arm-none-eabi-addr2line -e gcc/cm_mcu.axf 0x...
+__attribute__((noreturn)) void __stack_chk_fail(void) // NOLINT(bugprone-reserved-identifier)
 {
-  // fall back to lower-level routine since if we get here things are broken
-  UARTPrint(ZQ_UART, "Stack smashing detected\r\n");
-  while (MAP_UARTBusy(ZQ_UART))
+  uint32_t v = (uint32_t)GET_LR() & ~1u;   // &~1 clears the Thumb bit so addr2line maps it directly
+  static const char hex[] = "0123456789ABCDEF";
+  char buf[] = "Stack smashing detected, LR=0x00000000\r\n";
+  // last hex digit sits just before "\r\n\0" => index sizeof(buf)-4; fill LSB-first
+  for (int i = 0; i < 8; ++i) {
+    buf[sizeof(buf) - 4 - i] = hex[v & 0xF];
+    v >>= 4;
+  }
+  UARTPrint(ZQ_UART, buf);
+  while (MAP_UARTBusy(ZQ_UART)) ;
+  configASSERT(1 == 0);
+  while (true) {
     ;
-  configASSERT(1 == 0); // capture in eeprom
-  while (true)
-    ;
+  }   
 }
 
 int SystemStackWaterHighWaterMark(void)
@@ -378,8 +385,9 @@ int SystemStackWaterHighWaterMark(void)
   // we need to disable interrupts since we are looking at the system stack
   taskENTER_CRITICAL();
   for (i = 0; i < SYSTEM_STACK_SIZE; ++i) {
-    if (stack[i] != 0xdeadbeefUL)
+    if (stack[i] != 0xdeadbeefUL) {
       break;
+    }
   }
   taskEXIT_CRITICAL();
   return i;

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -239,7 +239,6 @@ __attribute__((noreturn)) int main(void)
   for (enum log_facility_t i = 0; i < NUM_LOG_FACILITIES; ++i) {
     log_set_level(LOG_INFO, i);
   }
-  log_set_level(LOG_ERROR, LOG_MON); // for now
   log_set_lock(vGiveOrTakeSemaphore, log_sem);
 
   dcdc_args.xSem = i2c1_sem;
@@ -292,8 +291,8 @@ __attribute__((noreturn)) int main(void)
   xTaskCreate(MonitorTaskI2C, ff_f2_args.name, 384, &ff_f2_args, tskIDLE_PRIORITY + 3, NULL);
   xTaskCreate(MonitorTaskI2C, clk_args.name, 384, &clk_args, tskIDLE_PRIORITY + 3, NULL);
 #endif // REV2
-  xTaskCreate(MonitorTask, dcdc_args.name, 192, &dcdc_args, tskIDLE_PRIORITY + 3, NULL);
-  xTaskCreate(MonitorTask, fpga_args.name, 192, &fpga_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTask, dcdc_args.name, 256, &dcdc_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTask, fpga_args.name, 256, &fpga_args, tskIDLE_PRIORITY + 3, NULL);
   xTaskCreate(I2CSlaveTask, "I2CS0", 192, NULL, tskIDLE_PRIORITY + 4, NULL);
   xTaskCreate(EEPROMTask, "EPRM", 192, NULL, tskIDLE_PRIORITY + 3, NULL);
   xTaskCreate(InitTask, "INIT", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 4, NULL);
@@ -403,8 +402,14 @@ __attribute__((noreturn)) void vApplicationStackOverflowHook(TaskHandle_t pxTask
   /* If configCHECK_FOR_STACK_OVERFLOW is set to either 1 or 2 then this
      function will automatically get called if a task overflows its stack. */
   taskDISABLE_INTERRUPTS();
+  // get the link register
+  // Danger: only valid if stack isn't too corrupted
+  StackType_t *pxTopOfStack = *(StackType_t **)pxTask; // first field of TCB_t
+  uint32_t savedPC = pxTopOfStack[6];                  // PC in stacked frame
+  uint32_t savedLR = pxTopOfStack[5];                  // LR in stacked frame
   char tmp[256];
-  snprintf(tmp, 256, "Stack overflow: task %s\r\n", pcTaskName);
+  snprintf(tmp, 256, "Stack overflow: task %s, PC=0x%08x, LR=0x%08x\r\n",
+           pcTaskName, savedPC, savedLR);
   UARTPrint(ZQ_UART, tmp); // can't use Print() here -- this gets called
   // from an ISR-like context.
   while (MAP_UARTBusy(ZQ_UART))

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -232,14 +232,16 @@ __attribute__((noreturn)) int main(void)
 
   initFPGAMon();
 
+  // Initialize all semaphores
+  initSemaphores();
+  // Set up logging
   // all facilities start at INFO
   for (enum log_facility_t i = 0; i < NUM_LOG_FACILITIES; ++i) {
     log_set_level(LOG_INFO, i);
   }
   log_set_level(LOG_ERROR, LOG_MON); // for now
+  log_set_lock(vGiveOrTakeSemaphore, log_sem);
 
-  // Initialize all semaphores
-  initSemaphores();
   dcdc_args.xSem = i2c1_sem;
   fpga_args.xSem = i2c5_sem;
 #if defined(REV2) || defined(REV3)

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -364,7 +364,7 @@ uintptr_t __stack_chk_guard = 0xdeadbeef; // NOLINT(bugprone-reserved-identifier
 // decode this with arm-none-eabi-addr2line -e gcc/cm_mcu.axf 0x...
 __attribute__((noreturn)) void __stack_chk_fail(void) // NOLINT(bugprone-reserved-identifier)
 {
-  uint32_t v = (uint32_t)GET_LR() & ~1u;   // &~1 clears the Thumb bit so addr2line maps it directly
+  uint32_t v = (uint32_t)GET_LR() & ~1u; // &~1 clears the Thumb bit so addr2line maps it directly
   static const char hex[] = "0123456789ABCDEF";
   char buf[] = "Stack smashing detected, LR=0x00000000\r\n";
   // last hex digit sits just before "\r\n\0" => index sizeof(buf)-4; fill LSB-first
@@ -373,11 +373,12 @@ __attribute__((noreturn)) void __stack_chk_fail(void) // NOLINT(bugprone-reserve
     v >>= 4;
   }
   UARTPrint(ZQ_UART, buf);
-  while (MAP_UARTBusy(ZQ_UART)) ;
+  while (MAP_UARTBusy(ZQ_UART))
+    ;
   configASSERT(1 == 0);
   while (true) {
     ;
-  }   
+  }
 }
 
 int SystemStackWaterHighWaterMark(void)

--- a/projects/cm_mcu/cm_mcu.c
+++ b/projects/cm_mcu/cm_mcu.c
@@ -286,9 +286,9 @@ __attribute__((noreturn)) int main(void)
   xTaskCreate(ADCMonitorTask, "ADC", 192, NULL, tskIDLE_PRIORITY + 3, NULL);
 
 #if defined(REV2) || defined(REV3)
-  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, configMINIMAL_STACK_SIZE, &ff_f1_args, tskIDLE_PRIORITY + 3, NULL);
-  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, configMINIMAL_STACK_SIZE, &ff_f2_args, tskIDLE_PRIORITY + 3, NULL);
-  xTaskCreate(MonitorTaskI2C, clk_args.name, configMINIMAL_STACK_SIZE, &clk_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTaskI2C, ff_f1_args.name, 384, &ff_f1_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTaskI2C, ff_f2_args.name, 384, &ff_f2_args, tskIDLE_PRIORITY + 3, NULL);
+  xTaskCreate(MonitorTaskI2C, clk_args.name, 384, &clk_args, tskIDLE_PRIORITY + 3, NULL);
 #endif // REV2
   xTaskCreate(MonitorTask, dcdc_args.name, 192, &dcdc_args, tskIDLE_PRIORITY + 3, NULL);
   xTaskCreate(MonitorTask, fpga_args.name, 192, &fpga_args, tskIDLE_PRIORITY + 3, NULL);

--- a/projects/cm_mcu/commands/ClockCommands.c
+++ b/projects/cm_mcu/commands/ClockCommands.c
@@ -54,7 +54,12 @@ BaseType_t clkmon_ctl(int argc, char **argv, char *m)
       continue;
     }
     uint16_t val = clk_args.commands[c].retrieveData(i);
-    int devtype = 31 - __builtin_clz(ClockType(i));
+    int type = ClockType(i);
+    if ( type == 0) {
+      copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: ERROR device %d type 0 for CLZ call\r\n", argv[0], i);
+      continue; // skip if type is 0 (e.g., not determined)
+    }
+    int devtype = 31 - __builtin_clz(type); // clz is undefined if argument is zero
     copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%-15s : 0x%04x   0x%04x    0x%04x\r\n",
                        clk_args.commands[c].name, clk_args.commands[c].command[devtype],
                        clk_args.commands[c].bit_mask, val);

--- a/projects/cm_mcu/commands/ClockCommands.c
+++ b/projects/cm_mcu/commands/ClockCommands.c
@@ -55,7 +55,7 @@ BaseType_t clkmon_ctl(int argc, char **argv, char *m)
     }
     uint16_t val = clk_args.commands[c].retrieveData(i);
     int type = ClockType(i);
-    if ( type == 0) {
+    if (type == 0) {
       copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s: ERROR device %d type 0 for CLZ call\r\n", argv[0], i);
       continue; // skip if type is 0 (e.g., not determined)
     }

--- a/projects/cm_mcu/commands/FireflyCommands.c
+++ b/projects/cm_mcu/commands/FireflyCommands.c
@@ -480,6 +480,14 @@ BaseType_t ff_status(int argc, char **argv, char *m)
 // Re-read the firefly *PRESENT signals live from the I/O expanders and print
 // them. This is the on-demand equivalent of the boot-time readFFpresent(), but
 // it does NOT write the EEPROM or change the firefly enable masks.
+//
+// EXPERT TOOL: this calls readFFpresentSignals(false), i.e. it touches buses 3/4
+// WITHOUT taking their mutexes, so it works even when a bus is wedged. The
+// tradeoff is that, if a MonitorTaskI2C is driving the same bus at the same time,
+// the reading can be garbage or time out (250 ms) -- never a crash, but not
+// trustworthy. For a reliable read, lock the buses manually around the command:
+//   sem_ctl 3 take ; sem_ctl 4 take ; ff_present ; sem_ctl 3 release ; sem_ctl 4 release
+// See README.md "Higher-level semaphore-free helpers and unprogrammed exploration".
 BaseType_t ff_present(int argc, char **argv, char *m)
 {
   int copied = 0;

--- a/projects/cm_mcu/commands/FireflyCommands.c
+++ b/projects/cm_mcu/commands/FireflyCommands.c
@@ -477,6 +477,31 @@ BaseType_t ff_status(int argc, char **argv, char *m)
   return pdFALSE;
 }
 
+// Re-read the firefly *PRESENT signals live from the I/O expanders and print
+// them. This is the on-demand equivalent of the boot-time readFFpresent(), but
+// it does NOT write the EEPROM or change the firefly enable masks.
+BaseType_t ff_present(int argc, char **argv, char *m)
+{
+  int copied = 0;
+
+  uint32_t combined = readFFpresentSignals(false); // CLI must not take bus semaphores
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "%s: PRESENT signals (live read)\r\n", argv[0]);
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "combined (active high): 0x%06lx\r\n", (unsigned long)combined);
+#if defined(REV2) || defined(REV3)
+  char *ff_bitmask_names[4] = {"F1_12", "F1_4 ", "F2_12", "F2_4 "};
+  for (int i = 0; i < 4; ++i) {
+    copied += snprintf(m + copied, SCRATCH_SIZE - copied, "%s present: 0x%02x\r\n",
+                       ff_bitmask_names[i], getFFpresentbit(i));
+  }
+  copied += snprintf(m + copied, SCRATCH_SIZE - copied,
+                     "F1 4v0 sel: 0x%lx  F2 4v0 sel: 0x%lx\r\n",
+                     (unsigned long)f1_ff12xmit_4v0_sel, (unsigned long)f2_ff12xmit_4v0_sel);
+#endif // REV2 || REV3
+  return pdFALSE;
+}
+
 // ff_table_row_fn: signature for a single-row formatter used by ff_table_print.
 //
 // Each row function is called once per firefly device per CLI invocation. It is

--- a/projects/cm_mcu/commands/FireflyCommands.h
+++ b/projects/cm_mcu/commands/FireflyCommands.h
@@ -32,6 +32,7 @@ BaseType_t ff_optpow_dev(int argc, char **argv, char *m);
 BaseType_t ff_temp(int argc, char **argv, char *m);
 BaseType_t ff_reset(int argc, char **argv, char *m);
 BaseType_t ff_status(int argc, char **argv, char *m);
+BaseType_t ff_present(int argc, char **argv, char *m);
 BaseType_t ff_los_alarm(int argc, char **argv, char *m);
 BaseType_t ff_cdr_lol_alarm(int argc, char **argv, char *m);
 #if defined(REV2) || defined(REV3)


### PR DESCRIPTION
Change the i2c master code to use a blocking call and a notification from the ISR when the transaction was done. The polling was limited to 10ms rep rate because we were using systick based counters and systick is 100 Hz. 

Upshot is that the clock loading, which used to take a minute or more, now takes seconds.